### PR TITLE
Fix persistent memory tenant scoping

### DIFF
--- a/crates/krusty-core/src/agent/context.rs
+++ b/crates/krusty-core/src/agent/context.rs
@@ -46,6 +46,7 @@ pub fn inject_context(
     model_id: Option<&str>,
     session_type: Option<&str>,
     mako_crew_slug: Option<&str>,
+    user_id: Option<&str>,
 ) -> Vec<ModelMessage> {
     let is_chat = session_type == Some("chat");
 
@@ -57,7 +58,7 @@ pub fn inject_context(
                 text: "You are Krusty, a helpful conversational assistant. This is a chat session — you are having a natural conversation with the user.\n\nIMPORTANT: You do NOT have access to any tools in this session. Do not mention, list, or describe any tools. You cannot read files, run commands, or edit code. If the user asks about tools, explain that this is a chat-only session and suggest they switch to Code mode for coding tasks.\n\nBe friendly, helpful, and conversational.".to_string(),
             }],
         });
-        let memory_ctx = memory::build_memory_context(db_path, None, None);
+        let memory_ctx = memory::build_memory_context(db_path, None, user_id);
         if !memory_ctx.is_empty() {
             injected.push(ModelMessage {
                 role: Role::System,
@@ -75,7 +76,7 @@ pub fn inject_context(
     let memory_ctx = if is_mako {
         String::new()
     } else {
-        memory::build_memory_context(db_path, context_project_dir.as_deref(), None)
+        memory::build_memory_context(db_path, context_project_dir.as_deref(), user_id)
     };
     let plan_ctx = build_plan_context(db_path, session_id, work_mode);
     let delegated_ctx = runtime_state::build_delegated_context(db_path, session_id);
@@ -89,7 +90,7 @@ pub fn inject_context(
         reports::build_mako_knowledge_context(
             db_path,
             context_project_dir.as_deref(),
-            None,
+            user_id,
             session_id,
             conversation,
         )

--- a/crates/krusty-core/src/agent/context/tests.rs
+++ b/crates/krusty-core/src/agent/context/tests.rs
@@ -227,6 +227,7 @@ fn inject_context_skips_project_instructions_without_explicit_project_dir() {
         None,
         None,
         None,
+        None,
     );
 
     assert_eq!(injected.len(), 3);
@@ -241,6 +242,69 @@ fn inject_context_skips_project_instructions_without_explicit_project_dir() {
         Content::Text { text } if text.contains("[ENVIRONMENT]")
     ));
     assert_eq!(injected[2].role, Role::User);
+}
+
+#[test]
+fn inject_context_filters_persistent_memory_by_user_id() {
+    let temp = TempDir::new().unwrap();
+    let repo = temp.path();
+    fs::create_dir_all(repo.join(".git")).unwrap();
+    let db_path = repo.join("krusty.db");
+    let memory_store = MemoryStore::new(Database::new(&db_path).unwrap());
+    memory_store
+        .save(
+            MemoryType::User,
+            "Alice secret",
+            "alice-only instruction",
+            None,
+            Some("alice"),
+        )
+        .unwrap();
+    memory_store
+        .save(
+            MemoryType::User,
+            "Bob preference",
+            "bob-only preference",
+            None,
+            Some("bob"),
+        )
+        .unwrap();
+
+    let skills = RwLock::new(SkillsManager::with_defaults(repo));
+    let conversation = vec![ModelMessage {
+        role: Role::User,
+        content: vec![Content::Text {
+            text: "hello".to_string(),
+        }],
+    }];
+
+    let injected = inject_context(
+        &conversation,
+        db_path.as_path(),
+        "session-id",
+        repo,
+        None,
+        WorkMode::Build,
+        &skills,
+        None,
+        None,
+        None,
+        Some("bob"),
+    );
+
+    let context = injected
+        .iter()
+        .filter_map(|message| match &message.content[0] {
+            Content::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(context.contains("Bob preference"));
+    assert!(context.contains("bob-only preference"));
+    assert!(!context.contains("Alice secret"));
+    assert!(!context.contains("alice-only instruction"));
 }
 
 #[test]
@@ -270,6 +334,7 @@ fn inject_context_includes_mako_identity_only_for_mako_sessions() {
         None,
         Some("mako"),
         None,
+        None,
     );
     let code_injected = inject_context(
         &conversation,
@@ -281,6 +346,7 @@ fn inject_context_includes_mako_identity_only_for_mako_sessions() {
         &skills,
         None,
         Some("code"),
+        None,
         None,
     );
 
@@ -337,6 +403,7 @@ fn inject_context_places_all_mako_layers_before_project_settings() {
         None,
         Some("mako"),
         None,
+        None,
     );
 
     let texts = injected
@@ -385,6 +452,7 @@ fn inject_context_does_not_inline_mako_coordinator_prompt() {
         &skills,
         None,
         Some("mako"),
+        None,
         None,
     );
 
@@ -452,6 +520,7 @@ fn inject_context_includes_mako_knowledge_from_memory_and_reports() {
         &skills,
         None,
         Some("mako"),
+        None,
         None,
     );
 
@@ -526,6 +595,7 @@ fn inject_context_prioritizes_relevant_reports_over_recent_reports() {
         &skills,
         None,
         Some("code"),
+        None,
         None,
     );
 
@@ -604,6 +674,7 @@ fn inject_context_uses_active_mako_tasks_for_report_relevance() {
         None,
         Some("mako"),
         None,
+        None,
     );
 
     assert!(injected.iter().any(|message| {
@@ -673,6 +744,7 @@ fn inject_context_does_not_duplicate_generic_memory_and_report_blocks_for_mako()
         &skills,
         None,
         Some("mako"),
+        None,
         None,
     );
 
@@ -747,6 +819,7 @@ fn inject_context_includes_recent_delegated_run_guidance() {
         Some(repo),
         WorkMode::Build,
         &skills,
+        None,
         None,
         None,
         None,

--- a/crates/krusty-core/src/agent/orchestrator.rs
+++ b/crates/krusty-core/src/agent/orchestrator.rs
@@ -140,6 +140,7 @@ fn inject_runtime_context(
     skills_manager: &RwLock<SkillsManager>,
     model: Option<&str>,
     session_type: SessionType,
+    user_id: Option<&str>,
 ) -> Vec<ModelMessage> {
     context::inject_context(
         conversation,
@@ -152,6 +153,7 @@ fn inject_runtime_context(
         model,
         Some(session_type_name(session_type)),
         mako_crew_slug,
+        user_id,
     )
 }
 
@@ -323,6 +325,7 @@ impl AgenticOrchestrator {
                 &skills_manager,
                 Some(ai_client.config().model.as_str()),
                 session_type,
+                user_id.as_deref(),
             );
             let estimated_tokens_before =
                 super::estimate_conversation_tokens(&conversation_with_context);
@@ -955,6 +958,7 @@ mod tests {
             &skills,
             None,
             SessionType::Mako,
+            None,
         );
         let code_injected = inject_runtime_context(
             &conversation,
@@ -967,6 +971,7 @@ mod tests {
             &skills,
             None,
             SessionType::Code,
+            None,
         );
 
         assert!(mako_injected.iter().any(|message| {

--- a/crates/krusty-core/src/storage/memories/query.rs
+++ b/crates/krusty-core/src/storage/memories/query.rs
@@ -46,6 +46,8 @@ pub(super) fn build_list_query(
             " AND (user_id = ?{} OR user_id IS NULL)",
             bound.len()
         ));
+    } else {
+        sql.push_str(" AND user_id IS NULL");
     }
 
     sql.push_str(" ORDER BY updated_at DESC");

--- a/crates/krusty-core/src/storage/memories/store.rs
+++ b/crates/krusty-core/src/storage/memories/store.rs
@@ -185,6 +185,8 @@ impl MemoryStore {
                 " AND (user_id = ?{} OR user_id IS NULL)",
                 bound.len()
             ));
+        } else {
+            sql.push_str(" AND user_id IS NULL");
         }
 
         sql.push_str(" ORDER BY updated_at DESC LIMIT 1");

--- a/crates/krusty-core/src/storage/memories/tests.rs
+++ b/crates/krusty-core/src/storage/memories/tests.rs
@@ -35,6 +35,26 @@ fn save_and_list_memories() {
 }
 
 #[test]
+fn list_without_user_id_excludes_user_scoped_memories() {
+    let (store, _tmp) = create_store();
+    store
+        .save(MemoryType::User, "Global", "shared", None, None)
+        .unwrap();
+    store
+        .save(MemoryType::User, "Alice", "alice-only", None, Some("alice"))
+        .unwrap();
+
+    let unscoped = store.list(None, None);
+    assert_eq!(unscoped.len(), 1);
+    assert_eq!(unscoped[0].title, "Global");
+
+    let alice = store.list(None, Some("alice"));
+    assert_eq!(alice.len(), 2);
+    assert!(alice.iter().any(|memory| memory.title == "Alice"));
+    assert!(alice.iter().any(|memory| memory.title == "Global"));
+}
+
+#[test]
 fn update_memory() {
     let (store, _tmp) = create_store();
     let mem = store
@@ -139,6 +159,9 @@ fn find_by_title_for_user_respects_scope_and_owner() {
 
     assert_eq!(alice.unwrap().content, "Blue/green");
     assert_eq!(bob.unwrap().content, "Canary");
+    assert!(store
+        .find_by_title_for_user("Deployment", Some("/proj-a"), None)
+        .is_none());
 }
 
 #[test]

--- a/crates/krusty-core/src/tools/implementations/memory.rs
+++ b/crates/krusty-core/src/tools/implementations/memory.rs
@@ -116,8 +116,8 @@ Actions:
 
         match params.action.as_str() {
             "save" => execute_save(&store, db_path, &params, project_dir.as_deref(), user_id),
-            "update" => execute_update(&store, db_path, &params),
-            "delete" => execute_delete(&store, db_path, &params),
+            "update" => execute_update(&store, db_path, &params, user_id),
+            "delete" => execute_delete(&store, db_path, &params, user_id),
             "list" => execute_list(&store, &params, project_dir.as_deref(), user_id),
             other => ToolResult::invalid_parameters(format!(
                 "Unknown action '{}'. Valid actions: save, update, delete, list",
@@ -174,7 +174,12 @@ fn execute_save(
     }
 }
 
-fn execute_update(store: &MemoryStore, db_path: &std::path::Path, params: &Params) -> ToolResult {
+fn execute_update(
+    store: &MemoryStore,
+    db_path: &std::path::Path,
+    params: &Params,
+    user_id: Option<&str>,
+) -> ToolResult {
     let Some(id) = params.memory_id.as_deref().filter(|i| !i.is_empty()) else {
         return ToolResult::invalid_parameters("'update' requires memory_id");
     };
@@ -196,6 +201,12 @@ fn execute_update(store: &MemoryStore, db_path: &std::path::Path, params: &Param
     };
     if is_current_snapshot(&existing) {
         return ToolResult::invalid_parameters("Current Snapshot is managed automatically");
+    }
+    if !can_mutate_memory(&existing, user_id) {
+        return ToolResult::error(format!(
+            "failed to update memory: memory '{}' not found",
+            id
+        ));
     }
     if title.is_some_and(is_current_snapshot_title) {
         return ToolResult::invalid_parameters("Current Snapshot is managed automatically");
@@ -222,7 +233,12 @@ fn execute_update(store: &MemoryStore, db_path: &std::path::Path, params: &Param
     }
 }
 
-fn execute_delete(store: &MemoryStore, db_path: &std::path::Path, params: &Params) -> ToolResult {
+fn execute_delete(
+    store: &MemoryStore,
+    db_path: &std::path::Path,
+    params: &Params,
+    user_id: Option<&str>,
+) -> ToolResult {
     let Some(id) = params.memory_id.as_deref().filter(|i| !i.is_empty()) else {
         return ToolResult::invalid_parameters("'delete' requires memory_id");
     };
@@ -235,6 +251,12 @@ fn execute_delete(store: &MemoryStore, db_path: &std::path::Path, params: &Param
     };
     if is_current_snapshot(&existing) {
         return ToolResult::invalid_parameters("Current Snapshot is managed automatically");
+    }
+    if !can_mutate_memory(&existing, user_id) {
+        return ToolResult::error(format!(
+            "failed to delete memory: memory '{}' not found",
+            id
+        ));
     }
 
     match store.delete(id) {
@@ -255,6 +277,13 @@ fn execute_delete(store: &MemoryStore, db_path: &std::path::Path, params: &Param
             }))
         }
         Err(err) => ToolResult::error(format!("failed to delete memory: {err}")),
+    }
+}
+
+fn can_mutate_memory(memory: &crate::storage::AgentMemory, user_id: Option<&str>) -> bool {
+    match user_id {
+        Some(uid) => memory.user_id.as_deref() == Some(uid),
+        None => memory.user_id.is_none(),
     }
 }
 
@@ -407,6 +436,56 @@ mod tests {
         let list_result = MemoryTool.execute(json!({ "action": "list" }), &ctx).await;
         let parsed: Value = serde_json::from_str(&list_result.output).unwrap();
         assert_eq!(parsed["data"]["count"], 0);
+    }
+
+    #[tokio::test]
+    async fn update_and_delete_require_matching_user_scope() {
+        let (mut alice_ctx, _tmp) = test_ctx();
+        let db_path = alice_ctx.db_path.clone();
+        alice_ctx.user_id = Some("alice".to_string());
+        let bob_ctx = ToolContext {
+            db_path,
+            user_id: Some("bob".to_string()),
+            ..Default::default()
+        };
+
+        let save_result = MemoryTool
+            .execute(
+                json!({
+                    "action": "save",
+                    "memory_type": "feedback",
+                    "title": "Private",
+                    "content": "Alice only"
+                }),
+                &alice_ctx,
+            )
+            .await;
+        let parsed: Value = serde_json::from_str(&save_result.output).unwrap();
+        let id = parsed["data"]["id"].as_str().unwrap().to_string();
+
+        let update_result = MemoryTool
+            .execute(
+                json!({
+                    "action": "update",
+                    "memory_id": id,
+                    "content": "Bob cannot change this"
+                }),
+                &bob_ctx,
+            )
+            .await;
+        assert!(update_result.is_error);
+
+        let delete_result = MemoryTool
+            .execute(json!({ "action": "delete", "memory_id": id }), &bob_ctx)
+            .await;
+        assert!(delete_result.is_error);
+
+        let list_result = MemoryTool
+            .execute(json!({ "action": "list" }), &alice_ctx)
+            .await;
+        let parsed: Value = serde_json::from_str(&list_result.output).unwrap();
+        assert_eq!(parsed["data"]["count"], 1);
+        assert_eq!(parsed["data"]["memories"][0]["content"], "Alice only");
     }
 
     #[tokio::test]

--- a/crates/krusty-core/src/tools/registry/policy.rs
+++ b/crates/krusty-core/src/tools/registry/policy.rs
@@ -222,7 +222,6 @@ pub fn tool_policy(name: &str) -> ToolPolicy {
         "AskUserQuestion"
         | "PlanConfirm"
         | "enter_plan_mode"
-        | "memory"
         | "set_work_mode"
         | "set_workspace_context"
         | "task_start"


### PR DESCRIPTION
### Motivation
- Persistent memories were loaded with `user_id = None` during context injection, causing user-scoped memories to be returned unfiltered and leading to cross-tenant disclosure and prompt-injection risk.
- The list query omitted an explicit `user_id IS NULL` predicate when `user_id` was `None`, so unscoped calls returned all user-scoped memories for the project/global scope.
- Memory mutations (update/delete) did not enforce ownership checks and the memory tool was classified as `interactive`, bypassing write/approval and plan-mode governance.

### Description
- Thread the active `user_id` through context injection by adding a `user_id` parameter to `inject_context` and `inject_runtime_context` and passing it into `memory::build_memory_context` and `reports::build_mako_knowledge_context` so memory loading is tenant-scoped.
- Tighten memory SQL predicates so when `user_id` is `None` the query requires `user_id IS NULL`, preventing accidental inclusion of other users' memories (`storage/memories/query.rs` and `store.rs`).
- Enforce ownership for mutations by routing the tool `ctx.user_id` into `update`/`delete` operations and adding `can_mutate_memory` to reject cross-user modification attempts (`tools/implementations/memory.rs`).
- Change the memory tool governance by removing `"memory"` from the interactive allowlist so it falls through to the write-governed policy (requires supervised approval / is disallowed in plan-mode) (`tools/registry/policy.rs`).
- Add regression tests: memory list behavior for unscoped vs user-scoped (`storage/memories/tests.rs`), context injection filtering by user id (`agent/context/tests.rs`), and cross-user update/delete rejection for the memory tool (`tools/implementations/memory.rs`).

### Testing
- Ran unit tests for the memory surface: `cargo test -p krusty-core memory --lib` (all memory-related tests passed).
- Performed component checks: `cargo check -p krusty-core` and `cargo clippy -p krusty-core -- -D warnings` (succeeded for the crate scoped runs).
- Formatting verified with `cargo fmt --all -- --check` and mobile bundle export `cd apps/mobile && npx expo export --platform web` (both succeeded in this environment).
- Full workspace-level commands (`cargo check --workspace`, `cargo test --workspace`, `cargo clippy --workspace -- -D warnings`) were attempted but blocked in this environment due to a missing system dependency (`libudev.pc`) required by `libudev-sys`; this prevented completing workspace-wide compilation in the container but did not affect the crate-scoped tests described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd2f8f984832d875aaf01337295d8)