### PR TITLE
fix: secure pending updater application

### DIFF
--- a/crates/krusty-core/src/updater/checker/apply.rs
+++ b/crates/krusty-core/src/updater/checker/apply.rs
@@ -1,5 +1,8 @@
-use anyhow::Result;
-use tracing::{debug, info};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use tracing::{debug, info, warn};
 
 use super::paths::{pending_update_path, pending_version_path, update_marker_path};
 
@@ -10,53 +13,148 @@ pub fn apply_pending_update() -> Result<Option<String>> {
         return Ok(None);
     }
 
+    validate_pending_update(&pending)?;
     info!("Found pending update at: {}", pending.display());
 
     let current_exe = std::env::current_exe()?;
     info!("Current binary: {}", current_exe.display());
 
-    #[cfg(unix)]
-    {
-        let backup = current_exe.with_extension("old");
-        debug!("Renaming current to: {}", backup.display());
-        std::fs::rename(&current_exe, &backup)?;
-        debug!("Copying new binary to: {}", current_exe.display());
-        std::fs::copy(&pending, &current_exe)?;
-
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&current_exe)?.permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&current_exe, perms)?;
-
-        let _ = std::fs::remove_file(&backup);
-        let _ = std::fs::remove_file(&pending);
-
-        info!("Update applied successfully");
-    }
-
-    #[cfg(windows)]
-    {
-        let backup = current_exe.with_extension("exe.old");
-        std::fs::rename(&current_exe, &backup)?;
-        std::fs::copy(&pending, &current_exe)?;
-        let _ = std::fs::remove_file(&pending);
-        info!("Update applied successfully");
-    }
+    replace_current_exe(&pending, &current_exe)?;
 
     let version =
-        std::fs::read_to_string(pending_version_path()).unwrap_or_else(|_| "latest".to_string());
-    let _ = std::fs::remove_file(pending_version_path());
+        fs::read_to_string(pending_version_path()).unwrap_or_else(|_| "latest".to_string());
+    let _ = fs::remove_file(pending_version_path());
 
-    let _ = std::fs::create_dir_all(crate::paths::config_dir());
-    let _ = std::fs::write(update_marker_path(), &version);
+    let _ = fs::create_dir_all(crate::paths::config_dir());
+    let _ = fs::write(update_marker_path(), &version);
 
     Ok(Some(version))
 }
 
