### PR TITLE
fix: sandbox embedded workspace previews

### DIFF
--- a/apps/mobile/components/desktop/WorkspacePreview.tsx
+++ b/apps/mobile/components/desktop/WorkspacePreview.tsx
@@ -30,6 +30,12 @@ import { useConnection } from "../../hooks/useConnection";
 import { useThemeContext } from "../../hooks/useTheme";
 
 const PREVIEW_SESSION_KEY = "krusty_preview_tabs_v1";
+// Preview content is untrusted localhost app output served through the Krusty proxy.
+// Keep scripts/forms working for dev previews, but intentionally omit
+// allow-same-origin and top-navigation so preview JavaScript cannot access the
+// Krusty parent app or call privileged same-origin APIs.
+const PREVIEW_IFRAME_SANDBOX =
+  "allow-downloads allow-forms allow-modals allow-pointer-lock allow-popups allow-presentation allow-scripts";
 
 type PersistedPreviewTab = {
   id: string;
@@ -809,6 +815,7 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
                     <iframe
                       key={`${tab.id}:${tab.historyIndex}:${tab.reloadKey}`}
                       src={tab.history[tab.historyIndex]}
+                      sandbox={PREVIEW_IFRAME_SANDBOX}
                       style={{ width: "100%", height: "100%", border: "none" }}
                       title={tab.title}
                       onLoad={() => {


### PR DESCRIPTION
### Motivation
- Prevent same-origin escalation where proxied localhost preview content could run unsandboxed in an iframe and access parent-frame Krusty state or same-origin privileged APIs (e.g. `/api/tools/execute`) by making embedded previews explicitly restricted.

### Description
- Add a `PREVIEW_IFRAME_SANDBOX` policy and apply it to the embedded preview iframe in `apps/mobile/components/desktop/WorkspacePreview.tsx`, preserving useful preview capabilities (scripts/forms/downloads/popups) while intentionally omitting `allow-same-origin` and top-navigation to block preview JS from accessing the parent app or calling privileged same-origin APIs.

### Testing
- Ran `git diff --check`, a small static assertion script that verifies `PREVIEW_IFRAME_SANDBOX` is present and does not include `allow-same-origin`/`top-navigation`, and `cd apps/mobile && npx expo export --platform web` which succeeded; `cd apps/mobile && npx tsc --noEmit` was attempted and reported a preexisting local environment/type issue (`Cannot find module 'xterm/css/xterm.css'`) unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd311c908832d9ad954a7f26ffec4)