### PR TITLE
fix: sandbox workspace previews

### DIFF
--- a/apps/mobile/components/desktop/WorkspacePreview.tsx
+++ b/apps/mobile/components/desktop/WorkspacePreview.tsx
@@ -809,6 +809,7 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
                     <iframe
                       key={`${tab.id}:${tab.historyIndex}:${tab.reloadKey}`}
                       src={tab.history[tab.historyIndex]}
+                      sandbox="allow-downloads allow-forms allow-modals allow-popups allow-pointer-lock allow-scripts"
                       style={{ width: "100%", height: "100%", border: "none" }}
                       title={tab.title}
                       onLoad={() => {

--- a/crates/krusty-server/src/routes/ports/proxy.rs
+++ b/crates/krusty-server/src/routes/ports/proxy.rs
@@ -22,6 +22,8 @@ use super::super::preview_settings::load_preview_settings;
 use super::probe::probe_port_previewability;
 
 const MAX_PROXY_REQUEST_BODY_BYTES: usize = 8 * 1024 * 1024;
+const PREVIEW_PROXY_SANDBOX_CSP: &str =
+    "sandbox allow-downloads allow-forms allow-modals allow-popups allow-pointer-lock allow-scripts";
 
 pub(super) async fn proxy_root(
     State(state): State<AppState>,
@@ -183,6 +185,7 @@ async fn proxy_http_request(
             response_builder = response_builder.header(name, value);
         }
     }
+    response_builder = apply_preview_proxy_security_headers(response_builder);
 
     response_builder
         .body(axum::body::Body::from(response_body))
@@ -347,6 +350,15 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
     has_upgrade && has_connection_upgrade
 }
 
+fn apply_preview_proxy_security_headers(
+    response_builder: axum::http::response::Builder,
+) -> axum::http::response::Builder {
+    response_builder
+        .header(header::CONTENT_SECURITY_POLICY, PREVIEW_PROXY_SANDBOX_CSP)
+        .header(header::REFERRER_POLICY, "no-referrer")
+        .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+}
+
 fn should_forward_request_header(name: &HeaderName) -> bool {
     !is_hop_by_hop_header(name) && *name != header::HOST
 }
@@ -382,6 +394,33 @@ mod tests {
         assert_eq!(
             build_upstream_path(Some("foo"), Some("a=1&b=2")),
             "/foo?a=1&b=2"
+        );
+    }
+
+    #[test]
+    fn preview_proxy_security_headers_sandbox_without_same_origin() {
+        let response = apply_preview_proxy_security_headers(Response::builder())
+            .body(axum::body::Body::empty())
+            .expect("response should build");
+
+        let csp = response
+            .headers()
+            .get(header::CONTENT_SECURITY_POLICY)
+            .and_then(|value| value.to_str().ok())
+            .expect("content security policy should be present");
+        assert!(csp.starts_with("sandbox"));
+        assert!(csp.contains("allow-scripts"));
+        assert!(!csp.contains("allow-same-origin"));
+        assert_eq!(
+            response.headers().get(header::REFERRER_POLICY).unwrap(),
+            "no-referrer"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .unwrap(),
+            "*"
         );
     }
 


### PR DESCRIPTION
### Motivation
- Prevent previewed local dev servers from executing as the Krusty origin and accessing privileged APIs or stored tokens by restoring origin isolation for embedded previews.
- Provide defensive headers from the preview proxy so proxied content is sandboxed by default while still allowing typical preview behaviors (scripts, forms, popups) except same-origin access.

### Description
- Add a `sandbox` attribute to the embedded preview `iframe` in `apps/mobile/components/desktop/WorkspacePreview.tsx` that omits `allow-same-origin` while permitting downloads/forms/modals/popups/pointer-lock/scripts.
- Emit defensive headers from the preview proxy in `crates/krusty-server/src/routes/ports/proxy.rs`, including a CSP `sandbox` policy without `allow-same-origin`, `Referrer-Policy: no-referrer`, and `Access-Control-Allow-Origin: *` via an `apply_preview_proxy_security_headers` helper.
- Ensure proxy responses are passed through `apply_preview_proxy_security_headers` before being returned to clients so proxied pages remain origin-isolated from Krusty.
- Add a unit test asserting the proxy security headers include the `sandbox` directive (with `allow-scripts`), do not include `allow-same-origin`, and include the `no-referrer` and CORS header.

### Testing
- Ran `cargo test -p krusty-server routes::ports::proxy::tests::preview_proxy_security_headers_sandbox_without_same_origin` and the test passed.
- Ran `cargo check -p krusty-server`, `cargo clippy -p krusty-server -- -D warnings`, and `cargo fmt --all -- --check`, which all completed successfully for the `krusty-server` crate.
- Exported the web bundle with `cd apps/mobile && npx expo export --platform web`, which completed successfully to validate the web preview surface build.
- Attempts to run `cargo check --workspace`, `cargo test --workspace`, and `cargo clippy --workspace -- -D warnings` were blocked in this environment due to a missing system `libudev.pc` (failure building `libudev-sys`), so full workspace CI could not be exercised here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc1366ee8832db55788dd2dd1fd6c)