### PR TITLE
ci: gate TestFlight from main

### DIFF
--- a/.github/workflows/mobile-testflight.yml
+++ b/.github/workflows/mobile-testflight.yml
@@ -2,7 +2,7 @@ name: Mobile → TestFlight
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
     paths:
       - 'apps/mobile/**'
       - 'packages/**'
@@ -17,6 +17,7 @@ jobs:
   build-and-submit:
     name: Build iOS & Submit to TestFlight
     runs-on: ubuntu-latest
+    environment: testflight
     defaults:
       run:
         working-directory: apps/mobile


### PR DESCRIPTION
## Summary
- Move TestFlight push trigger from dev to main now that main is the trunk.
- Attach the TestFlight workflow job to the testflight environment so deployments can require a single environment approval.

## Test Plan
- git diff --check
- workflow YAML validated by repository patch lint

Part of GitHub governance cleanup after PR #69.