### PR TITLE
Preserve permission mode for interactive continuations

### DIFF
--- a/crates/krusty-core/src/agent/orchestrator.rs
+++ b/crates/krusty-core/src/agent/orchestrator.rs
@@ -546,6 +546,7 @@ impl AgenticOrchestrator {
                             &build_awaiting_input_recovery_state(
                                 build_partial_assistant_state(&result.recovery_checkpoint),
                                 vec![pending_interaction],
+                                permission_mode,
                             ),
                         );
                         set_agent_state(&db_path, &session_id, "awaiting_input");
@@ -652,6 +653,7 @@ impl AgenticOrchestrator {
                     &build_awaiting_input_recovery_state(
                         ask_user_partial_assistant,
                         ask_user_pending_interactions,
+                        permission_mode,
                     ),
                 );
                 set_agent_state(&db_path, &session_id, "awaiting_input");

--- a/crates/krusty-core/src/agent/orchestrator/recovery.rs
+++ b/crates/krusty-core/src/agent/orchestrator/recovery.rs
@@ -4,6 +4,7 @@ use crate::storage::{
     PartialAssistantState, PendingInteractionSnapshot, RecoveryDecision,
     RecoveryNonResumableReason, RecoveryStatus, RecoveryToolCall, SessionRecoveryState,
 };
+use crate::tools::registry::PermissionMode;
 
 use super::super::loop_events::LoopStopReason;
 
