### PR TITLE
chore: bump version to 0.3.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,7 +2447,7 @@ dependencies = [
 
 [[package]]
 name = "krusty"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "arboard",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/crates/krusty-cli/Cargo.toml
+++ b/crates/krusty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 description = "The most elegant coding CLI to ever exist"
 default-run = "krusty"

--- a/crates/krusty-core/Cargo.toml
+++ b/crates/krusty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-core"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 description = "Core library for Krusty - AI, storage, tools, and extensions"
 


### PR DESCRIPTION
## Summary

- Bump version to 0.3.9 in both `krusty-core` and `krusty-cli` Cargo.toml files

🤖 Generated with [Claude Code](https://claude.com/claude-code)