### PR TITLE
fix: sandbox delegated agent tool contexts

### DIFF
--- a/crates/krusty-core/src/agent/subagent/execution/governance.rs
+++ b/crates/krusty-core/src/agent/subagent/execution/governance.rs
@@ -28,9 +28,15 @@ pub(super) fn build_subagent_tool_context(task: &SubAgentTask, timeout_secs: u64
             .with_delegation_policy(policy);
     }
 
-    if delegated_is_explore(task) {
-        ctx = ctx.with_sandbox(task.working_dir.clone());
-    }
+    // Delegated agents must never silently drop the parent filesystem sandbox.
+    // When a task is constructed without an explicit inherited sandbox, fail closed
+    // to the assigned working directory instead of using ToolContext::default()'s
+    // unrestricted path behavior.
+    let sandbox_root = task
+        .sandbox_root
+        .clone()
+        .unwrap_or_else(|| task.working_dir.clone());
+    ctx = ctx.with_sandbox(sandbox_root);
 
     ctx
 }

--- a/crates/krusty-core/src/agent/subagent/execution/mod.rs
+++ b/crates/krusty-core/src/agent/subagent/execution/mod.rs
@@ -126,7 +126,25 @@ mod tests {
         assert_eq!(ctx.permission_mode, PermissionMode::Autonomous);
         assert_eq!(ctx.subagent_max_turns, Some(17));
         assert_eq!(ctx.delegation_policy, Some(policy));
-        assert!(ctx.sandbox_root.is_none());
+        assert_eq!(ctx.sandbox_root, Some(working_dir));
+    }
+
+    #[test]
+    fn build_subagent_tool_context_preserves_inherited_sandbox_root() {
+        let working_dir = PathBuf::from("/tmp/krusty-subagent/project");
+        let sandbox_root = PathBuf::from("/tmp/krusty-subagent");
+        let task = SubAgentTask::new("task", "prompt")
+            .with_working_dir(working_dir.clone())
+            .with_sandbox_root(sandbox_root.clone())
+            .with_delegation_policy(DelegationPolicy::for_subagent_build(
+                PermissionMode::Autonomous,
+                Some(17),
+            ));
+
+        let ctx = build_subagent_tool_context(&task, 45);
+
+        assert_eq!(ctx.working_dir, working_dir);
+        assert_eq!(ctx.sandbox_root, Some(sandbox_root));
     }
 
     #[test]

