### PR TITLE
fix(acp): gate privileged tool execution

### DIFF
--- a/crates/krusty-core/src/acp/bridge.rs
+++ b/crates/krusty-core/src/acp/bridge.rs
@@ -7,7 +7,7 @@
 use std::time::Duration;
 
 use agent_client_protocol::{
-    Client, Error as AcpError, PermissionOptionId, RequestPermissionOutcome,
+    Client, Error as AcpError, PermissionOptionKind, RequestPermissionOutcome,
     RequestPermissionRequest, RequestPermissionResponse, Result as AcpResult,
     SelectedPermissionOutcome, SessionNotification,
 };
@@ -39,24 +39,36 @@ impl NotificationBridge {
 ///
 /// # Security Note
 ///
-/// In headless/ACP mode, permissions are auto-approved because there's no UI
-/// to prompt the user. This is expected behavior for background agent execution.
-/// The editor (Zed, etc.) is responsible for user consent before spawning the agent.
+/// In headless bridge mode there is no UI that can safely confirm sensitive tool
+/// requests. The bridge therefore rejects permission requests by default instead
+/// of silently granting write or shell access. Interactive ACP clients can still
+/// approve by implementing `request_permission` on their real connection.
 #[async_trait::async_trait(?Send)]
 impl Client for NotificationBridge {
     async fn request_permission(
         &self,
         request: RequestPermissionRequest,
     ) -> AcpResult<RequestPermissionResponse> {
-        // In headless mode, auto-approve permissions since there's no UI to prompt.
-        // The editor is responsible for user consent before spawning the agent.
-        let option_id = request
+        // No UI is available on the notification bridge, so choose the safest
+        // provided option. Prefer an explicit reject choice; if the caller did
+        // not provide one, return Cancelled instead of granting access.
+        let Some(option_id) = request
             .options
-            .first()
+            .iter()
+            .find(|opt| {
+                matches!(
+                    opt.kind,
+                    PermissionOptionKind::RejectOnce | PermissionOptionKind::RejectAlways
+                )
+            })
             .map(|opt| opt.option_id.clone())
-            .unwrap_or_else(|| PermissionOptionId::from("allow"));
+        else {
+            warn!("Permission request cancelled in headless mode: no reject option provided");
+            return Ok(RequestPermissionResponse::new(
+                RequestPermissionOutcome::Cancelled,
+            ));
+        };
 
-        // Log what permission is being granted
         let tool_desc = request
             .tool_call
             .fields
@@ -64,7 +76,7 @@ impl Client for NotificationBridge {
             .as_deref()
             .unwrap_or("unknown operation");
         info!(
-            "Permission auto-granted for '{}' (headless mode, option: {})",
+            "Permission rejected for '{}' (headless mode, option: {})",
             tool_desc, option_id
         );
 
@@ -115,7 +127,8 @@ pub fn create_notification_channel() -> (NotificationBridge, mpsc::Receiver<Sess
 mod tests {
     use super::*;
     use agent_client_protocol::{
-        ContentBlock, ContentChunk, SessionId, SessionUpdate, TextContent,
+        ContentBlock, ContentChunk, PermissionOption, PermissionOptionId, RequestPermissionOutcome,
+        SessionId, SessionUpdate, TextContent, ToolCallId, ToolCallUpdate, ToolCallUpdateFields,
     };
 
     #[tokio::test]
@@ -133,6 +146,67 @@ mod tests {
         assert!(matches!(
             received.update,
             SessionUpdate::AgentMessageChunk(_)
+        ));
+    }
+    #[tokio::test]
+    async fn test_bridge_rejects_permission_requests_in_headless_mode() {
+        let (bridge, _rx) = create_notification_channel();
+
+        let response = bridge
+            .request_permission(RequestPermissionRequest::new(
+                SessionId::from("test-session"),
+                ToolCallUpdate::new(
+                    ToolCallId::from("write-001"),
+                    ToolCallUpdateFields::new().title("Run write"),
+                ),
+                vec![
+                    PermissionOption::new(
+                        PermissionOptionId::new("allow-once"),
+                        "Allow once",
+                        PermissionOptionKind::AllowOnce,
+                    ),
+                    PermissionOption::new(
+                        PermissionOptionId::new("reject-once"),
+                        "Reject",
+                        PermissionOptionKind::RejectOnce,
+                    ),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        match response.outcome {
+            RequestPermissionOutcome::Selected(selected) => {
+                assert_eq!(selected.option_id.0.as_ref(), "reject-once");
+            }
+            RequestPermissionOutcome::Cancelled => panic!("expected explicit rejection"),
+            _ => panic!("unexpected permission outcome"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_bridge_cancels_permission_without_reject_option() {
+        let (bridge, _rx) = create_notification_channel();
+
+        let response = bridge
+            .request_permission(RequestPermissionRequest::new(
+                SessionId::from("test-session"),
+                ToolCallUpdate::new(
+                    ToolCallId::from("write-001"),
+                    ToolCallUpdateFields::new().title("Run write"),
+                ),
+                vec![PermissionOption::new(
+                    PermissionOptionId::new("allow-once"),
+                    "Allow once",
+                    PermissionOptionKind::AllowOnce,
+                )],
+            ))
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            response.outcome,
+            RequestPermissionOutcome::Cancelled
         ));
     }
 }

--- a/crates/krusty-core/src/acp/processor/loop_impl.rs
+++ b/crates/krusty-core/src/acp/processor/loop_impl.rs
@@ -1,6 +1,8 @@
 use agent_client_protocol::{
-    Client as AcpClient, ContentBlock as AcpContent, ContentChunk, SessionNotification,
-    SessionUpdate, StopReason, TextContent, ToolCall, ToolCallId,
+    Client as AcpClient, ContentBlock as AcpContent, ContentChunk, PermissionOption,
+    PermissionOptionId, PermissionOptionKind, RequestPermissionOutcome, RequestPermissionRequest,
+    SessionNotification, SessionUpdate, StopReason, TextContent, ToolCall, ToolCallId,
+    ToolCallUpdate, ToolCallUpdateFields,
 };
 use anyhow::Result;
 
@@ -8,7 +10,7 @@ use crate::ai::client::CallOptions;
 use crate::ai::streaming::StreamPart;
 use crate::ai::types::{AiToolCall, Content, FinishReason};
 use crate::tools::git_identity::GitIdentityMode;
-use crate::tools::registry::PermissionMode;
+use crate::tools::registry::{tool_policy, PermissionMode};
 use crate::tools::{ToolContext, ToolResult};
 
 use super::content::convert_acp_content;
@@ -203,7 +205,7 @@ impl PromptProcessor {
             working_dir: session.cwd.clone(),
             ..Default::default()
         }
-        .with_permission_mode(PermissionMode::Autonomous)
+        .with_permission_mode(PermissionMode::Supervised)
         .with_subagent_max_turns(self.agent_config.subagent_max_turns)
         .with_ai_client(ai_client.clone());
 
@@ -229,10 +231,24 @@ impl PromptProcessor {
                 tracing::warn!("Failed to send tool start: {}", e);
             }
 
-            let result = self
-                .tools
-                .execute(&tool_call.name, tool_call.arguments.clone(), &ctx)
-                .await;
+            let result = if requires_acp_permission(&tool_call) {
+                match request_tool_permission(session, &tool_call, connection).await? {
+                    ToolPermissionDecision::Allow => {
+                        self.tools
+                            .execute(&tool_call.name, tool_call.arguments.clone(), &ctx)
+                            .await
+                    }
+                    ToolPermissionDecision::Deny => Some(ToolResult::error_with_code(
+                        "permission_denied",
+                        format!("Tool '{}' was denied by the ACP client", tool_call.name),
+                    )),
+                    ToolPermissionDecision::Cancelled => return Ok(StopReason::Cancelled),
+                }
+            } else {
+                self.tools
+                    .execute(&tool_call.name, tool_call.arguments.clone(), &ctx)
+                    .await
+            };
 
             let (update, output_for_history, is_error_for_history) = match &result {
                 Some(ToolResult { output, is_error }) if !*is_error => {
@@ -281,6 +297,62 @@ impl PromptProcessor {
         }
 
         Ok(StopReason::EndTurn)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ToolPermissionDecision {
+    Allow,
+    Deny,
+    Cancelled,
+}
+
+fn requires_acp_permission(tool_call: &AiToolCall) -> bool {
+    tool_policy(&tool_call.name).requires_supervised_approval
+}
+
+async fn request_tool_permission<C: AcpClient>(
+    session: &SessionState,
+    tool_call: &AiToolCall,
+    connection: &C,
+) -> Result<ToolPermissionDecision, AcpError> {
+    let request = RequestPermissionRequest::new(
+        session.id.clone(),
+        ToolCallUpdate::new(
+            ToolCallId::from(tool_call.id.clone()),
+            ToolCallUpdateFields::new()
+                .title(format!("Run {}", tool_call.name))
+                .kind(tool_name_to_kind(&tool_call.name))
+                .raw_input(tool_call.arguments.clone()),
+        ),
+        vec![
+            PermissionOption::new(
+                PermissionOptionId::new("allow-once"),
+                "Allow once",
+                PermissionOptionKind::AllowOnce,
+            ),
+            PermissionOption::new(
+                PermissionOptionId::new("reject-once"),
+                "Reject",
+                PermissionOptionKind::RejectOnce,
+            ),
+        ],
+    );
+
+    let response = connection
+        .request_permission(request)
+        .await
+        .map_err(|e| AcpError::ProtocolError(e.to_string()))?;
+
+    match response.outcome {
+        RequestPermissionOutcome::Selected(selected)
+            if selected.option_id.0.as_ref().starts_with("allow") =>
+        {
+            Ok(ToolPermissionDecision::Allow)
+        }
+        RequestPermissionOutcome::Selected(_) => Ok(ToolPermissionDecision::Deny),
+        RequestPermissionOutcome::Cancelled => Ok(ToolPermissionDecision::Cancelled),
+        _ => Ok(ToolPermissionDecision::Deny),
     }
 }
 


### PR DESCRIPTION
### Motivation
- The ACP agentic loop allowed tool outputs to be fed back to the model and trigger subsequent privileged tools in the same prompt without an approval/sandbox gate, enabling prompt-injection-driven local actions. 
- The change introduces explicit ACP permission checks and safer default headless behavior to stop untrusted model-visible tool output from causing chained privileged operations.

### Description
- Require ACP permission before executing write-capable tools by requesting a permission via `request_permission` and only executing when the client explicitly allows the operation, returning a `permission_denied` `ToolResult` on rejection or cancelling on client `Cancelled` responses (changes in `crates/krusty-core/src/acp/processor/loop_impl.rs`).
- Run ACP tool execution contexts in supervised mode so delegated surfaces inherit supervised governance via `ToolContext.with_permission_mode(PermissionMode::Supervised)` (change in `execute_tool_calls`).
- Add helper functions to detect privileged tools (`requires_acp_permission`) and to build/dispatch a permission request (`request_tool_permission`) that populates `ToolCallUpdate` with a title, kind and raw input and interprets the `RequestPermissionOutcome` result (new helpers in `loop_impl.rs`).
- Harden the headless notification bridge to reject permission requests by default instead of auto-approving sensitive operations when no UI is available, preferring an explicit reject option and returning `Cancelled` if no safe reject option exists (changes in `crates/krusty-core/src/acp/bridge.rs`).
- Add unit tests that assert the headless bridge rejects permission requests or cancels when no reject option is provided (new tests in `crates/krusty-core/src/acp/bridge.rs`).

### Testing
- Ran `cargo fmt --all -- --check`, which succeeded. 
- Ran `cargo check -p krusty-core`, which succeeded. 
- Ran `cargo test -p krusty-core acp::bridge::tests`, and the new bridge tests passed. 
- Ran `cargo clippy -p krusty-core -- -D warnings`, which completed successfully. 
- `cargo check --workspace` and `cargo test --workspace --no-run` could not complete in this environment due to a missing system `libudev` pkg-config dependency required by a transitive crate (build env issue), so full workspace-level checks were blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffdd5e8e38832d80da725fd30f7fe4)