### PR TITLE
Block destructive rm commands targeting home globs

### DIFF
--- a/crates/krusty-core/src/agent/hooks/builtins.rs
+++ b/crates/krusty-core/src/agent/hooks/builtins.rs
@@ -230,6 +230,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn safety_hook_blocks_destructive_home_glob_rm() {
+        let hook = SafetyHook::new();
+        let ctx = default_context();
+
+        for command in [
+            "rm -rf ~/*",
+            "rm -rf $HOME/*",
+            "rm -rf ${HOME}/*",
+            "DEBUG=1 rm -rf $HOME/*",
+        ] {
+            let result = hook
+                .before_execute("bash", &json!({ "command": command }), &ctx)
+                .await;
+            assert!(
+                matches!(result, HookResult::Block { .. }),
+                "expected safety hook to block {command:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn safety_hook_blocks_network_pipe_to_shell() {
         let hook = SafetyHook::new();
         let ctx = default_context();

--- a/crates/krusty-core/src/agent/hooks/shell_policy.rs
+++ b/crates/krusty-core/src/agent/hooks/shell_policy.rs
@@ -138,6 +138,21 @@ fn has_unquoted_redirect(segment: &str) -> bool {
     false
 }
 
+fn contains_shell_glob(suffix: &str) -> bool {
+    suffix.chars().any(|ch| matches!(ch, '*' | '?' | '[' | '{'))
+}
+
+fn is_dangerous_home_rm_target(target: &str) -> bool {
+    matches!(
+        target,
+        "~" | "~/" | "$HOME" | "$HOME/" | "${HOME}" | "${HOME}/"
+    ) || target
+        .strip_prefix("~/")
+        .or_else(|| target.strip_prefix("$HOME/"))
+        .or_else(|| target.strip_prefix("${HOME}/"))
+        .is_some_and(contains_shell_glob)
+}
+
 fn is_dangerous_rm(tokens: &[String]) -> bool {
     let has_force = tokens
         .iter()
@@ -156,10 +171,9 @@ fn is_dangerous_rm(tokens: &[String]) -> bool {
         .skip(1)
         .filter(|t| !t.starts_with('-'))
         .any(|target| {
-            matches!(
-                target.as_str(),
-                "/" | "/*" | "~" | "~/" | "$HOME" | "$HOME/" | "${HOME}" | "${HOME}/"
-            ) || target.starts_with("/etc")
+            matches!(target.as_str(), "/" | "/*")
+                || is_dangerous_home_rm_target(target)
+                || target.starts_with("/etc")
                 || target.starts_with("/usr")
                 || target.starts_with("/var")
         })


### PR DESCRIPTION
### Motivation
- A recent parser rewrite narrowed `rm` target checks and no longer classified globbed home targets such as `~/*`, `$HOME/*`, and `${HOME}/*` as dangerous, allowing forced recursive deletion of a user's home contents to bypass the SafetyHook.

### Description
- Add a `contains_shell_glob` helper and `is_dangerous_home_rm_target` predicate in `crates/krusty-core/src/agent/hooks/shell_policy.rs` to detect globbed home targets after `~/`, `$HOME/`, and `${HOME}/`.
- Update `is_dangerous_rm` to call the new helper while preserving existing checks for `"/"`, `"/*"`, and system paths such as `/etc`, `/usr`, and `/var`.
- Add a regression test `safety_hook_blocks_destructive_home_glob_rm` in `crates/krusty-core/src/agent/hooks/builtins.rs` that verifies `rm -rf ~/*`, `rm -rf $HOME/*`, `rm -rf ${HOME}/*`, and an env-prefixed variant are blocked.
- Keep the change minimal and conservative to restore prior guardrail semantics without altering unrelated shell-safety rules.

### Testing
- Ran `cargo test -p krusty-core agent::hooks::builtins::tests::safety_hook_blocks_destructive_home_glob_rm`, which passed.
- Ran `cargo test -p krusty-core`, which executed the crate test suite and passed (all tests green).
- Ran `cargo check -p krusty-core`, `cargo clippy -p krusty-core -- -D warnings`, and `cargo fmt --all -- --check`, which succeeded for the crate.
- Attempted `cargo check --workspace` but it could not complete in this environment due to missing system `libudev` pkg-config metadata required by `libudev-sys`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc96978c8832d872004003b994cdc)