### PR TITLE
Preserve permission_mode when resuming interactive tool-result continuations

### DIFF
--- a/crates/krusty-server/src/routes/chat/interactions.rs
+++ b/crates/krusty-server/src/routes/chat/interactions.rs
@@ -12,7 +12,7 @@ use krusty_core::agent::plan_handler::parse_plan_confirm_choice;
 use krusty_core::agent::LoopInput;
 use krusty_core::ai::types::{Content, ModelMessage, Role};
 use krusty_core::plan::PlanManager;
-use krusty_core::storage::{Database, PendingInteractionSnapshot, WorkMode};
+use krusty_core::storage::{Database, PendingInteractionSnapshot, SessionType, WorkMode};
 use krusty_core::tools::registry::PermissionMode;
 use krusty_core::SessionManager;
 
@@ -41,6 +41,8 @@ pub(super) async fn tool_result(
         false,
     )
     .await?;
+
+    let permission_mode = resumed_permission_mode(ctx.session_type, req.permission_mode);
 
     // Plan confirmation is an internal orchestrator event, not a real tool call.
     // Don't add a ToolResult — instead add a user message to resume the conversation.
@@ -78,8 +80,7 @@ pub(super) async fn tool_result(
                 .save_message(&req.session_id, "user", &user_json)?;
             ctx.work_mode
         };
-        return start_orchestrator_sse(&state, ctx, work_mode, PermissionMode::Autonomous, false)
-            .await;
+        return start_orchestrator_sse(&state, ctx, work_mode, permission_mode, false).await;
     }
 
     let has_thinking = ctx.conversation.iter().any(|msg| {
@@ -132,7 +133,18 @@ pub(super) async fn tool_result(
     }
 
     let work_mode = ctx.work_mode;
-    start_orchestrator_sse(&state, ctx, work_mode, PermissionMode::Autonomous, false).await
+    start_orchestrator_sse(&state, ctx, work_mode, permission_mode, false).await
+}
+
+fn resumed_permission_mode(
+    session_type: SessionType,
+    requested_permission_mode: PermissionMode,
+) -> PermissionMode {
+    if session_type == SessionType::Mako {
+        PermissionMode::Autonomous
+    } else {
+        requested_permission_mode
+    }
 }
 
 pub(super) async fn tool_approval(
@@ -195,4 +207,33 @@ fn recovery_has_pending_tool_approval(
                 if tool_call.id == tool_call_id
         )
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resumed_permission_mode_preserves_supervised_for_code_sessions() {
+        assert_eq!(
+            resumed_permission_mode(SessionType::Code, PermissionMode::Supervised),
+            PermissionMode::Supervised
+        );
+    }
+
+    #[test]
+    fn resumed_permission_mode_preserves_autonomous_for_code_sessions() {
+        assert_eq!(
+            resumed_permission_mode(SessionType::Code, PermissionMode::Autonomous),
+            PermissionMode::Autonomous
+        );
+    }
+
+    #[test]
+    fn resumed_permission_mode_keeps_mako_sessions_autonomous() {
+        assert_eq!(
+            resumed_permission_mode(SessionType::Mako, PermissionMode::Supervised),
+            PermissionMode::Autonomous
+        );
+    }
 }

--- a/crates/krusty-server/src/types/chat.rs
+++ b/crates/krusty-server/src/types/chat.rs
@@ -160,6 +160,10 @@ mod tests {
         .expect("request should deserialize");
 
         assert!(req.fast_mode);
+        assert_eq!(
+            req.permission_mode,
+            krusty_core::tools::registry::PermissionMode::default()
+        );
     }
 
     #[test]
@@ -201,6 +205,26 @@ mod tests {
         .expect("request should deserialize");
 
         assert!(req.fast_mode);
+        assert_eq!(
+            req.permission_mode,
+            krusty_core::tools::registry::PermissionMode::default()
+        );
+    }
+
+    #[test]
+    fn tool_result_request_accepts_permission_mode() {
+        let req: super::ToolResultRequest = serde_json::from_value(json!({
+            "session_id": "session-1",
+            "tool_call_id": "tool-1",
+            "result": "ok",
+            "permission_mode": "autonomous"
+        }))
+        .expect("request should deserialize");
+
+        assert_eq!(
+            req.permission_mode,
+            krusty_core::tools::registry::PermissionMode::Autonomous
+        );
     }
 
     #[test]
@@ -354,6 +378,9 @@ pub struct ToolResultRequest {
     /// Request provider fast/priority service tier while resuming after a tool result
     #[serde(default)]
     pub fast_mode: bool,
+    /// Permission mode to preserve while resuming after an interactive tool result.
+    #[serde(default)]
+    pub permission_mode: PermissionMode,
 }
 
 #[derive(Deserialize)]

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -13,6 +13,7 @@ import type {
   OAuthExchangeResponse,
   ServerAccessResponse,
   ChatRequest,
+  ToolResultRequest,
   StreamCallbacks,
   StreamEvent,
   DelegatedProgressEvent,
@@ -377,10 +378,22 @@ export class KrustyClient {
     });
   }
 
