### PR TITLE
chore: bump version to 0.3.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "krusty"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "anyhow",
  "arboard",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/crates/krusty-cli/Cargo.toml
+++ b/crates/krusty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "The most elegant coding CLI to ever exist"
 default-run = "krusty"

--- a/crates/krusty-core/Cargo.toml
+++ b/crates/krusty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-core"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "Core library for Krusty - AI, storage, tools, and extensions"
 


### PR DESCRIPTION
Version bump for clean release with Tailscale port fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)