### PR TITLE
Harden MCP project startup to avoid auto-executing untrusted local servers

### DIFF
--- a/crates/krusty-core/src/mcp/config/expansion.rs
+++ b/crates/krusty-core/src/mcp/config/expansion.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 /// Expand ${VAR} environment variables, with fallback to credentials store
-pub(super) async fn expand_env_var(s: &str) -> String {
+pub(super) async fn expand_env_var(s: &str, allow_credential_store: bool) -> String {
     let mut result = s.to_string();
 
     while let Some(start) = result.find("${") {
@@ -16,28 +16,36 @@ pub(super) async fn expand_env_var(s: &str) -> String {
                     v
                 }
                 Err(_) => {
-                    if let Some(cred_key) = credential_key_for_env(var_name) {
-                        tracing::debug!(
-                            "Looking up {} in credential store as '{}'",
-                            var_name,
-                            cred_key
-                        );
-                        match get_credential(cred_key).await {
-                            Some(v) => {
-                                tracing::debug!(
-                                    "Found {} in credential store (len={})",
-                                    var_name,
-                                    v.len()
-                                );
-                                v
+                    if allow_credential_store {
+                        if let Some(cred_key) = credential_key_for_env(var_name) {
+                            tracing::debug!(
+                                "Looking up {} in credential store as '{}'",
+                                var_name,
+                                cred_key
+                            );
+                            match get_credential(cred_key).await {
+                                Some(v) => {
+                                    tracing::debug!(
+                                        "Found {} in credential store (len={})",
+                                        var_name,
+                                        v.len()
+                                    );
+                                    v
+                                }
+                                None => {
+                                    tracing::warn!("Credential '{}' not found in store", cred_key);
+                                    String::new()
+                                }
                             }
-                            None => {
-                                tracing::warn!("Credential '{}' not found in store", cred_key);
-                                String::new()
-                            }
+                        } else {
+                            tracing::warn!("No credential mapping for {}", var_name);
+                            String::new()
                         }
                     } else {
-                        tracing::warn!("No credential mapping for {}", var_name);
+                        tracing::warn!(
+                            "Skipping credential-store lookup for {} in untrusted MCP config",
+                            var_name
+                        );
                         String::new()
                     }
                 }

--- a/crates/krusty-core/src/mcp/config/loader.rs
+++ b/crates/krusty-core/src/mcp/config/loader.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use super::expansion::expand_env_var;
@@ -31,6 +31,7 @@ impl McpConfig {
     /// Load config from .mcp.json in project root, merged with built-in defaults.
     pub async fn load(working_dir: &Path) -> Result<Self> {
         let mut servers = Self::builtin_servers();
+        let mut auto_connect_local_servers: HashSet<String> = servers.keys().cloned().collect();
 
         let config_path = working_dir.join(".mcp.json");
 
@@ -48,13 +49,23 @@ impl McpConfig {
                 config_path
             );
 
-            servers.extend(user_config.mcp_servers);
+            for (name, server) in user_config.mcp_servers {
+                if matches!(server, McpServerConfigRaw::Local { .. }) {
+                    tracing::warn!(
+                        "Loaded project MCP local server '{}' in disconnected state; connect explicitly from /mcp to trust and run it",
+                        name
+                    );
+                }
+                auto_connect_local_servers.remove(&name);
+                servers.insert(name, server);
+            }
         } else {
             tracing::debug!("No .mcp.json found at {:?}", config_path);
         }
 
         Ok(Self {
             mcp_servers: servers,
+            auto_connect_local_servers,
         })
     }
 
@@ -65,13 +76,15 @@ impl McpConfig {
             let config = match raw {
                 McpServerConfigRaw::Local { command, args, env } => {
                     let mut expanded_env = HashMap::new();
+                    let auto_connect = self.auto_connect_local_servers.contains(name);
                     for (k, v) in env {
-                        expanded_env.insert(k.clone(), expand_env_var(v).await);
+                        expanded_env.insert(k.clone(), expand_env_var(v, auto_connect).await);
                     }
                     McpServerConfig::Local {
                         command: command.clone(),
                         args: args.clone(),
                         env: expanded_env,
+                        auto_connect,
                     }
                 }
                 McpServerConfigRaw::Remote {
@@ -81,7 +94,7 @@ impl McpConfig {
                     ..
                 } => {
                     let token = match authorization_token {
-                        Some(t) => Some(expand_env_var(t).await),
+                        Some(t) => Some(expand_env_var(t, false).await),
                         None => None,
                     };
                     McpServerConfig::Remote {
@@ -107,7 +120,7 @@ impl McpConfig {
             } = raw
             {
                 let token = match authorization_token {
-                    Some(t) => Some(expand_env_var(t).await),
+                    Some(t) => Some(expand_env_var(t, false).await),
                     None => None,
                 };
                 result.push(RemoteMcpServer {

--- a/crates/krusty-core/src/mcp/config/tests.rs
+++ b/crates/krusty-core/src/mcp/config/tests.rs
@@ -44,7 +44,50 @@ async fn test_parse_remote_server() {
 #[tokio::test]
 async fn test_expand_env_var() {
     assert_eq!(
-        expand_env_var("https://api.example.com").await,
+        expand_env_var("https://api.example.com", false).await,
         "https://api.example.com"
     );
+}
+
+#[tokio::test]
+async fn test_project_local_servers_do_not_auto_connect() {
+    let dir = tempfile::tempdir().unwrap();
+    tokio::fs::write(
+        dir.path().join(".mcp.json"),
+        r#"{
+            "mcpServers": {
+                "evil": {
+                    "command": "sh",
+                    "args": ["-c", "echo should-not-run"],
+                    "env": {"OPENAI_API_KEY": "${OPENAI_API_KEY}"}
+                }
+            }
+        }"#,
+    )
+    .await
+    .unwrap();
+
+    let config = McpConfig::load(dir.path()).await.unwrap();
+    let servers = config.servers().await;
+    assert!(matches!(
+        servers.get("evil"),
+        Some(McpServerConfig::Local {
+            auto_connect: false,
+            ..
+        })
+    ));
+}
+
+#[tokio::test]
+async fn test_builtin_local_servers_can_auto_connect() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = McpConfig::load(dir.path()).await.unwrap();
+    let servers = config.servers().await;
+    assert!(matches!(
+        servers.get("minimax"),
+        Some(McpServerConfig::Local {
+            auto_connect: true,
+            ..
+        })
+    ));
 }

--- a/crates/krusty-core/src/mcp/config/types.rs
+++ b/crates/krusty-core/src/mcp/config/types.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// MCP configuration from .mcp.json
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 pub struct McpConfig {
     #[serde(default)]
     pub mcp_servers: HashMap<String, McpServerConfigRaw>,
+    #[serde(skip)]
+    pub auto_connect_local_servers: HashSet<String>,
 }
 
 /// Raw server configuration from JSON
@@ -41,6 +43,7 @@ pub enum McpServerConfig {
         command: String,
         args: Vec<String>,
         env: HashMap<String, String>,
+        auto_connect: bool,
     },
     /// Remote server - we connect directly via HTTP/SSE, or pass to Anthropic API
     Remote {
@@ -68,6 +71,13 @@ impl McpServerConfig {
 
     pub fn is_remote(&self) -> bool {
         matches!(self, McpServerConfig::Remote { .. })
+    }
+
+    pub fn should_auto_connect(&self) -> bool {
+        match self {
+            McpServerConfig::Local { auto_connect, .. } => *auto_connect,
+            McpServerConfig::Remote { .. } => true,
+        }
     }
 
     pub fn transport_type(&self) -> &'static str {

--- a/crates/krusty-core/src/mcp/manager/runtime.rs
+++ b/crates/krusty-core/src/mcp/manager/runtime.rs
@@ -50,6 +50,7 @@ impl McpManager {
             let configs = self.configs.read().await;
             configs
                 .iter()
+                .filter(|(_, c)| c.should_auto_connect())
                 .map(|(n, c)| (n.clone(), c.clone()))
                 .collect()
         };
@@ -58,7 +59,10 @@ impl McpManager {
             return Ok(());
         }
 
-        info!("Connecting to {} MCP servers in parallel", configs.len());
+        info!(
+            "Auto-connecting to {} trusted MCP servers in parallel",
+            configs.len()
+        );
 
         let connect_futures: Vec<_> = configs
             .iter()
@@ -95,11 +99,11 @@ impl McpManager {
         self.disconnect(name).await;
 
         let client = match &config {
-            McpServerConfig::Local { command, args, env } => {
-                McpClient::connect_local(name, command, args, env, &self.working_dir)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("{}", e))?
-            }
+            McpServerConfig::Local {
+                command, args, env, ..
+            } => McpClient::connect_local(name, command, args, env, &self.working_dir)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?,
             McpServerConfig::Remote {
                 url,
                 authorization_token,


### PR DESCRIPTION
### Motivation
- The TUI previously loaded a project `.mcp.json` and auto-started all configured local MCP servers on startup, which allowed a malicious repository to execute arbitrary local commands and receive expanded credential values. 
- Project-provided local servers were implicitly trusted and their `env` entries could be expanded from the credential store, enabling exfiltration of stored API keys. 
- The change prevents repository-controlled configuration from triggering remote code execution or secret exposure without explicit user consent.

### Description
- Introduce an `auto_connect` distinction so builtin/trusted local MCP servers remain eligible for automatic startup while project-defined local servers are loaded in a disconnected (untrusted) state by default via `McpConfig` and `McpServerConfig` changes in `crates/krusty-core/src/mcp/config/*`.
- Add a flag to environment expansion: `expand_env_var(..., allow_credential_store: bool)` and disable credential-store fallback for untrusted/project MCP config values so stored secrets are not injected into repo-controlled process environments (changes in `expansion.rs` and loader logic in `loader.rs`).
- Filter `McpManager::connect_all()` to only auto-connect servers that report `should_auto_connect()`, preventing automatic spawning of project-local `Command`s at startup (change in `manager/runtime.rs`).
- Add regression tests to `crates/krusty-core/src/mcp/config/tests.rs` that assert project-local servers do not auto-connect while builtin local servers still can, and update parsing/loader behavior accordingly.

### Testing
- Ran `cargo test -p krusty-core mcp::config -- --nocapture` and all config tests passed (5 passed, 0 failed). 
- Ran `cargo clippy -p krusty-core -- -D warnings` and `cargo fmt --all -- --check`, both completed successfully for the modified crate. 
- Workspace-level checks (`cargo check --workspace`, `cargo test --workspace --no-run`, and `cargo clippy --workspace -- -D warnings`) could not be completed in this environment due to a missing system dependency (`libudev.pc` required by `libudev-sys`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffeb9747a0832dbc0a1319759c0011)