-  async submitToolResult(sessionId: string, toolCallId: string, result: string, fastMode = false): Promise<void> {
+  async submitToolResult(
+    sessionId: string,
+    toolCallId: string,
+    result: string,
+    fastMode = false,
+    permissionMode?: ToolResultRequest['permission_mode'],
+  ): Promise<void> {
     await this.request('/chat/tool-result', {
       method: 'POST',
-      body: JSON.stringify({ session_id: sessionId, tool_call_id: toolCallId, result, fast_mode: fastMode }),
+      body: JSON.stringify({
+        session_id: sessionId,
+        tool_call_id: toolCallId,
+        result,
+        fast_mode: fastMode,
+        permission_mode: permissionMode,
+      }),
     });
   }
 
@@ -633,7 +646,7 @@ export class KrustyClient {
   }
 
   async streamToolResult(
-    request: { session_id: string; tool_call_id: string; result: string; fast_mode?: boolean },
+    request: ToolResultRequest,
     callbacks: StreamCallbacks,
     signal?: AbortSignal,
   ): Promise<void> {

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -143,6 +143,14 @@ export interface ToolCall {
 // Chat Request
 // ============================================================================
 
+export interface ToolResultRequest {
+  session_id: string;
+  tool_call_id: string;
+  result: string;
+  fast_mode?: boolean;
+  permission_mode?: PermissionMode;
+}
+
 export interface ChatRequest {
   session_id?: string;
   message: string;

--- a/packages/state/src/session/store.ts
+++ b/packages/state/src/session/store.ts
@@ -737,6 +737,7 @@ export function createSessionStore(
             tool_call_id: toolCallId,
             result,
             fast_mode: state.fastModeEnabled,
+            permission_mode: state.permissionMode,
           },
           callbacks,
           abortController.signal,


### PR DESCRIPTION
### Motivation
- Mobile AskUserQuestion/PlanConfirm flows resumed sessions via `/chat/tool-result` unconditionally in `Autonomous` mode, which downgraded supervised approval expectations and could allow model-mediated tool execution without the user's supervised consent.

### Description
- Add `permission_mode` to the `ToolResultRequest` shape and client API so callers can indicate the permission mode to preserve when resuming after an interactive tool result.  
- Compute a resumed permission mode in the server (`resumed_permission_mode`) and pass it into `start_orchestrator_sse` for both plan-confirm and regular tool-result continuations, while preserving Mako sessions as always `Autonomous`.  
- Wire the shared `packages/api` client and `packages/state` session store to include the current session `permissionMode` in streamed tool-result submissions.  
- Add unit tests that validate `ToolResultRequest` deserialization and that resumed permission selection preserves supervised/autonomous semantics and keeps Mako sessions autonomous.

### Testing
- Ran `cargo test -p krusty-server tool_result_request_accepts_permission_mode` and the test passed.  
- Ran the new `resumed_permission_mode` unit tests under `cargo test -p krusty-server` and they all passed.  
- Ran `cargo check -p krusty-server` which succeeded.  
- Ran `npx tsc --noEmit -p packages/api/tsconfig.json` which succeeded; broader workspace checks were partially blocked by environment/system issues (`cargo check --workspace` blocked by missing system `libudev` and `cd apps/mobile && npx tsc --noEmit -p tsconfig.json` blocked by an existing missing declaration for `xterm/css/xterm.css`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffcff29054832dac04aa6706574442)