### PR TITLE
style: fix rustfmt formatting across codebase

### DIFF
--- a/crates/krusty-cli/src/main.rs
+++ b/crates/krusty-cli/src/main.rs
@@ -10,7 +10,9 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 // Re-export core modules for TUI usage
-use krusty_core::{acp, agent, ai, constants, extensions, lsp, paths, plan, process, storage, tools};
+use krusty_core::{
+    acp, agent, ai, constants, extensions, lsp, paths, plan, process, storage, tools,
+};
 
 mod tui;
 

--- a/crates/krusty-cli/src/tui/handlers/update.rs
+++ b/crates/krusty-cli/src/tui/handlers/update.rs
@@ -103,10 +103,7 @@ impl App {
                 }
                 UpdateStatus::Available(info) => {
                     // Only show if not already showing a toast for this
-                    self.show_toast(Toast::info(format!(
-                        "Downloading v{}...",
-                        info.new_version
-                    )));
+                    self.show_toast(Toast::info(format!("Downloading v{}...", info.new_version)));
                 }
                 UpdateStatus::Downloading { progress: _ } => {
                     // Silent - don't spam user with progress

--- a/crates/krusty-cli/src/tui/popups/auth.rs
+++ b/crates/krusty-cli/src/tui/popups/auth.rs
@@ -126,7 +126,9 @@ impl AuthPopup {
     /// Mark API key as successfully saved
     pub fn set_api_key_complete(&mut self) {
         if let AuthState::ApiKeyInput { provider, .. } = &self.state {
-            self.state = AuthState::Complete { provider: *provider };
+            self.state = AuthState::Complete {
+                provider: *provider,
+            };
         }
     }
 

--- a/crates/krusty-core/src/acp/bridge.rs
+++ b/crates/krusty-core/src/acp/bridge.rs
@@ -5,8 +5,9 @@
 //! to the connection.
 
 use agent_client_protocol::{
-    Client, Error as AcpError, PermissionOptionId, RequestPermissionOutcome, RequestPermissionRequest,
-    RequestPermissionResponse, Result as AcpResult, SelectedPermissionOutcome, SessionNotification,
+    Client, Error as AcpError, PermissionOptionId, RequestPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, Result as AcpResult,
+    SelectedPermissionOutcome, SessionNotification,
 };
 use tokio::sync::mpsc;
 use tracing::warn;
@@ -66,7 +67,10 @@ impl Client for NotificationBridge {
 /// Returns (bridge, receiver) tuple:
 /// - bridge: implements Client, used by PromptProcessor
 /// - receiver: receives notifications to forward to real connection
-pub fn create_notification_channel() -> (NotificationBridge, mpsc::UnboundedReceiver<SessionNotification>) {
+pub fn create_notification_channel() -> (
+    NotificationBridge,
+    mpsc::UnboundedReceiver<SessionNotification>,
+) {
     let (tx, rx) = mpsc::unbounded_channel();
     (NotificationBridge::new(tx), rx)
 }
@@ -74,7 +78,9 @@ pub fn create_notification_channel() -> (NotificationBridge, mpsc::UnboundedRece
 #[cfg(test)]
 mod tests {
     use super::*;
-    use agent_client_protocol::{SessionId, SessionUpdate, ContentChunk, ContentBlock, TextContent};
+    use agent_client_protocol::{
+        ContentBlock, ContentChunk, SessionId, SessionUpdate, TextContent,
+    };
 
     #[tokio::test]
     async fn test_bridge_sends_notifications() {
@@ -82,11 +88,15 @@ mod tests {
 
         let session_id = SessionId::from("test-session");
         let chunk = ContentChunk::new(ContentBlock::Text(TextContent::new("Hello")));
-        let notification = SessionNotification::new(session_id, SessionUpdate::AgentMessageChunk(chunk));
+        let notification =
+            SessionNotification::new(session_id, SessionUpdate::AgentMessageChunk(chunk));
 
         bridge.session_notification(notification).await.unwrap();
 
         let received = rx.recv().await.unwrap();
-        assert!(matches!(received.update, SessionUpdate::AgentMessageChunk(_)));
+        assert!(matches!(
+            received.update,
+            SessionUpdate::AgentMessageChunk(_)
+        ));
     }
 }

--- a/crates/krusty-core/src/acp/server.rs
+++ b/crates/krusty-core/src/acp/server.rs
@@ -72,7 +72,9 @@ impl AcpServer {
                 config.provider,
                 config.model.as_deref().unwrap_or("default")
             );
-            self.agent.init_ai_client_with_model(config.api_key, config.provider, config.model).await;
+            self.agent
+                .init_ai_client_with_model(config.api_key, config.provider, config.model)
+                .await;
         } else {
             warn!(
                 "No API key found in environment. Set one of:\n\
@@ -108,12 +110,8 @@ impl AcpServer {
                 };
 
                 // Create connection with our agent
-                let (connection, io_task) = AgentSideConnection::new(
-                    self.agent,
-                    stdout,
-                    stdin,
-                    spawn_fn,
-                );
+                let (connection, io_task) =
+                    AgentSideConnection::new(self.agent, stdout, stdin, spawn_fn);
 
                 info!("ACP connection established, waiting for requests...");
 
@@ -192,7 +190,11 @@ fn detect_api_key_from_env() -> Option<AcpEnvConfig> {
                 .or_else(|| get_provider_api_key(provider));
 
             if let Some(api_key) = api_key {
-                return Some(AcpEnvConfig { api_key, provider, model });
+                return Some(AcpEnvConfig {
+                    api_key,
+                    provider,
+                    model,
+                });
             }
         }
     }
@@ -212,7 +214,11 @@ fn detect_api_key_from_env() -> Option<AcpEnvConfig> {
     for (provider, env_var) in providers_and_vars {
         if let Ok(key) = std::env::var(env_var) {
             if !key.is_empty() {
-                return Some(AcpEnvConfig { api_key: key, provider, model });
+                return Some(AcpEnvConfig {
+                    api_key: key,
+                    provider,
+                    model,
+                });
             }
         }
     }
@@ -241,7 +247,10 @@ fn detect_from_credential_store(model: Option<String>) -> Option<AcpEnvConfig> {
 
     // Try active provider first
     if let Some(api_key) = store.get(&active_provider) {
-        info!("Using active provider {:?} from credential store", active_provider);
+        info!(
+            "Using active provider {:?} from credential store",
+            active_provider
+        );
         return Some(AcpEnvConfig {
             api_key: api_key.clone(),
             provider: active_provider,
@@ -253,7 +262,10 @@ fn detect_from_credential_store(model: Option<String>) -> Option<AcpEnvConfig> {
     let configured = store.configured_providers();
     if let Some(provider) = configured.first() {
         if let Some(api_key) = store.get(provider) {
-            info!("Using first configured provider {:?} from credential store", provider);
+            info!(
+                "Using first configured provider {:?} from credential store",
+                provider
+            );
             return Some(AcpEnvConfig {
                 api_key: api_key.clone(),
                 provider: *provider,

--- a/crates/krusty-core/src/acp/session.rs
+++ b/crates/krusty-core/src/acp/session.rs
@@ -39,14 +39,9 @@ pub struct SessionState {
 
 impl SessionState {
     /// Create a new session state
-    pub fn new(
-        id: SessionId,
-        cwd: Option<PathBuf>,
-        mcp_servers: Option<Vec<McpServer>>,
-    ) -> Self {
-        let working_dir = cwd.unwrap_or_else(|| {
-            std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"))
-        });
+    pub fn new(id: SessionId, cwd: Option<PathBuf>, mcp_servers: Option<Vec<McpServer>>) -> Self {
+        let working_dir =
+            cwd.unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")));
 
         debug!("Creating session {} with cwd: {:?}", id, working_dir);
 

--- a/crates/krusty-core/src/acp/tools.rs
+++ b/crates/krusty-core/src/acp/tools.rs
@@ -149,8 +149,10 @@ pub async fn get_terminal_output_via_client<C: Client>(
 ) -> Result<(String, bool), AcpError> {
     debug!("Getting terminal output: {}", terminal_id);
 
-    let request =
-        TerminalOutputRequest::new(session_id.clone(), TerminalId::from(terminal_id.to_string()));
+    let request = TerminalOutputRequest::new(
+        session_id.clone(),
+        TerminalId::from(terminal_id.to_string()),
+    );
 
     let response = client
         .terminal_output(request)
@@ -170,8 +172,10 @@ pub async fn release_terminal_via_client<C: Client>(
 ) -> Result<(), AcpError> {
     debug!("Releasing terminal: {}", terminal_id);
 
-    let request =
-        ReleaseTerminalRequest::new(session_id.clone(), TerminalId::from(terminal_id.to_string()));
+    let request = ReleaseTerminalRequest::new(
+        session_id.clone(),
+        TerminalId::from(terminal_id.to_string()),
+    );
 
     client
         .release_terminal(request)

--- a/crates/krusty-core/src/acp/updates.rs
+++ b/crates/krusty-core/src/acp/updates.rs
@@ -106,10 +106,7 @@ mod tests {
 
     #[test]
     fn test_plan_conversion() {
-        let items = vec![
-            ("Task 1".to_string(), true),
-            ("Task 2".to_string(), false),
-        ];
+        let items = vec![("Task 1".to_string(), true), ("Task 2".to_string(), false)];
 
         let entries = plan_items_to_entries(&items);
 

--- a/crates/krusty-core/src/agent/summarizer.rs
+++ b/crates/krusty-core/src/agent/summarizer.rs
@@ -304,7 +304,12 @@ pub async fn generate_summary(
             provider
         );
         client
-            .call_simple(model, SUMMARIZATION_SYSTEM_PROMPT, &prompt, SUMMARIZATION_MAX_TOKENS)
+            .call_simple(
+                model,
+                SUMMARIZATION_SYSTEM_PROMPT,
+                &prompt,
+                SUMMARIZATION_MAX_TOKENS,
+            )
             .await?
     };
 

--- a/crates/krusty-core/src/ai/client/core.rs
+++ b/crates/krusty-core/src/ai/client/core.rs
@@ -136,7 +136,10 @@ impl AiClient {
         match self.config.auth_header {
             AuthHeader::Bearer => {
                 request = request.header("authorization", format!("Bearer {}", self.api_key));
-                info!("Using Bearer authentication for {}", self.config.provider_id);
+                info!(
+                    "Using Bearer authentication for {}",
+                    self.config.provider_id
+                );
             }
             AuthHeader::XApiKey => {
                 request = request.header("x-api-key", &self.api_key);

--- a/crates/krusty-core/src/ai/client/streaming.rs
+++ b/crates/krusty-core/src/ai/client/streaming.rs
@@ -67,7 +67,8 @@ impl AiClient {
         call_start: Instant,
     ) -> Result<mpsc::UnboundedReceiver<StreamPart>> {
         let format_handler = AnthropicFormat::new();
-        let anthropic_messages = format_handler.convert_messages(&messages, Some(self.provider_id()));
+        let anthropic_messages =
+            format_handler.convert_messages(&messages, Some(self.provider_id()));
 
         // Extract any system messages from conversation (e.g., pinch context)
         let injected_context: String = messages
@@ -272,12 +273,14 @@ impl AiClient {
         let max_tokens = options.max_tokens.unwrap_or(self.config().max_tokens);
 
         // Responses API uses "input", Chat Completions uses "messages"
-        let (messages_key, max_tokens_key) =
-            if matches!(self.config().api_format, crate::ai::models::ApiFormat::OpenAIResponses) {
-                ("input", "max_output_tokens")
-            } else {
-                ("messages", "max_tokens")
-            };
+        let (messages_key, max_tokens_key) = if matches!(
+            self.config().api_format,
+            crate::ai::models::ApiFormat::OpenAIResponses
+        ) {
+            ("input", "max_output_tokens")
+        } else {
+            ("messages", "max_tokens")
+        };
 
         let mut body = serde_json::json!({
             "model": self.config().model,
@@ -540,12 +543,20 @@ impl AiClient {
     }
 
     /// Add reasoning/thinking config to the request body
-    fn add_reasoning_config(&self, body: &mut Value, options: &CallOptions, reasoning_enabled: bool) {
+    fn add_reasoning_config(
+        &self,
+        body: &mut Value,
+        options: &CallOptions,
+        reasoning_enabled: bool,
+    ) {
         let budget_tokens = options.thinking.as_ref().map(|t| t.budget_tokens);
 
-        if let Some(reasoning_config) =
-            ReasoningConfig::build(options.reasoning_format, reasoning_enabled, budget_tokens, None)
-        {
+        if let Some(reasoning_config) = ReasoningConfig::build(
+            options.reasoning_format,
+            reasoning_enabled,
+            budget_tokens,
+            None,
+        ) {
             match options.reasoning_format {
                 Some(ReasoningFormat::Anthropic) => {
                     body["thinking"] = reasoning_config;

--- a/crates/krusty-core/src/ai/client/tools.rs
+++ b/crates/krusty-core/src/ai/client/tools.rs
@@ -8,7 +8,9 @@ use std::time::Instant;
 use tracing::{error, info};
 
 use super::core::AiClient;
-use crate::ai::format::response::{extract_text_from_content, normalize_google_response, normalize_openai_response};
+use crate::ai::format::response::{
+    extract_text_from_content, normalize_google_response, normalize_openai_response,
+};
 
 impl AiClient {
     /// Call the API with tools (non-streaming, for sub-agents)
@@ -135,7 +137,8 @@ impl AiClient {
                                 }
                                 Some("tool_use") => {
                                     let id = item.get("id").and_then(|i| i.as_str()).unwrap_or("");
-                                    let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                                    let name =
+                                        item.get("name").and_then(|n| n.as_str()).unwrap_or("");
                                     let input = item.get("input").cloned().unwrap_or(Value::Null);
                                     tool_calls.push(serde_json::json!({
                                         "id": id,
@@ -177,10 +180,7 @@ impl AiClient {
                                 .get("tool_use_id")
                                 .and_then(|i| i.as_str())
                                 .unwrap_or("");
-                            let output = item
-                                .get("content")
-                                .and_then(|c| c.as_str())
-                                .unwrap_or("");
+                            let output = item.get("content").and_then(|c| c.as_str()).unwrap_or("");
                             openai_messages.push(serde_json::json!({
                                 "role": "tool",
                                 "tool_call_id": tool_use_id,
@@ -310,10 +310,7 @@ impl AiClient {
                                 .get("tool_use_id")
                                 .and_then(|i| i.as_str())
                                 .unwrap_or("");
-                            let output = item
-                                .get("content")
-                                .and_then(|c| c.as_str())
-                                .unwrap_or("");
+                            let output = item.get("content").and_then(|c| c.as_str()).unwrap_or("");
                             parts.push(serde_json::json!({
                                 "functionResponse": {
                                     "name": tool_use_id,

--- a/crates/krusty-core/src/ai/format/anthropic.rs
+++ b/crates/krusty-core/src/ai/format/anthropic.rs
@@ -40,7 +40,11 @@ impl FormatHandler for AnthropicFormat {
     /// THINKING BLOCKS: Provider-specific handling:
     /// - MiniMax: Preserve ALL thinking blocks (per their docs), no signature field needed
     /// - Anthropic: Only preserve last thinking with pending tools (signature validation)
-    fn convert_messages(&self, messages: &[ModelMessage], provider_id: Option<ProviderId>) -> Vec<Value> {
+    fn convert_messages(
+        &self,
+        messages: &[ModelMessage],
+        provider_id: Option<ProviderId>,
+    ) -> Vec<Value> {
         let mut result: Vec<Value> = Vec::new();
         let mut last_role: Option<&str> = None;
 
@@ -112,7 +116,8 @@ impl FormatHandler for AnthropicFormat {
             }
 
             // Determine if this message should include thinking blocks
-            let include_thinking = preserve_all_thinking || last_assistant_with_tools_idx == Some(i);
+            let include_thinking =
+                preserve_all_thinking || last_assistant_with_tools_idx == Some(i);
 
             let content: Vec<Value> = msg
                 .content
@@ -189,7 +194,11 @@ impl FormatHandler for AnthropicFormat {
 /// * `include_thinking` - Whether to include thinking blocks
 /// * `include_signature` - Whether to include signature field in thinking blocks
 ///   (Anthropic requires signature, MiniMax doesn't need it)
-fn convert_content(content: &Content, include_thinking: bool, include_signature: bool) -> Option<Value> {
+fn convert_content(
+    content: &Content,
+    include_thinking: bool,
+    include_signature: bool,
+) -> Option<Value> {
     match content {
         Content::Text { text } => Some(serde_json::json!({
             "type": "text",
@@ -264,7 +273,10 @@ fn convert_content(content: &Content, include_thinking: bool, include_signature:
         // Provider-specific thinking block handling:
         // - Anthropic: Include signature (required for validation)
         // - MiniMax: No signature field (matches their API format)
-        Content::Thinking { thinking, signature } => {
+        Content::Thinking {
+            thinking,
+            signature,
+        } => {
             if include_thinking {
                 if include_signature {
                     Some(serde_json::json!({

--- a/crates/krusty-core/src/ai/format/google.rs
+++ b/crates/krusty-core/src/ai/format/google.rs
@@ -30,7 +30,11 @@ impl Default for GoogleFormat {
 impl FormatHandler for GoogleFormat {
     /// Convert messages to Google contents format
     /// Note: provider_id is unused for Google format (no thinking block handling needed)
-    fn convert_messages(&self, messages: &[ModelMessage], _provider_id: Option<ProviderId>) -> Vec<Value> {
+    fn convert_messages(
+        &self,
+        messages: &[ModelMessage],
+        _provider_id: Option<ProviderId>,
+    ) -> Vec<Value> {
         messages
             .iter()
             .filter(|m| m.role != Role::System) // System handled separately

--- a/crates/krusty-core/src/ai/format/mod.rs
+++ b/crates/krusty-core/src/ai/format/mod.rs
@@ -24,7 +24,11 @@ pub trait FormatHandler: Send + Sync {
     /// The provider_id parameter allows provider-specific handling:
     /// - MiniMax: Preserve ALL thinking blocks (per their docs)
     /// - Anthropic: Only preserve last thinking with pending tools (signature validation)
-    fn convert_messages(&self, messages: &[ModelMessage], provider_id: Option<ProviderId>) -> Vec<Value>;
+    fn convert_messages(
+        &self,
+        messages: &[ModelMessage],
+        provider_id: Option<ProviderId>,
+    ) -> Vec<Value>;
 
     /// Convert tools to API-specific format
     fn convert_tools(&self, tools: &[AiTool]) -> Vec<Value>;
@@ -65,9 +69,7 @@ impl<'a> Default for RequestOptions<'a> {
 }
 
 /// Select the appropriate format handler based on API format
-pub fn get_format_handler(
-    format: crate::ai::models::ApiFormat,
-) -> Box<dyn FormatHandler> {
+pub fn get_format_handler(format: crate::ai::models::ApiFormat) -> Box<dyn FormatHandler> {
     use crate::ai::models::ApiFormat;
     match format {
         ApiFormat::Anthropic => Box::new(anthropic::AnthropicFormat::new()),

--- a/crates/krusty-core/src/ai/format/openai.rs
+++ b/crates/krusty-core/src/ai/format/openai.rs
@@ -37,7 +37,11 @@ impl FormatHandler for OpenAIFormat {
     ///
     /// OpenAI format is simpler: role + content (string or array of content parts)
     /// Note: provider_id is unused for OpenAI format (no thinking block handling needed)
-    fn convert_messages(&self, messages: &[ModelMessage], _provider_id: Option<ProviderId>) -> Vec<Value> {
+    fn convert_messages(
+        &self,
+        messages: &[ModelMessage],
+        _provider_id: Option<ProviderId>,
+    ) -> Vec<Value> {
         let mut result: Vec<Value> = Vec::new();
 
         for msg in messages.iter().filter(|m| m.role != Role::System) {

--- a/crates/krusty-core/src/ai/parsers/google.rs
+++ b/crates/krusty-core/src/ai/parsers/google.rs
@@ -100,7 +100,8 @@ impl SseParser for GoogleParser {
                                     // Store accumulator
                                     let mut accumulators = self.tool_accumulators.lock().unwrap();
                                     let index = accumulators.len();
-                                    let mut acc = ToolCallAccumulator::new(id.clone(), name.clone());
+                                    let mut acc =
+                                        ToolCallAccumulator::new(id.clone(), name.clone());
                                     acc.add_arguments(&args);
                                     accumulators.insert(index, acc);
 

--- a/crates/krusty-core/src/ai/providers.rs
+++ b/crates/krusty-core/src/ai/providers.rs
@@ -395,12 +395,32 @@ static BUILTIN_PROVIDERS: LazyLock<Vec<ProviderConfig>> = LazyLock::new(|| {
             auth_header: AuthHeader::Bearer,
             models: vec![
                 // Claude models
-                ModelInfo::new("anthropic/claude-opus-4.5", "Claude Opus 4.5", 200_000, 16_384)
-                    .with_anthropic_thinking(),
-                ModelInfo::new("anthropic/claude-sonnet-4.5", "Claude Sonnet 4.5", 1_000_000, 16_384)
-                    .with_anthropic_thinking(),
-                ModelInfo::new("anthropic/claude-sonnet-4", "Claude Sonnet 4", 200_000, 8_192),
-                ModelInfo::new("anthropic/claude-haiku-4.5", "Claude Haiku 4.5", 200_000, 16_384),
+                ModelInfo::new(
+                    "anthropic/claude-opus-4.5",
+                    "Claude Opus 4.5",
+                    200_000,
+                    16_384,
+                )
+                .with_anthropic_thinking(),
+                ModelInfo::new(
+                    "anthropic/claude-sonnet-4.5",
+                    "Claude Sonnet 4.5",
+                    1_000_000,
+                    16_384,
+                )
+                .with_anthropic_thinking(),
+                ModelInfo::new(
+                    "anthropic/claude-sonnet-4",
+                    "Claude Sonnet 4",
+                    200_000,
+                    8_192,
+                ),
+                ModelInfo::new(
+                    "anthropic/claude-haiku-4.5",
+                    "Claude Haiku 4.5",
+                    200_000,
+                    16_384,
+                ),
                 ModelInfo::new("anthropic/claude-opus-4", "Claude Opus 4", 200_000, 16_384),
                 // OpenAI models
                 ModelInfo::new("openai/gpt-4.1", "GPT-4.1", 1_000_000, 32_768),
@@ -409,15 +429,45 @@ static BUILTIN_PROVIDERS: LazyLock<Vec<ProviderConfig>> = LazyLock::new(|| {
                 ModelInfo::new("openai/o3", "OpenAI o3", 200_000, 100_000),
                 ModelInfo::new("openai/o4-mini", "OpenAI o4-mini", 200_000, 100_000),
                 // Google models
-                ModelInfo::new("google/gemini-2.5-pro-preview", "Gemini 2.5 Pro", 1_000_000, 65_536),
-                ModelInfo::new("google/gemini-2.5-flash-preview", "Gemini 2.5 Flash", 1_000_000, 65_536),
-                ModelInfo::new("google/gemini-2.0-flash-001", "Gemini 2.0 Flash", 1_000_000, 8_192),
+                ModelInfo::new(
+                    "google/gemini-2.5-pro-preview",
+                    "Gemini 2.5 Pro",
+                    1_000_000,
+                    65_536,
+                ),
+                ModelInfo::new(
+                    "google/gemini-2.5-flash-preview",
+                    "Gemini 2.5 Flash",
+                    1_000_000,
+                    65_536,
+                ),
+                ModelInfo::new(
+                    "google/gemini-2.0-flash-001",
+                    "Gemini 2.0 Flash",
+                    1_000_000,
+                    8_192,
+                ),
                 // DeepSeek models
                 ModelInfo::new("deepseek/deepseek-r1", "DeepSeek R1", 64_000, 8_192),
-                ModelInfo::new("deepseek/deepseek-chat-v3-0324", "DeepSeek V3", 64_000, 8_192),
+                ModelInfo::new(
+                    "deepseek/deepseek-chat-v3-0324",
+                    "DeepSeek V3",
+                    64_000,
+                    8_192,
+                ),
                 // Meta Llama models
-                ModelInfo::new("meta-llama/llama-4-maverick", "Llama 4 Maverick", 1_000_000, 256_000),
-                ModelInfo::new("meta-llama/llama-4-scout", "Llama 4 Scout", 512_000, 128_000),
+                ModelInfo::new(
+                    "meta-llama/llama-4-maverick",
+                    "Llama 4 Maverick",
+                    1_000_000,
+                    256_000,
+                ),
+                ModelInfo::new(
+                    "meta-llama/llama-4-scout",
+                    "Llama 4 Scout",
+                    512_000,
+                    128_000,
+                ),
                 // Qwen models
                 ModelInfo::new("qwen/qwen3-235b-a22b", "Qwen 3 235B", 128_000, 8_192),
                 ModelInfo::new("qwen/qwq-32b", "QwQ 32B", 128_000, 16_384),
@@ -480,8 +530,13 @@ static BUILTIN_PROVIDERS: LazyLock<Vec<ProviderConfig>> = LazyLock::new(|| {
             auth_header: AuthHeader::XApiKey,
             models: vec![
                 // Lightning: Fastest (100 tps)
-                ModelInfo::new("MiniMax-M2.1-lightning", "MiniMax M2.1 Lightning", 200_000, 64_000)
-                    .with_anthropic_thinking(),
+                ModelInfo::new(
+                    "MiniMax-M2.1-lightning",
+                    "MiniMax M2.1 Lightning",
+                    200_000,
+                    64_000,
+                )
+                .with_anthropic_thinking(),
                 // Standard M2.1: Balanced (60 tps)
                 ModelInfo::new("MiniMax-M2.1", "MiniMax M2.1", 200_000, 64_000)
                     .with_anthropic_thinking(),

--- a/crates/krusty-core/src/ai/retry/backoff.rs
+++ b/crates/krusty-core/src/ai/retry/backoff.rs
@@ -188,14 +188,8 @@ mod tests {
 
     #[test]
     fn test_parse_retry_after_seconds() {
-        assert_eq!(
-            parse_retry_after("120"),
-            Some(Duration::from_secs(120))
-        );
-        assert_eq!(
-            parse_retry_after("0"),
-            Some(Duration::from_secs(0))
-        );
+        assert_eq!(parse_retry_after("120"), Some(Duration::from_secs(120)));
+        assert_eq!(parse_retry_after("0"), Some(Duration::from_secs(0)));
     }
 
     #[test]

--- a/crates/krusty-core/src/ai/sse.rs
+++ b/crates/krusty-core/src/ai/sse.rs
@@ -561,17 +561,26 @@ mod tests {
 
     #[test]
     fn test_parse_finish_reason_end_turn() {
-        assert!(matches!(parse_finish_reason("end_turn"), FinishReason::Stop));
+        assert!(matches!(
+            parse_finish_reason("end_turn"),
+            FinishReason::Stop
+        ));
     }
 
     #[test]
     fn test_parse_finish_reason_max_tokens() {
-        assert!(matches!(parse_finish_reason("max_tokens"), FinishReason::Length));
+        assert!(matches!(
+            parse_finish_reason("max_tokens"),
+            FinishReason::Length
+        ));
     }
 
     #[test]
     fn test_parse_finish_reason_tool_use() {
-        assert!(matches!(parse_finish_reason("tool_use"), FinishReason::ToolCalls));
+        assert!(matches!(
+            parse_finish_reason("tool_use"),
+            FinishReason::ToolCalls
+        ));
     }
 
     #[test]
@@ -749,9 +758,17 @@ mod tests {
             }
         }
 
-        processor.process_sse_data("[DONE]", &MockParser).await.unwrap();
+        processor
+            .process_sse_data("[DONE]", &MockParser)
+            .await
+            .unwrap();
         let part = rx.recv().await.unwrap();
-        assert!(matches!(part, StreamPart::Finish { reason: FinishReason::Stop }));
+        assert!(matches!(
+            part,
+            StreamPart::Finish {
+                reason: FinishReason::Stop
+            }
+        ));
     }
 
     #[tokio::test]
@@ -771,7 +788,10 @@ mod tests {
             }
         }
 
-        processor.process_sse_data("{}", &TextDeltaParser).await.unwrap();
+        processor
+            .process_sse_data("{}", &TextDeltaParser)
+            .await
+            .unwrap();
         let text = buffer_rx.recv().await.unwrap();
         assert!(!text.is_empty());
         processor.finish().await;
@@ -796,7 +816,10 @@ mod tests {
             }
         }
 
-        processor.process_sse_data("{}", &ToolStartParser).await.unwrap();
+        processor
+            .process_sse_data("{}", &ToolStartParser)
+            .await
+            .unwrap();
         let part = rx.recv().await.unwrap();
         match part {
             StreamPart::ToolCallStart { id, name } => {
@@ -822,7 +845,10 @@ mod tests {
         }
 
         processor.process_sse_data("", &SkipParser).await.unwrap();
-        processor.process_sse_data("   ", &SkipParser).await.unwrap();
+        processor
+            .process_sse_data("   ", &SkipParser)
+            .await
+            .unwrap();
         assert!(rx.try_recv().is_err());
     }
 
@@ -840,7 +866,10 @@ mod tests {
             }
         }
 
-        processor.process_sse_data("{}", &ThinkingStartParser).await.unwrap();
+        processor
+            .process_sse_data("{}", &ThinkingStartParser)
+            .await
+            .unwrap();
         let part = rx.recv().await.unwrap();
         assert!(matches!(part, StreamPart::ThinkingStart { index: 0 }));
     }

--- a/crates/krusty-core/src/tools/path_utils.rs
+++ b/crates/krusty-core/src/tools/path_utils.rs
@@ -17,9 +17,9 @@ pub fn validate_path(
         working_dir.join(path)
     };
 
-    let canonical = resolved.canonicalize().map_err(|e| {
-        ToolResult::error(format!("Cannot resolve path '{}': {}", path, e))
-    })?;
+    let canonical = resolved
+        .canonicalize()
+        .map_err(|e| ToolResult::error(format!("Cannot resolve path '{}': {}", path, e)))?;
 
     if let Some(sandbox) = sandbox_root {
         if !canonical.starts_with(sandbox) {

--- a/crates/krusty-core/src/updater/checker.rs
+++ b/crates/krusty-core/src/updater/checker.rs
@@ -72,7 +72,10 @@ pub async fn check_for_updates() -> Result<Option<UpdateInfo>> {
 
 /// Check for updates via GitHub releases API
 async fn check_for_updates_release() -> Result<Option<UpdateInfo>> {
-    let url = format!("https://api.github.com/repos/{}/releases/latest", GITHUB_REPO);
+    let url = format!(
+        "https://api.github.com/repos/{}/releases/latest",
+        GITHUB_REPO
+    );
     debug!("Fetching: {}", url);
 
     let client = reqwest::Client::builder()
@@ -458,7 +461,12 @@ fn extract_tar_gz(archive: &Path, dest: &Path) -> Result<()> {
 
     // Extract archive to temp directory
     let output = Command::new("tar")
-        .args(["xzf", archive.to_str().unwrap(), "-C", extract_dir.to_str().unwrap()])
+        .args([
+            "xzf",
+            archive.to_str().unwrap(),
+            "-C",
+            extract_dir.to_str().unwrap(),
+        ])
         .output()?;
 
     if !output.status.success() {
@@ -473,7 +481,10 @@ fn extract_tar_gz(archive: &Path, dest: &Path) -> Result<()> {
         let entries: Vec<_> = std::fs::read_dir(&extract_dir)?
             .filter_map(|e| e.ok())
             .collect();
-        debug!("Extracted contents: {:?}", entries.iter().map(|e| e.path()).collect::<Vec<_>>());
+        debug!(
+            "Extracted contents: {:?}",
+            entries.iter().map(|e| e.path()).collect::<Vec<_>>()
+        );
         return Err(anyhow!("Binary 'krusty' not found in archive"));
     }
 


### PR DESCRIPTION
Run `cargo fmt --all` to fix formatting violations that were
causing CI failures. Affected 24 files primarily in the acp
and ai modules from recent feature additions.

Common issues fixed:
- Long import statements now properly wrapped
- Function signatures/calls split across multiple lines
- Struct initializations properly formatted
- Match expressions and closures properly indented