### PR TITLE
feat: optimize prompt caching across all API paths

### DIFF
--- a/crates/krusty-core/src/agent/subagent/execution.rs
+++ b/crates/krusty-core/src/agent/subagent/execution.rs
@@ -591,8 +591,11 @@ pub(crate) async fn call_subagent_api(
         })
         .collect();
 
-    // Build tools JSON
-    let tools_json: Vec<Value> = tools
+    // Build tools JSON — sorted by name for deterministic ordering.
+    // Tool order is part of the cached prefix; non-deterministic order breaks caching.
+    let mut sorted_tools: Vec<_> = tools.iter().collect();
+    sorted_tools.sort_by(|a, b| a.name.cmp(&b.name));
+    let tools_json: Vec<Value> = sorted_tools
         .iter()
         .map(|t| {
             json!({

--- a/crates/krusty-core/src/ai/client/simple.rs
+++ b/crates/krusty-core/src/ai/client/simple.rs
@@ -64,6 +64,9 @@ impl AiClient {
     }
 
     /// Simple non-streaming call using Anthropic format
+    ///
+    /// Uses cache_control on the system prompt so repeated calls with the same
+    /// system prompt (e.g., title generation, summarization) benefit from caching.
     async fn call_simple_anthropic(
         &self,
         model: &str,
@@ -78,7 +81,11 @@ impl AiClient {
                 "role": "user",
                 "content": user_message
             }],
-            "system": system_prompt
+            "system": [{
+                "type": "text",
+                "text": system_prompt,
+                "cache_control": {"type": "ephemeral"}
+            }]
         });
 
         let request = self.build_request(&self.config().api_url());

--- a/crates/krusty-core/src/ai/client/simple.rs
+++ b/crates/krusty-core/src/ai/client/simple.rs
@@ -1,12 +1,21 @@
 //! Simple (non-streaming) API calls
 //!
 //! Used for quick tasks like title generation where streaming is overkill.
+//! Also provides `call_with_conversation` for cache-safe fork operations
+//! (summarization/compaction) that reuse the parent conversation's cached prefix.
 
 use anyhow::Result;
 use serde_json::Value;
 use tracing::debug;
 
 use super::core::AiClient;
+use super::streaming::partition_system_messages;
+use crate::ai::format::anthropic::AnthropicFormat;
+use crate::ai::format::google::GoogleFormat;
+use crate::ai::format::openai::OpenAIFormat;
+use crate::ai::format::FormatHandler;
+use crate::ai::providers::ProviderCapabilities;
+use crate::ai::types::ModelMessage;
 
 fn trim_or_empty(text: Option<&str>) -> String {
     text.unwrap_or("").trim().to_string()
@@ -254,4 +263,296 @@ impl AiClient {
 
         Ok(trim_or_empty(Some(&collected_text)))
     }
+
+    /// Non-streaming API call that reuses the parent conversation's cached prefix.
+    ///
+    /// Instead of flattening conversation into a single user message (which shares
+    /// zero cache prefix with the parent conversation), this sends the actual
+    /// conversation messages as API messages and appends a new user instruction.
+    ///
+    /// The cached prefix from the parent conversation (system prompt + conversation
+    /// history) is fully reused, so the only uncached tokens are the appended message.
+    /// This follows Thariq's lesson: "When we run compaction, we use the exact same
+    /// system prompt, user context, system context, and tool definitions."
+    pub async fn call_with_conversation(
+        &self,
+        model: &str,
+        base_system_prompt: &str,
+        conversation: &[ModelMessage],
+        appended_user_message: &str,
+        max_tokens: usize,
+    ) -> Result<String> {
+        if self.config().uses_chatgpt_codex_format() {
+            // Codex requires streaming — combine system prompt and fall back to simple
+            return self
+                .call_simple_chatgpt_codex(model, base_system_prompt, appended_user_message)
+                .await;
+        }
+
+        if self.config().uses_openai_format() {
+            return self
+                .call_conversation_openai(
+                    model,
+                    base_system_prompt,
+                    conversation,
+                    appended_user_message,
+                    max_tokens,
+                )
+                .await;
+        }
+
+        if self.config().uses_google_format() {
+            return self
+                .call_conversation_google(
+                    model,
+                    base_system_prompt,
+                    conversation,
+                    appended_user_message,
+                    max_tokens,
+                )
+                .await;
+        }
+
+        self.call_conversation_anthropic(
+            model,
+            base_system_prompt,
+            conversation,
+            appended_user_message,
+            max_tokens,
+        )
+        .await
+    }
+
+    /// Cache-safe conversation call using Anthropic format.
+    ///
+    /// Builds the same multi-block system prompt structure as the streaming path:
+    /// base prompt (cached) → project context (cached) → session context (not cached).
+    /// Conversation messages are converted using the same format handler, so the
+    /// entire prefix matches what the parent conversation built.
+    async fn call_conversation_anthropic(
+        &self,
+        model: &str,
+        base_system_prompt: &str,
+        conversation: &[ModelMessage],
+        appended_user_message: &str,
+        max_tokens: usize,
+    ) -> Result<String> {
+        let capabilities = ProviderCapabilities::for_provider(self.provider_id());
+        let format_handler = AnthropicFormat::new();
+
+        // Convert parent conversation messages (System role filtered by format handler)
+        let mut api_messages =
+            format_handler.convert_messages(conversation, Some(self.provider_id()));
+
+        // Append the new user message at the end
+        api_messages.push(serde_json::json!({
+            "role": "user",
+            "content": [{"type": "text", "text": appended_user_message}]
+        }));
+
+        // Build system prompt with the same multi-block structure as streaming.
+        // This ensures the cached prefix from the parent conversation is reused.
+        let (project_context, session_context) = partition_system_messages(conversation);
+
+        let system_value: Value = if capabilities.prompt_caching {
+            let mut blocks: Vec<Value> = Vec::new();
+
+            // Block 1: Base system prompt — cached
+            if !base_system_prompt.is_empty() {
+                blocks.push(serde_json::json!({
+                    "type": "text",
+                    "text": base_system_prompt,
+                    "cache_control": {"type": "ephemeral"}
+                }));
+            }
+
+            // Block 2 (optional): Project context — cached
+            if !project_context.is_empty() {
+                blocks.push(serde_json::json!({
+                    "type": "text",
+                    "text": project_context,
+                    "cache_control": {"type": "ephemeral"}
+                }));
+            }
+
+            // Block 3 (optional): Session context — not cached (dynamic)
+            if !session_context.is_empty() {
+                blocks.push(serde_json::json!({
+                    "type": "text",
+                    "text": session_context
+                }));
+            }
+
+            Value::Array(blocks)
+        } else {
+            // No caching: combine into single string
+            let mut system = base_system_prompt.to_string();
+            if !project_context.is_empty() {
+                system.push_str("\n\n---\n\n");
+                system.push_str(&project_context);
+            }
+            if !session_context.is_empty() {
+                system.push_str("\n\n---\n\n");
+                system.push_str(&session_context);
+            }
+            Value::String(system)
+        };
+
+        let body = serde_json::json!({
+            "model": model,
+            "max_tokens": max_tokens,
+            "system": system_value,
+            "messages": api_messages,
+        });
+
+        debug!(
+            "Cache-safe Anthropic call: {} conversation messages + appended user message",
+            conversation.len()
+        );
+
+        let request = self.build_request(&self.config().api_url());
+        let response = request.json(&body).send().await?;
+        let response = self.handle_error_response(response).await?;
+
+        let json: Value = response.json().await?;
+
+        let text = json
+            .get("content")
+            .and_then(|c| c.as_array())
+            .map(|arr| collect_anthropic_text(arr))
+            .unwrap_or_default();
+
+        Ok(trim_or_empty(Some(&text)))
+    }
+
+    /// Cache-safe conversation call using OpenAI format.
+    ///
+    /// Combines system content in the same stability order as streaming
+    /// (base → project → session) for optimal automatic prefix caching.
+    async fn call_conversation_openai(
+        &self,
+        model: &str,
+        base_system_prompt: &str,
+        conversation: &[ModelMessage],
+        appended_user_message: &str,
+        max_tokens: usize,
+    ) -> Result<String> {
+        let format_handler = OpenAIFormat::new(self.config().api_format);
+
+        let mut api_messages =
+            format_handler.convert_messages(conversation, Some(self.provider_id()));
+
+        // Prepend system message with combined prompt (same order as streaming)
+        let system_prompt = build_combined_system_prompt(base_system_prompt, conversation);
+        api_messages.insert(
+            0,
+            serde_json::json!({"role": "system", "content": system_prompt}),
+        );
+
+        // Append user message
+        api_messages.push(serde_json::json!({
+            "role": "user",
+            "content": appended_user_message
+        }));
+
+        let body = serde_json::json!({
+            "model": model,
+            "max_tokens": max_tokens,
+            "messages": api_messages,
+        });
+
+        debug!(
+            "Cache-safe OpenAI call: {} conversation messages + appended user message",
+            conversation.len()
+        );
+
+        let request = self.build_request(&self.config().api_url());
+        let response = request.json(&body).send().await?;
+        let response = self.handle_error_response(response).await?;
+
+        let json: Value = response.json().await?;
+
+        Ok(trim_or_empty(
+            json.get("choices")
+                .and_then(|c| c.as_array())
+                .and_then(|arr| arr.first())
+                .and_then(|choice| choice.get("message"))
+                .and_then(|msg| msg.get("content"))
+                .and_then(|t| t.as_str()),
+        ))
+    }
+
+    /// Cache-safe conversation call using Google format.
+    async fn call_conversation_google(
+        &self,
+        _model: &str,
+        base_system_prompt: &str,
+        conversation: &[ModelMessage],
+        appended_user_message: &str,
+        max_tokens: usize,
+    ) -> Result<String> {
+        let format_handler = GoogleFormat::new();
+
+        let mut contents = format_handler.convert_messages(conversation, Some(self.provider_id()));
+
+        // Append user message
+        contents.push(serde_json::json!({
+            "role": "user",
+            "parts": [{"text": appended_user_message}]
+        }));
+
+        let system_prompt = build_combined_system_prompt(base_system_prompt, conversation);
+
+        let body = serde_json::json!({
+            "contents": contents,
+            "systemInstruction": {
+                "parts": [{"text": system_prompt}]
+            },
+            "generationConfig": {
+                "maxOutputTokens": max_tokens
+            }
+        });
+
+        debug!(
+            "Cache-safe Google call: {} conversation messages + appended user message",
+            conversation.len()
+        );
+
+        let request = self.build_request(&self.config().api_url());
+        let response = request.json(&body).send().await?;
+        let response = self.handle_error_response(response).await?;
+
+        let json: Value = response.json().await?;
+
+        Ok(trim_or_empty(
+            json.get("candidates")
+                .and_then(|c| c.as_array())
+                .and_then(|arr| arr.first())
+                .and_then(|candidate| candidate.get("content"))
+                .and_then(|content| content.get("parts"))
+                .and_then(|parts| parts.as_array())
+                .and_then(|arr| arr.first())
+                .and_then(|part| part.get("text"))
+                .and_then(|t| t.as_str()),
+        ))
+    }
+}
+
+/// Build a combined system prompt for non-Anthropic providers.
+///
+/// Orders content by stability (base → project → session) matching
+/// the streaming path for optimal automatic prefix caching.
+fn build_combined_system_prompt(base: &str, conversation: &[ModelMessage]) -> String {
+    let (project_context, session_context) = partition_system_messages(conversation);
+
+    let mut prompt = base.to_string();
+    if !project_context.is_empty() {
+        prompt.push_str("\n\n---\n\n");
+        prompt.push_str(&project_context);
+    }
+    if !session_context.is_empty() {
+        prompt.push_str("\n\n---\n\n");
+        prompt.push_str(&session_context);
+    }
+    prompt
 }

--- a/crates/krusty-core/src/ai/client/streaming.rs
+++ b/crates/krusty-core/src/ai/client/streaming.rs
@@ -79,7 +79,7 @@ fn spawn_sse_stream_task<S, P>(
     });
 }
 
