### PR TITLE
fix(acp): sandbox tool execution

### DIFF
--- a/crates/krusty-core/src/acp/processor/loop_impl.rs
+++ b/crates/krusty-core/src/acp/processor/loop_impl.rs
@@ -2,6 +2,8 @@ use agent_client_protocol::{
     Client as AcpClient, ContentBlock as AcpContent, ContentChunk, SessionNotification,
     SessionUpdate, StopReason, TextContent, ToolCall, ToolCallId,
 };
+use std::path::PathBuf;
+
 use anyhow::Result;
 
 use crate::ai::client::CallOptions;
@@ -199,8 +201,12 @@ impl PromptProcessor {
             AcpError::NotAuthenticated("AI client not initialized - authenticate first".into())
         })?;
 
+        let workspace_root = canonical_acp_workspace_root(session)?;
+
         let mut ctx = ToolContext {
-            working_dir: session.cwd.clone(),
+            working_dir: workspace_root.clone(),
+            project_dir: Some(workspace_root.clone()),
+            sandbox_root: Some(workspace_root),
             ..Default::default()
         }
         .with_permission_mode(PermissionMode::Autonomous)
@@ -282,6 +288,16 @@ impl PromptProcessor {
 
         Ok(StopReason::EndTurn)
     }
+}
+
+pub(super) fn canonical_acp_workspace_root(session: &SessionState) -> Result<PathBuf, AcpError> {
+    session.cwd.canonicalize().map_err(|error| {
+        AcpError::InvalidRequest(format!(
+            "session working directory '{}' is not accessible: {}",
+            session.cwd.display(),
+            error
+        ))
+    })
 }
 
 /// Convert AI finish reason to ACP stop reason.

--- a/crates/krusty-core/src/acp/processor/tests.rs
+++ b/crates/krusty-core/src/acp/processor/tests.rs
@@ -34,3 +34,20 @@ fn test_init_ai_client_requires_selected_model() {
     assert!(!initialized);
     assert!(processor.ai_client.is_none());
 }
+
+#[test]
+fn acp_workspace_root_is_canonicalized_for_sandboxing() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let nested = dir.path().join("nested");
+    std::fs::create_dir(&nested)?;
+    let session = crate::acp::session::SessionState::new(
+        agent_client_protocol::SessionId::from("sandbox-test"),
+        Some(nested.join("..")),
+        None,
+    );
+
+    let root = super::loop_impl::canonical_acp_workspace_root(&session)?;
+
+    assert_eq!(root, dir.path().canonicalize()?);
+    Ok(())
+}

--- a/crates/krusty-core/src/tools/implementations/registration.rs
+++ b/crates/krusty-core/src/tools/implementations/registration.rs
@@ -37,24 +37,21 @@ pub async fn register_all_tools(registry: &ToolRegistry) {
     registry.register(Arc::new(SleepTool)).await;
 }
 
-/// Register tools for ACP (excludes TUI-only tools)
+/// Register tools for ACP.
 ///
-/// Excludes:
-/// - AskUserQuestionTool (requires TUI interaction)
-/// - TaskCompleteTool (requires TUI plan mode)
-/// - EnterPlanModeTool (requires TUI plan mode)
-/// - SkillTool (requires skills manager setup)
+/// ACP currently has no editor-backed user approval flow, so do not expose tools
+/// that can execute arbitrary commands or manage long-lived host processes. File
+/// tools remain available and are constrained to the session workspace by the ACP
+/// processor's sandboxed [`ToolContext`].
 pub async fn register_acp_tools(registry: &ToolRegistry) {
     registry.register(Arc::new(ReadTool)).await;
     registry.register(Arc::new(WriteTool)).await;
     registry.register(Arc::new(EditTool)).await;
     registry.register(Arc::new(MultiEditTool)).await;
-    registry.register(Arc::new(BashTool)).await;
     registry.register(Arc::new(GrepTool)).await;
     registry.register(Arc::new(GlobTool)).await;
     registry.register(Arc::new(ListTool)).await;
     registry.register(Arc::new(ApplyPatchTool)).await;
-    registry.register(Arc::new(ProcessesTool)).await;
 }
 
 /// Register the unified agent tool (explore, plan, verify, build)
@@ -79,4 +76,25 @@ pub async fn register_agent_tool(
 pub async fn register_mako_tools(registry: &ToolRegistry) {
     registry.register(Arc::new(AutonomousTaskTool)).await;
     registry.register(Arc::new(ReportTool)).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::registry::ToolRegistry;
+
+    #[tokio::test]
+    async fn acp_tools_exclude_unsandboxable_host_execution_tools() {
+        let registry = ToolRegistry::new();
+
+        register_acp_tools(&registry).await;
+
+        assert!(registry.get("read").await.is_some());
+        assert!(registry.get("write").await.is_some());
+        assert!(registry.get("edit").await.is_some());
+        assert!(registry.get("grep").await.is_some());
+        assert!(registry.get("glob").await.is_some());
+        assert!(registry.get("bash").await.is_none());
+        assert!(registry.get("processes").await.is_none());
+    }
 }


### PR DESCRIPTION
### Motivation

- Prevent ACP-mode from exposing and auto-executing high-impact host tools (e.g., `bash`, `processes`) without editor-backed approval or a sandbox, which allowed model-driven command execution and file access outside the intended workspace.
- Ensure model-invoked file operations are constrained to the session workspace so ACP sessions cannot be used for prompt-injection-driven host compromises.

### Description

- Stop registering unsandboxable host execution tools for ACP by removing `BashTool` and `ProcessesTool` from `register_acp_tools()` in `crates/krusty-core/src/tools/implementations/registration.rs` so ACP only advertises workspace-sandboxable tools.
- Build ACP `ToolContext` from a canonical session workspace and set `sandbox_root` (and `project_dir`) before executing model-returned tool calls in `PromptProcessor::execute_tool_calls` so file and glob/grep/read/write tools are scoped to the session workspace (changes in `crates/krusty-core/src/acp/processor/loop_impl.rs`).
- Add `canonical_acp_workspace_root()` helper to validate/canonicalize the session `cwd` and return a protocol error if the working directory is not accessible (in `loop_impl.rs`).
- Add regression tests to assert ACP tool exposure excludes unsandboxable host tools and to validate workspace canonicalization for sandboxing (`crates/krusty-core/src/tools/implementations/registration.rs` tests and `crates/krusty-core/src/acp/processor/tests.rs`).
- Update comments to document the conservative ACP tool surface while editor approval is not implemented.

### Testing

- Ran `cargo test -p krusty-core` which executed unit tests for the core crate (including the new ACP tests) and completed successfully (`624 passed; 0 failed` for the run in this environment).
- Ran targeted test subset (`cargo test -p krusty-core acp_`) and the new ACP-focused tests passed.
- Ran `cargo check -p krusty-core`, `cargo clippy -p krusty-core -- -D warnings`, and `cargo fmt --all -- --check` which succeeded for the core crate.
- Full workspace-level commands (`cargo check --workspace`, `cargo test --workspace`, `cargo clippy --workspace -- -D warnings`) could not be completed in this environment because the `libudev` system library (`libudev.pc`) required by `libudev-sys` is missing; these workspace-level failures are environmental and unrelated to the code changes themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffdcb53e88832da5a5494225642521)