--- a/crates/krusty-core/src/agent/subagent/types/models.rs
+++ b/crates/krusty-core/src/agent/subagent/types/models.rs
@@ -54,6 +54,8 @@ pub struct SubAgentTask {
     pub name: String,
     pub prompt: String,
     pub working_dir: PathBuf,
+    /// Filesystem sandbox root inherited from the parent tool context.
+    pub sandbox_root: Option<PathBuf>,
     /// Stable delegated runtime unit identifier shared by all tasks in one parent invocation.
     pub delegated_run_id: Option<String>,
     /// Plan task ID this agent completes (for auto-marking).
@@ -75,6 +77,7 @@ impl SubAgentTask {
             name,
             prompt: prompt.into(),
             working_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            sandbox_root: None,
             delegated_run_id: None,
             plan_task_id: None,
             thinking_enabled: false,
@@ -90,6 +93,11 @@ impl SubAgentTask {
 
     pub fn with_working_dir(mut self, dir: PathBuf) -> Self {
         self.working_dir = dir;
+        self
+    }
+
+    pub fn with_sandbox_root(mut self, sandbox_root: PathBuf) -> Self {
+        self.sandbox_root = Some(sandbox_root);
         self
     }
 

--- a/crates/krusty-core/src/tools/implementations/agent/build.rs
+++ b/crates/krusty-core/src/tools/implementations/agent/build.rs
@@ -108,6 +108,11 @@ impl AgentTool {
                 let mut task = SubAgentTask::new(format!("builder-{}", i), task_prompt)
                     .with_name(name)
                     .with_working_dir(ctx.working_dir.clone())
+                    .with_sandbox_root(
+                        ctx.sandbox_root
+                            .clone()
+                            .unwrap_or_else(|| ctx.working_dir.clone()),
+                    )
                     .with_delegated_run_id(delegated_run_id.clone())
                     .with_delegation_policy(delegation_policy.clone());
                 if let Some(max_turns) = ctx.subagent_max_turns {
@@ -138,6 +143,11 @@ impl AgentTool {
             let mut task = SubAgentTask::new("builder-main", params.prompt.clone())
                 .with_name("main")
                 .with_working_dir(ctx.working_dir.clone())
+                .with_sandbox_root(
+                    ctx.sandbox_root
+                        .clone()
+                        .unwrap_or_else(|| ctx.working_dir.clone()),
+                )
                 .with_delegated_run_id(delegated_run_id.clone())
                 .with_delegation_policy(delegation_policy.clone());
             if let Some(max_turns) = ctx.subagent_max_turns {

--- a/crates/krusty-core/src/tools/implementations/agent/single.rs
+++ b/crates/krusty-core/src/tools/implementations/agent/single.rs
@@ -110,9 +110,14 @@ impl AgentTool {
             }
         }
 
+        let inherited_sandbox = ctx
+            .sandbox_root
+            .clone()
+            .unwrap_or_else(|| working_dir.clone());
         let mut task = SubAgentTask::new("explorer-0", &task_prompt)
             .with_name(scope_label.clone())
             .with_working_dir(working_dir)
+            .with_sandbox_root(inherited_sandbox)
             .with_delegated_run_id(delegated_run_id.clone())
             .with_delegation_policy(delegation_policy.clone());
         if let Some(max_turns) = ctx.subagent_max_turns {
@@ -277,6 +282,11 @@ impl AgentTool {
         let mut task = SubAgentTask::new("planner-0", &params.prompt)
             .with_name("planner")
             .with_working_dir(ctx.working_dir.clone())
+            .with_sandbox_root(
+                ctx.sandbox_root
+                    .clone()
+                    .unwrap_or_else(|| ctx.working_dir.clone()),
+            )
             .with_delegated_run_id(delegated_run_id.clone())
             .with_delegation_policy(delegation_policy.clone());
         if let Some(max_turns) = ctx.subagent_max_turns {
@@ -432,6 +442,11 @@ impl AgentTool {
         let mut task = SubAgentTask::new("verifier-0", &params.prompt)
             .with_name("verifier")
             .with_working_dir(ctx.working_dir.clone())
+            .with_sandbox_root(
+                ctx.sandbox_root
+                    .clone()
+                    .unwrap_or_else(|| ctx.working_dir.clone()),
+            )
             .with_delegated_run_id(delegated_run_id.clone())
             .with_delegation_policy(delegation_policy.clone());
         if let Some(max_turns) = ctx.subagent_max_turns {


### PR DESCRIPTION
### Motivation

- Prevent sub-agents from running with an unbounded filesystem view when the parent tool context intended a workspace sandbox, closing a critical sandbox-escape vulnerability.
- Ensure explore/build/plan/verify delegated tasks inherit or fall back to a safe sandbox so read/write/bash tools cannot access or modify files outside the intended workspace.

### Description

- Add an optional `sandbox_root: Option<PathBuf>` field and builder `with_sandbox_root` to `SubAgentTask` so delegated tasks can carry an inherited sandbox. (updated `crates/krusty-core/src/agent/subagent/types/models.rs`)
- Always apply a sandbox when building a sub-agent `ToolContext`: use `task.sandbox_root` if present, otherwise fail-closed to the task `working_dir`. (updated `crates/krusty-core/src/agent/subagent/execution/governance.rs`)
- Propagate the parent sandbox into delegated tasks created by the agent tool for explore, plan, verify and build flows (both parallel and single-builder paths). (updated `crates/krusty-core/src/tools/implementations/agent/single.rs` and `crates/krusty-core/src/tools/implementations/agent/build.rs`)
- Add/adjust unit tests to assert the sub-agent `ToolContext` is sandboxed by default and that an explicitly inherited sandbox is preserved. (updated `crates/krusty-core/src/agent/subagent/execution/mod.rs`)

### Testing

- Ran `cargo fmt --all -- --check` which passed. 
- Ran `cargo check -p krusty-core` which passed. 
- Ran the targeted unit tests `cargo test -p krusty-core build_subagent_tool_context` and the new/updated tests passed (2 tests ran for the modified assertions). 
- Ran `cargo clippy -p krusty-core -- -D warnings` which passed. 
- `cargo check --workspace` was attempted but could not complete in this environment due to a missing system `libudev.pc` (build failure from `libudev-sys`), so full workspace verification is blocked by the environment rather than code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffca2211ec832dac44138c598c1dbd)