+fn replace_current_exe(pending: &Path, current_exe: &Path) -> Result<()> {
+    let backup = backup_path(current_exe);
+    let staged = current_exe.with_extension("new");
+
+    let _ = fs::remove_file(&staged);
+    debug!("Staging pending update at: {}", staged.display());
+    fs::copy(pending, &staged).context("failed to stage pending update")?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&staged)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&staged, perms)?;
+    }
+
+    debug!("Renaming current to: {}", backup.display());
+    fs::rename(current_exe, &backup).context("failed to back up current executable")?;
+
+    debug!("Installing staged update to: {}", current_exe.display());
+    if let Err(err) = fs::rename(&staged, current_exe) {
+        if let Err(restore_err) = fs::rename(&backup, current_exe) {
+            return Err(err).with_context(|| {
+                format!(
+                    "failed to install staged update and failed to restore backup: {}",
+                    restore_err
+                )
+            });
+        }
+        return Err(err).context("failed to install staged update");
+    }
+
+    if let Err(err) = fs::remove_file(&backup) {
+        warn!(
+            "Failed to remove update backup {}: {}",
+            backup.display(),
+            err
+        );
+    }
+    if let Err(err) = fs::remove_file(pending) {
+        warn!(
+            "Failed to remove pending update {}: {}",
+            pending.display(),
+            err
+        );
+    }
+
+    info!("Update applied successfully");
+    Ok(())
+}
+
+#[cfg(windows)]
+fn backup_path(current_exe: &Path) -> PathBuf {
+    current_exe.with_extension("exe.old")
+}
+
+#[cfg(not(windows))]
+fn backup_path(current_exe: &Path) -> PathBuf {
+    current_exe.with_extension("old")
+}
+
+fn validate_pending_update(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path).context("failed to inspect pending update")?;
+
+    if !metadata.file_type().is_file() {
+        return Err(anyhow!("pending update is not a regular file"));
+    }
+
+    #[cfg(unix)]
+    validate_pending_update_unix(path, &metadata)?;
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_pending_update_unix(path: &Path, metadata: &fs::Metadata) -> Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let current_uid = unsafe { libc::geteuid() };
+    if metadata.uid() != current_uid {
+        return Err(anyhow!(
+            "pending update is owned by uid {}, expected {}",
+            metadata.uid(),
+            current_uid
+        ));
+    }
+
+    let mode = metadata.permissions().mode();
+    if mode & 0o022 != 0 {
+        return Err(anyhow!(
+            "pending update permissions are too broad: {:o}",
+            mode & 0o777
+        ));
+    }
+
+    if let Some(parent) = path.parent() {
+        let parent_metadata = fs::symlink_metadata(parent)
+            .with_context(|| format!("failed to inspect update directory {}", parent.display()))?;
+        if !parent_metadata.file_type().is_dir() {
+            return Err(anyhow!("pending update directory is not a directory"));
+        }
+        if parent_metadata.uid() != current_uid {
+            return Err(anyhow!(
+                "pending update directory is owned by uid {}, expected {}",
+                parent_metadata.uid(),
+                current_uid
+            ));
+        }
+        let parent_mode = parent_metadata.permissions().mode();
+        if parent_mode & 0o022 != 0 {
+            return Err(anyhow!(
+                "pending update directory permissions are too broad: {:o}",
+                parent_mode & 0o777
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 pub fn read_update_marker() -> Option<String> {
     let path = update_marker_path();
-    let version = std::fs::read_to_string(&path).ok()?;
-    let _ = std::fs::remove_file(&path);
+    let version = fs::read_to_string(&path).ok()?;
+    let _ = fs::remove_file(&path);
     let trimmed = version.trim().to_string();
     (!trimmed.is_empty() && trimmed != "latest").then_some(trimmed)
 }
@@ -64,8 +162,52 @@ pub fn read_update_marker() -> Option<String> {
 pub fn cleanup_pending_update() {
     let pending = pending_update_path();
     if pending.exists() {
-        let _ = std::fs::remove_file(&pending);
-        let _ = std::fs::remove_file(pending_version_path());
+        let _ = fs::remove_file(&pending);
+        let _ = fs::remove_file(pending_version_path());
         info!("Cleaned up pending update");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_non_regular_pending_update() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pending_dir = dir.path().join("pending-dir");
+        fs::create_dir(&pending_dir).expect("create dir");
+
+        let err = validate_pending_update(&pending_dir).expect_err("directory should be rejected");
+        assert!(err.to_string().contains("not a regular file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_group_or_world_writable_pending_update() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).expect("chmod dir");
+        let pending = dir.path().join("pending");
+        fs::write(&pending, b"binary").expect("write pending");
+        fs::set_permissions(&pending, fs::Permissions::from_mode(0o666)).expect("chmod pending");
+
+        let err = validate_pending_update(&pending).expect_err("writable file should be rejected");
+        assert!(err.to_string().contains("permissions are too broad"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn accepts_owner_only_regular_pending_update() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).expect("chmod dir");
+        let pending = dir.path().join("pending");
+        fs::write(&pending, b"binary").expect("write pending");
+        fs::set_permissions(&pending, fs::Permissions::from_mode(0o600)).expect("chmod pending");
+
+        validate_pending_update(&pending).expect("owner-only file should be accepted");
     }
 }

--- a/crates/krusty-core/src/updater/checker/download/dev.rs
+++ b/crates/krusty-core/src/updater/checker/download/dev.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, Result};
 use tokio::sync::mpsc;
 
-use crate::updater::checker::paths::{pending_update_path, pending_version_path};
+use crate::updater::checker::paths::{
+    ensure_pending_update_dir, pending_update_path, pending_version_path,
+};
 use crate::updater::checker::types::UpdateStatus;
 
 pub(super) async fn download_update_dev(
@@ -43,6 +45,7 @@ pub(super) async fn download_update_dev(
         progress: "Preparing update...".into(),
     });
 
+    ensure_pending_update_dir()?;
     let source = repo_path.join("target/release/krusty");
     let dest = pending_update_path();
 
@@ -52,7 +55,7 @@ pub(super) async fn download_update_dev(
     {
         use std::os::unix::fs::PermissionsExt;
         let mut perms = std::fs::metadata(&dest)?.permissions();
-        perms.set_mode(0o755);
+        perms.set_mode(0o700);
         std::fs::set_permissions(&dest, perms)?;
     }
 

--- a/crates/krusty-core/src/updater/checker/download/release.rs
+++ b/crates/krusty-core/src/updater/checker/download/release.rs
@@ -3,7 +3,9 @@ use tokio::sync::mpsc;
 use tracing::{debug, info};
 
 use crate::updater::checker::extract::{extract_tar_gz, extract_zip};
-use crate::updater::checker::paths::{detect_platform, pending_update_path, pending_version_path};
+use crate::updater::checker::paths::{
+    detect_platform, ensure_pending_update_dir, pending_update_path, pending_version_path,
+};
 use crate::updater::checker::types::UpdateStatus;
 use crate::updater::checker::GITHUB_REPO;
 
@@ -42,8 +44,8 @@ pub(super) async fn download_update_release(
         progress: "Extracting...".into(),
     });
 
-    let temp_dir = std::env::temp_dir();
-    let archive_path = temp_dir.join(format!("krusty-download.{}", ext));
+    let update_dir = ensure_pending_update_dir()?;
+    let archive_path = update_dir.join(format!("krusty-download.{}", ext));
     std::fs::write(&archive_path, &bytes)?;
     debug!("Saved archive to: {}", archive_path.display());
 
@@ -57,6 +59,14 @@ pub(super) async fn download_update_release(
 
     if !binary_path.exists() {
         return Err(anyhow!("Extraction failed - binary not found"));
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&binary_path)?.permissions();
+        perms.set_mode(0o700);
+        std::fs::set_permissions(&binary_path, perms)?;
     }
 
     let metadata = std::fs::metadata(&binary_path)?;

--- a/crates/krusty-core/src/updater/checker/extract.rs
+++ b/crates/krusty-core/src/updater/checker/extract.rs
@@ -7,9 +7,17 @@ use tracing::debug;
 pub(super) fn extract_tar_gz(archive: &Path, dest: &Path) -> Result<()> {
     debug!("Extracting {} to {}", archive.display(), dest.display());
 
-    let extract_dir = std::env::temp_dir().join("krusty-extract");
+    let extract_dir = archive
+        .parent()
+        .ok_or_else(|| anyhow!("Archive path has no parent: {}", archive.display()))?
+        .join("krusty-extract");
     let _ = std::fs::remove_dir_all(&extract_dir);
     std::fs::create_dir_all(&extract_dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&extract_dir, std::fs::Permissions::from_mode(0o700))?;
+    }
     let archive_str = archive
         .to_str()
         .ok_or_else(|| anyhow!("Archive path is not valid UTF-8: {}", archive.display()))?;
@@ -42,6 +50,7 @@ pub(super) fn extract_tar_gz(archive: &Path, dest: &Path) -> Result<()> {
         return Err(anyhow!("Binary 'krusty' not found in archive"));
     }
 
+    let _ = std::fs::remove_file(dest);
     std::fs::copy(&extracted_binary, dest)?;
 
     #[cfg(unix)]
@@ -60,7 +69,10 @@ pub(super) fn extract_tar_gz(archive: &Path, dest: &Path) -> Result<()> {
 
 #[cfg(windows)]
 pub(super) fn extract_zip(archive: &Path, dest: &Path) -> Result<()> {
-    let extract_dir = std::env::temp_dir().join("krusty-extract");
+    let extract_dir = archive
+        .parent()
+        .ok_or_else(|| anyhow!("Archive path has no parent: {}", archive.display()))?
+        .join("krusty-extract");
     let _ = std::fs::remove_dir_all(&extract_dir);
     std::fs::create_dir_all(&extract_dir)?;
 
@@ -81,6 +93,7 @@ pub(super) fn extract_zip(archive: &Path, dest: &Path) -> Result<()> {
     }
 
     let extracted = extract_dir.join("krusty.exe");
+    let _ = std::fs::remove_file(dest);
     std::fs::copy(&extracted, dest)?;
     let _ = std::fs::remove_dir_all(&extract_dir);
 

--- a/crates/krusty-core/src/updater/checker/paths.rs
+++ b/crates/krusty-core/src/updater/checker/paths.rs
@@ -1,13 +1,32 @@
 use std::path::PathBuf;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+
+pub(super) fn pending_update_dir() -> PathBuf {
+    crate::paths::config_dir().join("updates")
+}
+
+pub(super) fn ensure_pending_update_dir() -> Result<PathBuf> {
+    let dir = pending_update_dir();
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("failed to create update directory {}", dir.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("failed to secure update directory {}", dir.display()))?;
+    }
+
+    Ok(dir)
+}
 
 pub fn pending_update_path() -> PathBuf {
-    std::env::temp_dir().join("krusty-pending-update")
+    pending_update_dir().join("krusty-pending-update")
 }
 
 pub(super) fn pending_version_path() -> PathBuf {
-    std::env::temp_dir().join("krusty-pending-update.version")
+    pending_update_dir().join("krusty-pending-update.version")
 }
 
 pub(super) fn update_marker_path() -> PathBuf {


### PR DESCRIPTION
### Motivation
- Prevent a local privilege persistence/execution vulnerability where a predictable `/tmp/krusty-pending-update` could be planted and automatically applied at startup. 
- Ensure updater artifacts are stored in a per-user location with conservative permissions so only the owning user can prepare updates. 
- Avoid destructive replacement sequences by staging installs and restoring the original binary on failure. 

### Description
- Move pending update artifacts out of the system temp dir and into a per-user update folder under the Krusty config directory via `pending_update_dir()` / `ensure_pending_update_dir()` and tighten directory permissions on Unix (owner-only). (`crates/krusty-core/src/updater/checker/paths.rs`)
- Validate pending updates before applying by checking the file is a regular file, is owned by the current user, and that file and parent directory are not group/world-writable; reject otherwise. (`crates/krusty-core/src/updater/checker/apply.rs`)
- Stage the new binary to a `.new` path, rename the current binary to a backup, atomically install the staged file, and restore the backup if installation fails; log warnings on cleanup failures rather than silently ignoring them. (`crates/krusty-core/src/updater/checker/apply.rs`)
- Make download and extraction flows write into the secured update directory and set tighter permissions on downloaded/extracted binaries and intermediate artifacts. (`crates/krusty-core/src/updater/checker/download/release.rs`, `crates/krusty-core/src/updater/checker/download/dev.rs`, `crates/krusty-core/src/updater/checker/extract.rs`)
- Add unit tests covering validation behavior for non-regular files and Unix permission checks. (`crates/krusty-core/src/updater/checker/apply.rs` tests)

### Testing
- Ran `cargo test -p krusty-core updater::checker::apply::tests -- --nocapture` and all updater validation tests passed. 
- Ran `cargo check -p krusty-core`, `cargo clippy -p krusty-core -- -D warnings`, and `cargo fmt --all -- --check` and they succeeded for the crate. 
- Ran `cd apps/mobile && npx expo export --platform web` and the web export completed successfully. 
- Workspace-level checks (`cargo check --workspace`, `cargo test --workspace`, `cargo clippy --workspace -- -D warnings`) could not complete in this environment due to a missing system dependency required by `libudev-sys` (`libudev.pc`), not because of the changes here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffeb983b4c832db0fafdd4b7edced5)