### PR TITLE
Harden Git environment context collection

### DIFF
--- a/crates/krusty-core/src/agent/context/tests.rs
+++ b/crates/krusty-core/src/agent/context/tests.rs
@@ -1,10 +1,11 @@
 use std::fs;
+use std::io::Write;
 
 use tempfile::TempDir;
 use tokio::sync::RwLock;
 
 use super::mako::{build_mako_context_sections, build_mako_context_sections_with_home};
-use super::workspace::summarize_git_status;
+use super::workspace::{build_environment_context, summarize_git_status};
 use super::{build_plan_context, build_project_context, build_skills_context, inject_context};
 
 use crate::agent::DelegatedRunStage;
@@ -182,6 +183,46 @@ fn build_skills_context_returns_empty_when_manager_is_busy() {
     let context = build_skills_context(&skills, true);
 
     assert!(context.is_empty());
+}
+
+#[test]
+fn build_environment_context_does_not_execute_repo_local_git_commands() {
+    let temp = TempDir::new().unwrap();
+    let repo_path = temp.path().join("repo");
+    fs::create_dir_all(&repo_path).unwrap();
+    git2::Repository::init(&repo_path).unwrap();
+
+    let payload_path = repo_path.join("fsmonitor-payload.sh");
+    let marker_path = repo_path.join("fsmonitor-marker");
+    fs::write(
+        &payload_path,
+        format!("#!/bin/sh\necho vulnerable > {}\n", marker_path.display()),
+    )
+    .unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(&payload_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&payload_path, permissions).unwrap();
+    }
+
+    fs::OpenOptions::new()
+        .append(true)
+        .open(repo_path.join(".git").join("config"))
+        .unwrap()
+        .write_all(format!("\n[core]\n	fsmonitor = {}\n", payload_path.display()).as_bytes())
+        .unwrap();
+
+    let context = build_environment_context(&repo_path, Some("test-model"));
+
+    assert!(context.contains("Git repository: yes"));
+    assert!(context.contains("Model: test-model"));
+    assert!(
+        !marker_path.exists(),
+        "environment context must not execute repo-local git helpers"
+    );
 }
 
 #[test]

--- a/crates/krusty-core/src/agent/context/workspace.rs
+++ b/crates/krusty-core/src/agent/context/workspace.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
-use std::process::Command;
-
 use tracing::warn;
+
+use git2::{Repository, Status, StatusOptions};
 
 use crate::storage::ProjectSettings;
 
@@ -65,50 +65,74 @@ pub(super) fn build_workspace_context(working_dir: &Path, project_dir: Option<&P
     )
 }
 