@@ -55,6 +56,7 @@ pub(super) fn build_recovery_state(
 pub(super) fn build_awaiting_input_recovery_state(
     partial_assistant: PartialAssistantState,
     pending_interactions: Vec<PendingInteractionSnapshot>,
+    permission_mode: PermissionMode,
 ) -> SessionRecoveryState {
     SessionRecoveryState::new_with_pending_interactions(
         RecoveryStatus::AwaitingInput,
@@ -66,6 +68,7 @@ pub(super) fn build_awaiting_input_recovery_state(
             reason: RecoveryNonResumableReason::AwaitingHumanInput,
         },
     )
+    .with_permission_mode(permission_mode)
 }
 
 fn recovery_decision(
@@ -150,6 +153,7 @@ mod tests {
             vec![PendingInteractionSnapshot::ask_user_from_call(
                 "ask-1", &arguments,
             )],
+            PermissionMode::Supervised,
         );
 
         assert_eq!(state.status, RecoveryStatus::AwaitingInput);
@@ -159,6 +163,7 @@ mod tests {
                 reason: RecoveryNonResumableReason::AwaitingHumanInput
             }
         );
+        assert_eq!(state.permission_mode, Some(PermissionMode::Supervised));
         assert_eq!(state.pending_interactions.len(), 1);
         match &state.pending_interactions[0] {
             PendingInteractionSnapshot::AskUserQuestion {

--- a/crates/krusty-core/src/storage/recovery.rs
+++ b/crates/krusty-core/src/storage/recovery.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use crate::agent::loop_events::LoopStopReason;
+use crate::tools::registry::PermissionMode;
 
 pub const REDACTED_ARGUMENT_VALUE: &str = "[REDACTED]";
 const MAX_ARGUMENT_STRING_CHARS: usize = 2_048;
@@ -241,6 +242,10 @@ pub struct SessionRecoveryState {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pending_interactions: Vec<PendingInteractionSnapshot>,
     pub decision: RecoveryDecision,
+    /// Effective permission mode for the interrupted turn, used to resume
+    /// interactive continuations without weakening tool approval policy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission_mode: Option<PermissionMode>,
 }
 
 impl SessionRecoveryState {
@@ -277,6 +282,7 @@ impl SessionRecoveryState {
             partial_assistant,
             pending_interactions,
             decision,
+            permission_mode: None,
         }
     }
 
@@ -285,6 +291,11 @@ impl SessionRecoveryState {
         pending_interactions: Vec<PendingInteractionSnapshot>,
     ) -> Self {
         self.pending_interactions = pending_interactions;
+        self
+    }
+
+    pub fn with_permission_mode(mut self, permission_mode: PermissionMode) -> Self {
+        self.permission_mode = Some(permission_mode);
         self
     }
 
@@ -527,6 +538,39 @@ fn contains_sensitive_string_marker(text: &str) -> bool {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn recovery_state_permission_mode_is_optional_for_legacy_snapshots() {
+        let state: SessionRecoveryState = serde_json::from_value(json!({
+            "schema_version": 1,
+            "status": "awaiting_input",
+            "stop_reason": "awaiting_input",
+            "last_error": null,
+            "partial_assistant": {"text": "", "thinking": "", "tool_calls": []},
+            "pending_interactions": [],
+            "decision": {"kind": "non_resumable", "reason": "awaiting_human_input"}
+        }))
+        .expect("legacy recovery state should deserialize");
+
+        assert_eq!(state.permission_mode, None);
+    }
+
+    #[test]
+    fn recovery_state_serializes_permission_mode_when_present() {
+        let state = SessionRecoveryState::new(
+            RecoveryStatus::AwaitingInput,
+            Some(LoopStopReason::AwaitingInput),
+            None,
+            PartialAssistantState::default(),
+            RecoveryDecision::NonResumable {
+                reason: RecoveryNonResumableReason::AwaitingHumanInput,
+            },
+        )
+        .with_permission_mode(PermissionMode::Supervised);
+
+        let serialized = serde_json::to_value(&state).expect("state should serialize");
+        assert_eq!(serialized["permission_mode"], "supervised");
+    }
 
     #[test]
     fn resumable_notice_mentions_objective() {

--- a/crates/krusty-server/src/routes/chat/interactions.rs
+++ b/crates/krusty-server/src/routes/chat/interactions.rs
@@ -12,7 +12,7 @@ use krusty_core::agent::plan_handler::parse_plan_confirm_choice;
 use krusty_core::agent::LoopInput;
 use krusty_core::ai::types::{Content, ModelMessage, Role};
 use krusty_core::plan::PlanManager;
-use krusty_core::storage::{Database, PendingInteractionSnapshot, WorkMode};
+use krusty_core::storage::{Database, PendingInteractionSnapshot, SessionType, WorkMode};
 use krusty_core::tools::registry::PermissionMode;
 use krusty_core::SessionManager;
 
@@ -78,8 +78,8 @@ pub(super) async fn tool_result(
                 .save_message(&req.session_id, "user", &user_json)?;
             ctx.work_mode
         };
-        return start_orchestrator_sse(&state, ctx, work_mode, PermissionMode::Autonomous, false)
-            .await;
+        let permission_mode = continuation_permission_mode(&ctx);
+        return start_orchestrator_sse(&state, ctx, work_mode, permission_mode, false).await;
     }
 
     let has_thinking = ctx.conversation.iter().any(|msg| {
@@ -132,7 +132,21 @@ pub(super) async fn tool_result(
     }
 
     let work_mode = ctx.work_mode;
-    start_orchestrator_sse(&state, ctx, work_mode, PermissionMode::Autonomous, false).await
+    let permission_mode = continuation_permission_mode(&ctx);
+    start_orchestrator_sse(&state, ctx, work_mode, permission_mode, false).await
+}
+
+fn continuation_permission_mode(ctx: &super::session::ChatSessionContext) -> PermissionMode {
+    if ctx.session_type == SessionType::Mako {
+        return PermissionMode::Autonomous;
+    }
+
+    ctx.session_manager
+        .load_recovery_state(&ctx.session_id)
+        .ok()
+        .flatten()
+        .and_then(|state| state.permission_mode)
+        .unwrap_or(PermissionMode::Supervised)
 }
 
 pub(super) async fn tool_approval(


### PR DESCRIPTION
### Motivation
- Prevent supervised sessions from losing their approval policy when a model issues an interactive prompt (`AskUserQuestion` / `PlanConfirm`) and the client resumes the loop via the continuation route.
- Ensure write-category tools cannot bypass the supervised approval gate after a user-provided tool-result.

### Description
- Add an optional `permission_mode: Option<PermissionMode>` to `SessionRecoveryState` and a `with_permission_mode` builder so awaiting-input recovery snapshots can record the effective permission mode.
- Update the orchestrator to pass the active `permission_mode` into `build_awaiting_input_recovery_state` for both `PlanConfirm` and `AskUserQuestion` awaiting-input paths so the snapshot preserves the mode.
- Change the `/chat/tool-result` continuation handler to resume the orchestrator using the stored permission mode from recovery state (with `Supervised` as a conservative fallback for legacy snapshots and `Autonomous` preserved for Mako sessions) instead of hardcoding `PermissionMode::Autonomous`.
- Add unit tests to verify legacy recovery snapshots deserialize without `permission_mode`, that `permission_mode` serializes when present, and that the orchestrator persists supervised permission mode for `AskUserQuestion` awaiting-input snapshots.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo check --workspace`, which failed in this environment due to missing system `libudev.pc` required by `libudev-sys` (environment limitation; not a functional regression in the change).
- Ran `cargo test -p krusty-core` focused on recovery and orchestrator tests including `recovery_state_permission_mode_is_optional_for_legacy_snapshots`, `recovery_state_serializes_permission_mode_when_present`, and `orchestrator_awaiting_ask_user_persists_reconstructable_pending_input`, and these tests passed.
- Ran `cargo clippy -p krusty-core -- -D warnings` for the modified crate and it completed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd92c2dfc832d88d405b6e4581f9c)