### PR TITLE
fix: clean PWA check and build warnings

### DIFF
--- a/apps/pwa/app/src/lib/components/chat/ChatHeader.svelte
+++ b/apps/pwa/app/src/lib/components/chat/ChatHeader.svelte
@@ -34,7 +34,7 @@
 	const dirCache = new Map<string, DirCache>();
 
 	// Scroll optimization
-	let dirListContainer: HTMLDivElement;
+	let dirListContainer = $state<HTMLDivElement>(undefined!);
 	let dirScrollTimeout: ReturnType<typeof setTimeout>;
 
 	function handleDirScroll() {
@@ -199,7 +199,7 @@
 
 	let isEditingTitle = $state(false);
 	let editedTitle = $state('');
-	let titleInput: HTMLInputElement;
+	let titleInput = $state<HTMLInputElement>(undefined!);
 
 	function startEditTitle() {
 		editedTitle = $sessionStore.title;

--- a/apps/pwa/app/src/lib/components/chat/ChatView.svelte
+++ b/apps/pwa/app/src/lib/components/chat/ChatView.svelte
@@ -10,10 +10,10 @@
 	import { sessionStore, sendMessage, stopGeneration, type Attachment } from '$stores/session';
 
 	let inputValue = $state('');
-	let inputElement: HTMLTextAreaElement;
-	let messagesContainer: HTMLDivElement;
-	let fileInput: HTMLInputElement;
-	let imageInput: HTMLInputElement;
+	let inputElement = $state<HTMLTextAreaElement>(undefined!);
+	let messagesContainer = $state<HTMLDivElement>(undefined!);
+	let fileInput = $state<HTMLInputElement>(undefined!);
+	let imageInput = $state<HTMLInputElement>(undefined!);
 	let attachedFiles = $state<File[]>([]);
 
 	function handleSubmit() {

--- a/apps/pwa/app/src/lib/components/chat/Message.svelte
+++ b/apps/pwa/app/src/lib/components/chat/Message.svelte
@@ -139,7 +139,7 @@
 
 <style>
 	.timeline-entry {
-		/* Each entry is a separate visual block */
+		display: block;
 	}
 
 	:global(.message-bubble .prose) {

--- a/apps/pwa/app/src/lib/components/chat/ModelSelector.svelte
+++ b/apps/pwa/app/src/lib/components/chat/ModelSelector.svelte
@@ -32,8 +32,8 @@
 	let error = $state<string | null>(null);
 	let searchQuery = $state('');
 	let selectedIndex = 0; // Not reactive - managed via DOM
-	let searchInput: HTMLInputElement;
-	let listContainer: HTMLDivElement;
+	let searchInput = $state<HTMLInputElement>(undefined!);
+	let listContainer = $state<HTMLDivElement>(undefined!);
 	let scrollTimeout: ReturnType<typeof setTimeout>;
 
 	const RECENT_KEY = 'krusty:recent_models';
@@ -219,6 +219,7 @@
 	<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 	<div
 		class="fixed inset-0 z-50 bg-black/60"
+		role="presentation"
 		onclick={onClose}
 	></div>
 


### PR DESCRIPTION
## Summary
- Fix all 9 svelte-check warnings (0 errors, 0 warnings now)
- Add `$state()` to DOM `bind:this` element refs for Svelte 5 compatibility
- Add `role="presentation"` to modal backdrop for a11y
- Replace empty CSS ruleset

## Test plan
- [x] `bun run check` — 0 errors, 0 warnings
- [x] `bun run build` — clean build
- [x] `cargo fmt/clippy/build/test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)