-fn run_git_context_command(working_dir: &Path, args: &[&str]) -> Option<std::process::Output> {
-    match Command::new("git")
-        .args(args)
-        .current_dir(working_dir)
-        .output()
-    {
-        Ok(output) if output.status.success() => Some(output),
-        Ok(output) => {
-            warn!(
-                working_dir = %working_dir.display(),
-                ?args,
-                status = ?output.status,
-                "Git probe failed while building environment context"
-            );
-            None
-        }
+fn open_git_repository(working_dir: &Path) -> Option<Repository> {
+    match Repository::open(working_dir) {
+        Ok(repo) => Some(repo),
         Err(error) => {
             warn!(
                 working_dir = %working_dir.display(),
-                ?args,
                 error = %error,
-                "Failed to run git probe while building environment context"
+                "Failed to open git repository while building environment context"
             );
             None
         }
     }
 }
 
-pub(super) fn summarize_git_status(status_text: &str) -> Option<String> {
+fn current_git_branch(repo: &Repository) -> Option<String> {
+    let head = repo.head().ok()?;
+    let branch = head.shorthand()?.trim();
+    if branch.is_empty() {
+        None
+    } else {
+        Some(branch.to_string())
+    }
+}
+
+fn summarize_git_statuses(repo: &Repository) -> Option<String> {
+    let mut options = StatusOptions::new();
+    options.include_untracked(true);
+
+    let statuses = match repo.statuses(Some(&mut options)) {
+        Ok(statuses) => statuses,
+        Err(error) => {
+            warn!(
+                error = %error,
+                "Failed to inspect git status while building environment context"
+            );
+            return None;
+        }
+    };
+
     let mut modified = 0usize;
     let mut staged = 0usize;
     let mut untracked = 0usize;
 
-    for line in status_text.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("??") {
+    for entry in statuses.iter() {
+        let status = entry.status();
+        if status.contains(Status::WT_NEW) {
             untracked += 1;
-        } else if trimmed.starts_with('A') {
+        }
+        if status.intersects(
+            Status::INDEX_NEW
+                | Status::INDEX_MODIFIED
+                | Status::INDEX_DELETED
+                | Status::INDEX_RENAMED
+                | Status::INDEX_TYPECHANGE,
+        ) {
             staged += 1;
-        } else if trimmed.starts_with('M') || trimmed.contains('M') {
+        }
+        if status.intersects(
+            Status::WT_MODIFIED | Status::WT_DELETED | Status::WT_RENAMED | Status::WT_TYPECHANGE,
+        ) {
             modified += 1;
         }
     }
 
+    format_git_status_summary(modified, staged, untracked)
+}
+
+fn format_git_status_summary(modified: usize, staged: usize, untracked: usize) -> Option<String> {
     let mut parts = Vec::new();
     if modified > 0 {
         parts.push(format!("{} modified", modified));
@@ -127,10 +151,31 @@ pub(super) fn summarize_git_status(status_text: &str) -> Option<String> {
     }
 }
 
+#[cfg(test)]
+pub(super) fn summarize_git_status(status_text: &str) -> Option<String> {
+    let mut modified = 0usize;
+    let mut staged = 0usize;
+    let mut untracked = 0usize;
+
+    for line in status_text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("??") {
+            untracked += 1;
+        } else if trimmed.starts_with('A') {
+            staged += 1;
+        } else if trimmed.starts_with('M') || trimmed.contains('M') {
+            modified += 1;
+        }
+    }
+
+    format_git_status_summary(modified, staged, untracked)
+}
+
 /// Build environment context with runtime information.
 ///
 /// Gathers working directory, git status, platform, shell, date, and model
-/// information. Git commands that fail are skipped with warnings.
+/// information. Repository metadata is read through libgit2 so context collection
+/// does not spawn repo-configurable Git helper commands.
 pub(super) fn build_environment_context(working_dir: &Path, model_id: Option<&str>) -> String {
     let mut lines = vec![
         "[ENVIRONMENT]".to_string(),
@@ -144,18 +189,12 @@ pub(super) fn build_environment_context(working_dir: &Path, model_id: Option<&st
     ));
 
     if is_git_repo {
-        if let Some(output) =
-            run_git_context_command(working_dir, &["rev-parse", "--abbrev-ref", "HEAD"])
-        {
-            let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !branch.is_empty() {
+        if let Some(repo) = open_git_repository(working_dir) {
+            if let Some(branch) = current_git_branch(&repo) {
                 lines.push(format!("Git branch: {}", branch));
             }
-        }
 
-        if let Some(output) = run_git_context_command(working_dir, &["status", "--short"]) {
-            let status_text = String::from_utf8_lossy(&output.stdout);
-            if let Some(summary) = summarize_git_status(&status_text) {
+            if let Some(summary) = summarize_git_statuses(&repo) {
                 lines.push(format!("Git status: {}", summary));
             }
         }


### PR DESCRIPTION
### Motivation
- The environment context builder previously spawned `git` processes per turn, which can execute repository-configured helpers (e.g., `core.fsmonitor`) and block indefinitely, creating a remote code-execution and availability risk when an untrusted repo is opened.
- Context is injected automatically before each AI turn, so the probe must be side-effect-free and non-blocking to preserve tool-approval and plan-mode safety guarantees.

### Description
- Replace ad-hoc `std::process::Command` `git` probes with libgit2 (`git2`) repository reads by adding `open_git_repository`, `current_git_branch`, and `summarize_git_statuses`, and by using those from `build_environment_context` in `crates/krusty-core/src/agent/context/workspace.rs`.
- Preserve the same `Git branch` / `Git status` output shape while avoiding spawning external Git helper processes or repo-configurable hooks.
- Add a regression test `build_environment_context_does_not_execute_repo_local_git_commands` in `crates/krusty-core/src/agent/context/tests.rs` that installs a repo-local `core.fsmonitor` helper and asserts the context builder does not execute it.
- Update documentation string to note repository metadata is read through libgit2 so context collection does not spawn repo-configurable Git helper commands.

### Testing
- Ran `cargo fmt --all -- --check` and `git diff --check`, both succeeded.
- Ran `cargo check -p krusty-core`, which succeeded without errors.
- Ran `cargo test -p krusty-core agent::context::tests`, which executed the context tests and reported all tests passed (21 passed, 0 failed).
- Ran `cargo clippy -p krusty-core -- -D warnings`, which completed successfully for the crate.
- Attempts to run workspace-wide `cargo check --workspace` and `cargo clippy --workspace -- -D warnings` were blocked in this environment due to a missing system `libudev.pc` required by `libudev-sys`, so those workspace-wide checks could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc832adbc832db90c615a4f634b20)