### PR TITLE
Restrict push endpoints to trusted providers and remove response-body diagnostic leakage

### DIFF
--- a/crates/krusty-server/src/push.rs
+++ b/crates/krusty-server/src/push.rs
@@ -24,6 +24,55 @@ use krusty_core::storage::{
 const MAX_PUSH_ATTEMPTS: usize = 3;
 const PUSH_RETRY_BASE_DELAY_MS: u64 = 300;
 
+const ALLOWED_PUSH_ENDPOINT_HOSTS: &[&str] = &[
+    "fcm.googleapis.com",
+    "updates.push.services.mozilla.com",
+    "webpush.push.apple.com",
+];
+const ALLOWED_PUSH_ENDPOINT_SUFFIXES: &[&str] = &[
+    ".push.services.mozilla.com",
+    ".notify.windows.com",
+    ".push.apple.com",
+];
+
+/// Validate and normalize a browser Web Push endpoint before it is persisted or used.
+///
+/// Push delivery is an outbound server request, so endpoints are restricted to HTTPS
+/// origins operated by known browser push providers. This prevents attacker-supplied
+/// subscriptions from turning push test/diagnostic routes into SSRF probes.
+pub fn normalize_push_endpoint(endpoint: &str) -> Result<String> {
+    let endpoint = endpoint.trim();
+    if endpoint.is_empty() {
+        anyhow::bail!("Push subscription endpoint is required");
+    }
+
+    let uri: http::Uri = endpoint
+        .parse()
+        .context("Push subscription endpoint must be a valid URL")?;
+
+    if uri.scheme_str() != Some("https") || uri.host().is_none() {
+        anyhow::bail!("Push subscription endpoint must be an https URL");
+    }
+
+    let host = uri
+        .host()
+        .unwrap_or_default()
+        .trim_end_matches('.')
+        .to_ascii_lowercase();
+    if !is_allowed_push_endpoint_host(&host) {
+        anyhow::bail!("Push subscription endpoint host is not a supported push service");
+    }
+
+    Ok(endpoint.to_string())
+}
+
+fn is_allowed_push_endpoint_host(host: &str) -> bool {
+    ALLOWED_PUSH_ENDPOINT_HOSTS.contains(&host)
+        || ALLOWED_PUSH_ENDPOINT_SUFFIXES
+            .iter()
+            .any(|suffix| host.ends_with(suffix))
+}
+
 /// Payload sent inside a push notification.
 #[derive(Debug, Clone, Serialize)]
 pub struct PushPayload {
@@ -121,7 +170,10 @@ impl PushService {
             public_key_base64url,
             contact,
             db_path,
-            http_client: reqwest::Client::new(),
+            http_client: reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .context("Failed to create push HTTP client")?,
         })
     }
 
