### PR TITLE
Restrict iOS ATS exception to local networking

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -26,8 +26,7 @@
           "fetch"
         ],
         "NSAppTransportSecurity": {
-          "NSAllowsLocalNetworking": true,
-          "NSAllowsArbitraryLoads": true
+          "NSAllowsLocalNetworking": true
         }
       },
       "config": {


### PR DESCRIPTION
### Motivation
- Close an iOS App Transport Security regression by removing the global `NSAllowsArbitraryLoads` setting so cleartext HTTP is not allowed to arbitrary hosts while preserving `NSAllowsLocalNetworking` for localhost development previews.

### Description
- Remove `NSAllowsArbitraryLoads` from the `ios.infoPlist.NSAppTransportSecurity` block in `apps/mobile/app.json`, leaving `NSAllowsLocalNetworking: true` so local WebView previews continue to work without permitting global cleartext loads.

### Testing
- Ran `cargo fmt --all`, `python3 -m json.tool apps/mobile/app.json`, `rg -n "NSAppTransportSecurity|NSAllowsLocalNetworking|NSAllowsArbitraryLoads" apps/mobile/app.json`, `git diff --check`, and `cd apps/mobile && npx expo export --platform web` which succeeded, while `cargo check --workspace`, `cargo test --workspace`, and `cargo clippy --workspace -- -D warnings` were blocked by the environment due to a missing system `libudev.pc` (libudev development package).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb3a717ec832d8759053ddb2d3823)