### PR TITLE
fix: secure pending update storage

### DIFF
--- a/crates/krusty-core/src/updater/checker/apply.rs
+++ b/crates/krusty-core/src/updater/checker/apply.rs
@@ -1,7 +1,10 @@
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
+use std::path::Path;
 use tracing::{debug, info};
 
-use super::paths::{pending_update_path, pending_version_path, update_marker_path};
+use super::paths::{
+    pending_update_dir, pending_update_path, pending_version_path, update_marker_path,
+};
 
 pub fn apply_pending_update() -> Result<Option<String>> {
     let pending = pending_update_path();
@@ -9,6 +12,8 @@ pub fn apply_pending_update() -> Result<Option<String>> {
     if !pending.exists() {
         return Ok(None);
     }
+
+    validate_pending_update(&pending)?;
 
     info!("Found pending update at: {}", pending.display());
 
@@ -53,6 +58,72 @@ pub fn apply_pending_update() -> Result<Option<String>> {
     Ok(Some(version))
 }
 
+fn validate_pending_update(pending: &Path) -> Result<()> {
+    if pending != pending_update_path() {
+        return Err(anyhow!(
+            "pending update path is not the trusted updater path"
+        ));
+    }
+
+    #[cfg(unix)]
+    validate_pending_update_unix(pending)?;
+
+    #[cfg(windows)]
+    {
+        let metadata = std::fs::symlink_metadata(pending)?;
+        if !metadata.file_type().is_file() {
+            return Err(anyhow!("pending update is not a regular file"));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_pending_update_unix(pending: &Path) -> Result<()> {
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+    let update_dir = pending_update_dir();
+    let uid = unsafe { libc::geteuid() };
+
+    let dir_metadata = std::fs::symlink_metadata(&update_dir).with_context(|| {
+        format!(
+            "failed to inspect update directory {}",
+            update_dir.display()
+        )
+    })?;
+    if !dir_metadata.file_type().is_dir() {
+        return Err(anyhow!("pending update directory is not a directory"));
+    }
+    if dir_metadata.uid() != uid {
+        return Err(anyhow!(
+            "pending update directory is not owned by the current user"
+        ));
+    }
+    if dir_metadata.mode() & 0o022 != 0 {
+        return Err(anyhow!(
+            "pending update directory is writable by group or other users"
+        ));
+    }
+
+    let metadata = std::fs::symlink_metadata(pending)
+        .with_context(|| format!("failed to inspect pending update {}", pending.display()))?;
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() || !file_type.is_file() || file_type.is_socket() {
+        return Err(anyhow!("pending update is not a regular file"));
+    }
+    if metadata.uid() != uid {
+        return Err(anyhow!("pending update is not owned by the current user"));
+    }
+    if metadata.mode() & 0o022 != 0 {
+        return Err(anyhow!(
+            "pending update is writable by group or other users"
+        ));
+    }
+
+    Ok(())
+}
+
 pub fn read_update_marker() -> Option<String> {
     let path = update_marker_path();
     let version = std::fs::read_to_string(&path).ok()?;
@@ -67,5 +138,21 @@ pub fn cleanup_pending_update() {
         let _ = std::fs::remove_file(&pending);
         let _ = std::fs::remove_file(pending_version_path());
         info!("Cleaned up pending update");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_updates_use_private_config_directory() {
+        let pending = pending_update_path();
+        assert!(pending.starts_with(crate::paths::config_dir()));
+        assert!(!pending.starts_with(std::env::temp_dir()));
+        assert_eq!(
+            pending.file_name().and_then(|name| name.to_str()),
+            Some("pending-update")
+        );
     }
 }

--- a/crates/krusty-core/src/updater/checker/download/dev.rs
+++ b/crates/krusty-core/src/updater/checker/download/dev.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, Result};
 use tokio::sync::mpsc;
 
-use crate::updater::checker::paths::{pending_update_path, pending_version_path};
+use crate::updater::checker::paths::{
+    ensure_pending_update_dir, pending_update_path, pending_version_path,
+};
 use crate::updater::checker::types::UpdateStatus;
 
 pub(super) async fn download_update_dev(
@@ -42,6 +44,8 @@ pub(super) async fn download_update_dev(
     let _ = progress_tx.send(UpdateStatus::Downloading {
         progress: "Preparing update...".into(),
     });
+
+    ensure_pending_update_dir()?;
 
     let source = repo_path.join("target/release/krusty");
     let dest = pending_update_path();

--- a/crates/krusty-core/src/updater/checker/download/release.rs
+++ b/crates/krusty-core/src/updater/checker/download/release.rs
@@ -3,7 +3,10 @@ use tokio::sync::mpsc;
 use tracing::{debug, info};
 
 use crate::updater::checker::extract::{extract_tar_gz, extract_zip};
-use crate::updater::checker::paths::{detect_platform, pending_update_path, pending_version_path};
+use crate::updater::checker::paths::{
+    detect_platform, ensure_pending_update_dir, pending_archive_path, pending_update_path,
+    pending_version_path,
+};
 use crate::updater::checker::types::UpdateStatus;
 use crate::updater::checker::GITHUB_REPO;
 
@@ -42,8 +45,8 @@ pub(super) async fn download_update_release(
         progress: "Extracting...".into(),
     });
 
-    let temp_dir = std::env::temp_dir();
-    let archive_path = temp_dir.join(format!("krusty-download.{}", ext));
+    ensure_pending_update_dir()?;
+    let archive_path = pending_archive_path(ext);
     std::fs::write(&archive_path, &bytes)?;
     debug!("Saved archive to: {}", archive_path.display());
 

--- a/crates/krusty-core/src/updater/checker/paths.rs
+++ b/crates/krusty-core/src/updater/checker/paths.rs
@@ -2,16 +2,40 @@ use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
 
+pub(super) fn pending_update_dir() -> PathBuf {
+    crate::paths::config_dir().join("updates")
+}
+
 pub fn pending_update_path() -> PathBuf {
-    std::env::temp_dir().join("krusty-pending-update")
+    pending_update_dir().join("pending-update")
+}
+
+pub(super) fn pending_archive_path(ext: &str) -> PathBuf {
+    pending_update_dir().join(format!("download.{}", ext))
 }
 
 pub(super) fn pending_version_path() -> PathBuf {
-    std::env::temp_dir().join("krusty-pending-update.version")
+    pending_update_dir().join("pending-update.version")
 }
 
 pub(super) fn update_marker_path() -> PathBuf {
     crate::paths::config_dir().join("last-update-version")
+}
+
+pub(super) fn ensure_pending_update_dir() -> Result<PathBuf> {
+    let dir = pending_update_dir();
+    std::fs::create_dir_all(&dir)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut perms = std::fs::metadata(&dir)?.permissions();
+        perms.set_mode(0o700);
+        std::fs::set_permissions(&dir, perms)?;
+    }
+
+    Ok(dir)
 }
 
 pub fn has_pending_update() -> bool {


### PR DESCRIPTION
### Motivation
- Prevent a local privilege escalation via a predictable temp-file updater path that allowed attacker-controlled binaries in `std::env::temp_dir()` to be applied silently on startup.
- Ensure update artifacts are stored and validated in a user-owned, private location before replacing the running executable.

### Description
- Move pending update artifacts out of the shared system temp directory into a per-user config updates dir under `crate::paths::config_dir()/updates` and provide `ensure_pending_update_dir()` which sets `0700` on Unix. (`crates/krusty-core/src/updater/checker/paths.rs`)
- Validate pending update files before applying by checking the path matches the trusted pending path and, on Unix, verifying the update directory and file are owned by the current user, are regular files (not symlinks), and are not group/other writable. (`crates/krusty-core/src/updater/checker/apply.rs`)
- Update release and dev download flows to create/use the protected update directory and write archives/binaries into the new locations before marking updates ready. (`crates/krusty-core/src/updater/checker/download/release.rs`, `crates/krusty-core/src/updater/checker/download/dev.rs`)
- Add a regression unit test asserting pending update storage no longer resolves under `std::env::temp_dir()`. (`crates/krusty-core/src/updater/checker/apply.rs` tests)

### Testing
- Ran unit tests for the updater checker with `cargo test -p krusty-core updater::checker:: --lib` and they passed. 
- Performed `cargo check -p krusty-core`, `cargo clippy -p krusty-core -- -D warnings`, and `cargo fmt --all -- --check`, all of which succeeded for the modified crate.
- Full workspace `cargo check --workspace` could not be completed in this environment due to missing system `libudev` pkg-config metadata required by a native dependency, but the updater-related crate-level checks and tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffe1de0e84832dba08bde85b2125d6)