### PR TITLE
chore: bump version to 0.3.8

### DIFF
--- a/crates/krusty-cli/Cargo.toml
+++ b/crates/krusty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 description = "The most elegant coding CLI to ever exist"
 default-run = "krusty"

--- a/crates/krusty-core/Cargo.toml
+++ b/crates/krusty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-core"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 description = "Core library for Krusty - AI, storage, tools, and extensions"
 


### PR DESCRIPTION
## Summary

- Bump version to 0.3.8 for release

🤖 Generated with [Claude Code](https://claude.com/claude-code)