-fn first_text_block(content: &[Content]) -> Option<&str> {
+pub(crate) fn first_text_block(content: &[Content]) -> Option<&str> {
     content.iter().find_map(|block| match block {
         Content::Text { text } => Some(text.as_str()),
         _ => None,
@@ -93,7 +93,7 @@ fn first_text_block(content: &[Content]) -> Option<&str> {
 /// `[PROJECT INSTRUCTIONS` prefix and rarely changes within a session.
 /// Everything else (plan state, skills list) changes frequently and should
 /// NOT be included in the cached prefix.
-fn partition_system_messages(messages: &[ModelMessage]) -> (String, String) {
+pub(crate) fn partition_system_messages(messages: &[ModelMessage]) -> (String, String) {
     let mut project_context = String::new();
     let mut session_context = String::new();
 

--- a/crates/krusty-core/src/ai/parsers/google.rs
+++ b/crates/krusty-core/src/ai/parsers/google.rs
@@ -136,13 +136,18 @@ impl SseParser for GoogleParser {
                 .get("candidatesTokenCount")
                 .and_then(|t| t.as_u64())
                 .unwrap_or(0) as usize;
+            // Gemini 2.5+ reports implicit cache hits via cachedContentTokenCount
+            let cached = usage
+                .get("cachedContentTokenCount")
+                .and_then(|t| t.as_u64())
+                .unwrap_or(0) as usize;
             if prompt > 0 || completion > 0 {
                 return Ok(SseEvent::Usage(crate::ai::types::Usage {
                     prompt_tokens: prompt,
                     completion_tokens: completion,
                     total_tokens: prompt + completion,
                     cache_creation_input_tokens: 0,
-                    cache_read_input_tokens: 0,
+                    cache_read_input_tokens: cached,
                 }));
             }
         }

--- a/crates/krusty-core/src/ai/providers.rs
+++ b/crates/krusty-core/src/ai/providers.rs
@@ -355,11 +355,13 @@ impl ProviderCapabilities {
     /// Get capabilities for a provider
     pub fn for_provider(provider: ProviderId) -> Self {
         match provider {
+            // OpenRouter passes through Anthropic's cache_control to Claude models.
+            // For non-Claude models, caching is automatic and the extra fields are ignored.
             ProviderId::OpenRouter => Self {
                 web_search: false, // Not via server tools
                 web_fetch: false,
                 context_management: false,
-                prompt_caching: false,
+                prompt_caching: true,
                 web_plugins: true,     // Uses plugins array
                 supports_vision: true, // Passes through to underlying model
             },

--- a/crates/krusty-server/src/ws/terminal.rs
+++ b/crates/krusty-server/src/ws/terminal.rs
@@ -169,11 +169,7 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                 }
 
                 let send_result = if binary_output.load(Ordering::Relaxed) {
-                    ws_sink
-                        .lock()
-                        .await
-                        .send(Message::Binary(batch))
-                        .await
+                    ws_sink.lock().await.send(Message::Binary(batch)).await
                 } else {
                     let msg = serde_json::json!({
                         "type": "output",


### PR DESCRIPTION
Apply lessons from Anthropic's prompt caching best practices:

- Split system prompt into ordered cache blocks: static base prompt
  (cached) → project context/CLAUDE.md (cached per project) → dynamic
  session context like plan state and skills (NOT cached). This prevents
  plan state changes from invalidating the entire system prompt cache.

- Sort tool definitions deterministically by name in all paths
  (streaming, sub-agent, tool registry). HashMap iteration order is
  non-deterministic and silently breaks the cached prefix between turns.

- Add cache breakpoint on last conversation message so the conversation
  prefix from previous turns is reused, and each new turn only pays for
  newly appended messages.

- Add cache_control to sub-agent API calls (call_with_tools_anthropic).
  Sub-agents make multiple round-trips with the same system prompt and
  tools — caching the prefix saves significant cost and latency.

- Add cache_control to simple API calls (call_simple_anthropic) used for
  title generation and summarization.

https://claude.ai/code/session_01EMFmrVtKfifvKJiUMwPNrb