### PR TITLE
Prevent project settings from elevating permission mode

### DIFF
--- a/crates/krusty-core/src/agent/orchestrator.rs
+++ b/crates/krusty-core/src/agent/orchestrator.rs
@@ -115,6 +115,39 @@ pub struct OrchestratorServices {
     pub skills_manager: Arc<RwLock<SkillsManager>>,
 }
 
+fn resolve_project_permission_mode(
+    requested_permission_mode: PermissionMode,
+    project_settings: &ProjectSettings,
+) -> PermissionMode {
+    let Some(ref mode_str) = project_settings.permission_mode else {
+        return requested_permission_mode;
+    };
+
+    match mode_str.as_str() {
+        "supervised" => {
+            tracing::info!("Project settings override: permission_mode = supervised");
+            PermissionMode::Supervised
+        }
+        "autonomous" if requested_permission_mode == PermissionMode::Autonomous => {
+            tracing::info!("Project settings confirm: permission_mode = autonomous");
+            PermissionMode::Autonomous
+        }
+        "autonomous" => {
+            tracing::warn!(
+                "Ignoring project settings permission_mode = autonomous because the request is supervised"
+            );
+            requested_permission_mode
+        }
+        other => {
+            tracing::warn!(
+                "Unknown permission_mode in project settings: {:?}, keeping requested mode",
+                other
+            );
+            requested_permission_mode
+        }
+    }
+}
+
 /// The agentic orchestrator — runs the complete AI agent loop.
 pub struct AgenticOrchestrator {
     services: OrchestratorServices,
@@ -236,28 +269,7 @@ impl AgenticOrchestrator {
             .map(ProjectSettings::load)
             .unwrap_or_default();
 
-        // Apply permission_mode override from project settings
-        let permission_mode = if let Some(ref mode_str) = project_settings.permission_mode {
-            match mode_str.as_str() {
-                "autonomous" => {
-                    tracing::info!("Project settings override: permission_mode = autonomous");
-                    PermissionMode::Autonomous
-                }
-                "supervised" => {
-                    tracing::info!("Project settings override: permission_mode = supervised");
-                    PermissionMode::Supervised
-                }
-                other => {
-                    tracing::warn!(
-                        "Unknown permission_mode in project settings: {:?}, keeping default",
-                        other
-                    );
-                    permission_mode
-                }
-            }
-        } else {
-            permission_mode
-        };
+        let permission_mode = resolve_project_permission_mode(permission_mode, &project_settings);
 
         // Log model override (consumed by the presentation layer that constructs AiClient)
         if let Some(ref model) = project_settings.model {
@@ -866,12 +878,50 @@ mod tests {
 
     use super::inject_runtime_context;
     use super::message_builder::finalize_explore_only_turn;
+    use super::resolve_project_permission_mode;
     use crate::ai::types::{AiToolCall, Content, ModelMessage, Role};
     use crate::skills::SkillsManager;
-    use crate::storage::{SessionType, WorkMode};
+    use crate::storage::{ProjectSettings, SessionType, WorkMode};
+    use crate::tools::registry::PermissionMode;
     use serde_json::json;
     use tempfile::TempDir;
     use tokio::sync::RwLock;
+
+    #[test]
+    fn project_settings_cannot_elevate_supervised_permission_mode() {
+        let settings = ProjectSettings {
+            permission_mode: Some("autonomous".to_string()),
+            ..Default::default()
+        };
+
+        let resolved = resolve_project_permission_mode(PermissionMode::Supervised, &settings);
+
+        assert_eq!(resolved, PermissionMode::Supervised);
+    }
+
+    #[test]
+    fn project_settings_can_restrict_autonomous_permission_mode() {
+        let settings = ProjectSettings {
+            permission_mode: Some("supervised".to_string()),
+            ..Default::default()
+        };
+
+        let resolved = resolve_project_permission_mode(PermissionMode::Autonomous, &settings);
+
+        assert_eq!(resolved, PermissionMode::Supervised);
+    }
+
+    #[test]
+    fn project_settings_preserve_requested_autonomous_permission_mode() {
+        let settings = ProjectSettings {
+            permission_mode: Some("autonomous".to_string()),
+            ..Default::default()
+        };
+
+        let resolved = resolve_project_permission_mode(PermissionMode::Autonomous, &settings);
+
+        assert_eq!(resolved, PermissionMode::Autonomous);
+    }
 
     #[test]
     fn finalize_explore_only_turn_returns_summary_for_successful_explore() {


### PR DESCRIPTION
### Motivation
- Fix a security regression where repository-controlled `.krusty/settings.json` could silently elevate a supervised HTTP chat/code request into `autonomous`, bypassing human tool approvals. 
- Ensure project-scoped settings can still restrict autonomy (force `supervised`) and confirm already-autonomous runs remain autonomous (preserve intended Mako/autonomy semantics). 
- Make the permission-mode resolution explicit and auditable inside the orchestrator rather than trusting unvetted project files.

### Description
- Add a central resolver `resolve_project_permission_mode(requested_permission_mode, project_settings)` that refuses to elevate a supervised request to `Autonomous`, allows project settings to restrict an `Autonomous` request to `Supervised`, and preserves requested `Autonomous` when appropriate. 
- Replace the previous unconditional project-based override in the orchestrator with a call to the new resolver right after loading `ProjectSettings`. 
- Add unit tests exercising three security-critical cases: supervised non-elevation, autonomous restriction by project settings, and preserving an explicitly autonomous request. 
- Add logging/warning messages when a project setting attempts an unsupported elevation and adjust imports/test helpers to cover the new behavior.

### Testing
- Ran targeted unit tests for the changes: `cargo test -p krusty-core agent::orchestrator::tests::project_settings_` and the `krusty-core` test suite, and the new tests passed (all `krusty-core` tests passed). 
- Ran `cargo check -p krusty-core` and `cargo clippy -p krusty-core -- -D warnings`, which completed successfully for the package. 
- Ran `cd apps/mobile && npx expo export --platform web`, which produced a web bundle successfully. 
- Workspace-wide verification (`cargo check --workspace`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`) could not complete in this container due to a missing system `libudev.pc` dependency required by `libudev-sys`, so those workspace-wide checks are pending in CI or a proper environment with that system package installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb999f184832dab58bade1924a823)