### PR TITLE
fix(mcp): make MCP startup opt-in (remove built-in minimax auto-exec)

### DIFF
--- a/crates/krusty-core/src/mcp/config/loader.rs
+++ b/crates/krusty-core/src/mcp/config/loader.rs
@@ -6,56 +6,29 @@ use super::expansion::expand_env_var;
 use super::types::{McpConfig, McpServerConfig, McpServerConfigRaw, RemoteMcpServer};
 
 impl McpConfig {
-    /// Built-in MCP servers included by default.
-    /// User configs in `.mcp.json` override these by name.
-    fn builtin_servers() -> HashMap<String, McpServerConfigRaw> {
-        HashMap::from([(
-            "minimax".to_string(),
-            McpServerConfigRaw::Local {
-                command: "uvx".to_string(),
-                args: vec!["minimax-coding-plan-mcp".to_string(), "-y".to_string()],
-                env: HashMap::from([
-                    (
-                        "MINIMAX_API_KEY".to_string(),
-                        "${MINIMAX_API_KEY}".to_string(),
-                    ),
-                    (
-                        "MINIMAX_API_HOST".to_string(),
-                        "https://api.minimax.io".to_string(),
-                    ),
-                ]),
-            },
-        )])
-    }
-
-    /// Load config from .mcp.json in project root, merged with built-in defaults.
+    /// Load config from .mcp.json in project root.
     pub async fn load(working_dir: &Path) -> Result<Self> {
-        let mut servers = Self::builtin_servers();
-
         let config_path = working_dir.join(".mcp.json");
 
-        if config_path.exists() {
-            let content = tokio::fs::read_to_string(&config_path)
-                .await
-                .with_context(|| format!("Failed to read {:?}", config_path))?;
-
-            let user_config: McpConfig = serde_json::from_str(&content)
-                .with_context(|| format!("Failed to parse {:?}", config_path))?;
-
-            tracing::info!(
-                "Loaded MCP config with {} servers from {:?}",
-                user_config.mcp_servers.len(),
-                config_path
-            );
-
-            servers.extend(user_config.mcp_servers);
-        } else {
+        if !config_path.exists() {
             tracing::debug!("No .mcp.json found at {:?}", config_path);
+            return Ok(Self::default());
         }
 
-        Ok(Self {
-            mcp_servers: servers,
-        })
+        let content = tokio::fs::read_to_string(&config_path)
+            .await
+            .with_context(|| format!("Failed to read {:?}", config_path))?;
+
+        let config: McpConfig = serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse {:?}", config_path))?;
+
+        tracing::info!(
+            "Loaded MCP config with {} servers from {:?}",
+            config.mcp_servers.len(),
+            config_path
+        );
+
+        Ok(config)
     }
 
     /// Get resolved server configurations

--- a/crates/krusty-core/src/mcp/config/tests.rs
+++ b/crates/krusty-core/src/mcp/config/tests.rs
@@ -2,6 +2,45 @@ use super::expansion::expand_env_var;
 use super::*;
 
 #[tokio::test]
+async fn test_load_without_mcp_json_returns_empty_config() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let config = McpConfig::load(dir.path()).await.unwrap();
+
+    assert!(config.mcp_servers.is_empty());
+    assert!(config.servers().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_load_uses_only_project_mcp_json_servers() {
+    let dir = tempfile::tempdir().unwrap();
+    tokio::fs::write(
+        dir.path().join(".mcp.json"),
+        r#"{
+            "mcpServers": {
+                "project-server": {
+                    "command": "echo",
+                    "args": ["hello"]
+                }
+            }
+        }"#,
+    )
+    .await
+    .unwrap();
+
+    let config = McpConfig::load(dir.path()).await.unwrap();
+    let servers = config.servers().await;
+
+    assert_eq!(servers.len(), 1);
+    assert!(matches!(
+        servers.get("project-server"),
+        Some(McpServerConfig::Local { command, args, .. })
+            if command == "echo" && args.as_slice() == ["hello"]
+    ));
+    assert!(!servers.contains_key("minimax"));
+}
+
+#[tokio::test]
 async fn test_parse_local_server() {
     let json = r#"{
         "mcpServers": {

--- a/docs/extensions/mcp-and-plugins.md
+++ b/docs/extensions/mcp-and-plugins.md
@@ -43,7 +43,7 @@ MCP servers are declared in a `.mcp.json` file at the project root. The format u
 
 Local servers need a `command` and optional `args` and `env`. Remote servers need `type: "url"` and a `url`, with an optional `authorization_token`. Environment variables in the config support `${VAR}` expansion -- Krusty checks the process environment first, then falls back to its internal credential store at `~/.krusty/tokens/credentials.json`.
 
-Krusty ships with one built-in MCP server (minimax) that gets merged with your `.mcp.json` configuration. User-defined servers override built-ins by name.
+Krusty does not start any MCP servers unless they are explicitly declared in the project's `.mcp.json`. This keeps local MCP subprocess execution opt-in and project-controlled.
 
 ### Tool Registration
 


### PR DESCRIPTION
### Motivation
- Prevent automatic execution of an unpinned third-party MCP package at startup by avoiding seeding built-in local MCP servers when a project has no `.mcp.json` configuration. 
- Close a high-severity supply-chain/execution vector where Krusty could spawn `uvx minimax-coding-plan-mcp -y` from the working directory without explicit project opt-in, approval, or pinning. 

### Description
- Stop merging built-in MCP servers into the runtime config by removing the implicit `minimax` seed and making `McpConfig::load` return `Default` when `.mcp.json` is absent (`crates/krusty-core/src/mcp/config/loader.rs`).
- Add regression tests that verify the no-`.mcp.json` code path returns an empty config and that an explicit project `.mcp.json` loads only declared servers (no implicit `minimax`) (`crates/krusty-core/src/mcp/config/tests.rs`).
- Update the MCP documentation to clarify that Krusty will only start MCP subprocesses explicitly declared in a project `.mcp.json` so local MCP execution is opt-in (`docs/extensions/mcp-and-plugins.md`).

### Testing
- Ran `cargo test -p krusty-core mcp::config::tests -- --nocapture` and the added unit tests passed (5 passed, 0 failed). 
- Ran `cargo check -p krusty-core`, `cargo clippy -p krusty-core -- -D warnings`, and `cargo fmt --all -- --check`, and these checks succeeded for the modified crate. 
- Workspace-level checks (`cargo check --workspace`, `cargo test --workspace --no-run`, and `cargo clippy --workspace -- -D warnings`) were blocked by the environment due to a missing system dependency (`libudev.pc` required by `libudev-sys`) and therefore could not be completed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffca2ce3cc832db0359717b9f271b7)