@@ -138,6 +190,8 @@ impl PushService {
         auth: &str,
         payload: &PushPayload,
     ) -> Result<reqwest::Response> {
+        let endpoint =
+            normalize_push_endpoint(endpoint).context("Invalid push subscription endpoint")?;
         let endpoint_uri: http::Uri = endpoint
             .parse()
             .context("Invalid push subscription endpoint")?;
@@ -210,12 +264,7 @@ impl PushService {
                         return DeliveryOutcome::Stale { status, latency_ms };
                     }
 
-                    let body = response.text().await.unwrap_or_default();
-                    let reason = if body.is_empty() {
-                        format!("Push failed with status {}", status)
-                    } else {
-                        format!("Push failed with status {}: {}", status, body)
-                    };
+                    let reason = format!("Push failed with status {}", status);
 
                     if is_transient_status(status) && attempt < MAX_PUSH_ATTEMPTS {
                         tracing::warn!(

--- a/crates/krusty-server/src/routes/push.rs
+++ b/crates/krusty-server/src/routes/push.rs
@@ -2,7 +2,6 @@
 
 use axum::{
     extract::State,
-    http::Uri,
     routing::{delete, get, post},
     Json, Router,
 };
@@ -14,7 +13,7 @@ use krusty_core::storage::{Database, PushDeliveryAttemptStore, PushSubscriptionS
 
 use crate::auth::CurrentUser;
 use crate::error::AppError;
-use crate::push::{PushEventType, PushPayload};
+use crate::push::{normalize_push_endpoint, PushEventType, PushPayload};
 use crate::AppState;
 
 pub fn router() -> Router<AppState> {
@@ -154,24 +153,7 @@ struct SubscribeResponse {
 }
 
 fn normalize_endpoint(endpoint: &str) -> Result<String, AppError> {
-    let endpoint = endpoint.trim();
-    if endpoint.is_empty() {
-        return Err(AppError::BadRequest(
-            "Push subscription endpoint is required".to_string(),
-        ));
-    }
-
-    let uri: Uri = endpoint.parse().map_err(|_| {
-        AppError::BadRequest("Push subscription endpoint must be a valid URL".to_string())
-    })?;
-
-    if uri.scheme_str() != Some("https") || uri.host().is_none() {
-        return Err(AppError::BadRequest(
-            "Push subscription endpoint must be an https URL".to_string(),
-        ));
-    }
-
-    Ok(endpoint.to_string())
+    normalize_push_endpoint(endpoint).map_err(|err| AppError::BadRequest(err.to_string()))
 }
 
 fn normalize_auth_secret(auth: &str) -> Result<String, AppError> {
@@ -263,9 +245,23 @@ mod tests {
 
     #[test]
     fn subscribe_validation_rejects_non_https_endpoints() {
-        let error = normalize_endpoint("http://push.example.test/subscription")
+        let error = normalize_endpoint("http://fcm.googleapis.com/subscription")
             .expect_err("http endpoint should be rejected");
         assert!(matches!(error, super::AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn subscribe_validation_rejects_loopback_and_untrusted_hosts() {
+        for endpoint in [
+            "https://127.0.0.1/internal",
+            "https://localhost/internal",
+            "https://192.168.0.10/internal",
+            "https://push.example.test/subscription",
+        ] {
+            let error = normalize_endpoint(endpoint)
+                .expect_err("unsupported push endpoint host should be rejected");
+            assert!(matches!(error, super::AppError::BadRequest(_)));
+        }
     }
 
     #[test]
@@ -278,7 +274,7 @@ mod tests {
     #[test]
     fn subscribe_validation_accepts_valid_push_keys() {
         let auth = Base64UrlUnpadded::encode_string(b"abcdefghijklmnop");
-        assert!(normalize_endpoint("https://push.example.test/subscription").is_ok());
+        assert!(normalize_endpoint("https://fcm.googleapis.com/fcm/send/test").is_ok());
         assert!(normalize_auth_secret(&auth).is_ok());
         assert!(normalize_p256dh_key(&valid_p256dh_key()).is_ok());
     }


### PR DESCRIPTION
### Motivation
- Push subscription storage and the `/api/push/test` + `/api/push/status` diagnostics could be abused as an SSRF/information-leak: attacker-supplied endpoints (including loopback/private IPs) were accepted and non-2xx response bodies were persisted and exposed.
- The change hardens push delivery and diagnostics to prevent turning the push feature into a semi-blind SSRF channel.

### Description
- Add `normalize_push_endpoint` in `crates/krusty-server/src/push.rs` which trims/parses endpoints, enforces `https`, and restricts hosts to a small allowlist of known browser push providers or allowed suffixes.
- Apply the normalization at subscription time (subscribe/unsubscribe routes) and again at send time (`send_once`) to provide defense-in-depth and reject legacy/invalid stored endpoints.
- Disable HTTP redirects for the push HTTP client by building the `reqwest::Client` with `redirect::Policy::none()` to avoid following redirect chains to attacker-controlled/internal targets.
- Stop reading and persisting remote response bodies for non-stale failures; failure reasons now omit response bodies so `/api/push/status` cannot leak remote content.
- Add and update unit tests in `crates/krusty-server/src/routes/push.rs` to assert rejection of non-HTTPS, loopback/private/untrusted hosts and acceptance of a canonical provider URL.

### Testing
- Ran `cargo test -p krusty-server routes::push --lib` and all route tests passed (4 passed, 0 failed).
- Ran `cargo check -p krusty-server` and it succeeded for the crate.
- Ran `cargo clippy -p krusty-server -- -D warnings` and `clippy` passed for the crate after minor adjustments.
- Ran `cargo fmt --all -- --check` and formatting checks passed.
- Ran `npx expo export --platform web` for the web bundle and it succeeded.
- Workspace-wide checks (`cargo check --workspace`, `cargo test --workspace`, `cargo clippy --workspace -- -D warnings`) were attempted but could not complete in this environment due to a missing system dependency (`libudev`/`libudev.pc`) required by `libudev-sys`; this is an environmental issue and not caused by the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffcfcdcc90832db6733238d53b8b3e)