### PR TITLE
Harden release workflow and require installer checksum verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -28,16 +28,14 @@ jobs:
             os: windows-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+      - name: Install Bun
+        run: npm install -g bun
 
       - name: Install mobile web dependencies
         working-directory: apps/mobile
@@ -47,10 +45,8 @@ jobs:
         working-directory: apps/mobile
         run: npx expo export --platform web
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
@@ -60,15 +56,20 @@ jobs:
         run: |
           cd target/${{ matrix.target }}/release
           tar czf ../../../krusty-${{ matrix.target }}.tar.gz krusty
+          cd ../../..
+          sha256sum krusty-${{ matrix.target }}.tar.gz > krusty-${{ matrix.target }}.tar.gz.sha256
 
       - name: Package (Windows)
         if: matrix.os == 'windows-latest'
+        shell: bash
         run: |
           cd target/${{ matrix.target }}/release
           7z a ../../../krusty-${{ matrix.target }}.zip krusty.exe
+          cd ../../..
+          sha256sum krusty-${{ matrix.target }}.zip > krusty-${{ matrix.target }}.zip.sha256
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8 # v4.6.2
         with:
           name: krusty-${{ matrix.target }}
           path: krusty-${{ matrix.target }}.*
@@ -77,20 +78,18 @@ jobs:
     name: Build Desktop Linux Bundles
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Install desktop bundling dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y             libudev-dev             libwebkit2gtk-4.1-dev             libgtk-3-dev             libayatana-appindicator3-dev             librsvg2-dev             patchelf
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+      - name: Install Bun
+        run: npm install -g bun
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup show
 
       - name: Install mobile web dependencies
         working-directory: apps/mobile
@@ -103,7 +102,7 @@ jobs:
           bun run build
 
       - name: Upload desktop Linux artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8 # v4.6.2
         with:
           name: krusty-desktop-linux
           path: |
@@ -114,18 +113,26 @@ jobs:
     name: Create Release
     needs: [build, desktop-linux]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v5
+      - name: Require protected release tag
+        if: github.ref_protected != true
+        run: |
+          echo "Release tags must be protected before publishing artifacts." >&2
+          exit 1
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh run download "$GITHUB_RUN_ID" --dir artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
-        with:
-          files: artifacts/**/*
-          generate_release_notes: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG_NAME" artifacts/**/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG_NAME" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ wit/              WebAssembly Interface Types for the extension system
 ### Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/honeycomb-Technologies/Krusty/main/install.sh | sh
+curl -fsSLO https://raw.githubusercontent.com/honeycomb-Technologies/Krusty/main/install.sh
+sh install.sh
 ```
+
+The installer requires the release archive checksum published alongside each GitHub release asset before it installs the binary.
 
 Or from source:
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Krusty installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/honeycomb-Technologies/Krusty/main/install.sh | sh
+# Usage: curl -fsSLO https://raw.githubusercontent.com/honeycomb-Technologies/Krusty/main/install.sh && sh install.sh
 
 REPO="honeycomb-Technologies/Krusty"
 BINARY="krusty"
@@ -59,47 +59,50 @@ install() {
 
     echo "Installing Krusty $VERSION for $PLATFORM..."
 
-    DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/krusty-$PLATFORM.$EXT"
+    ARCHIVE="krusty-$PLATFORM.$EXT"
+    DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/$ARCHIVE"
     CHECKSUM_URL="$DOWNLOAD_URL.sha256"
     TMP_DIR="$(mktemp -d)"
 
     echo "Downloading from $DOWNLOAD_URL..."
-    curl -fsSL "$DOWNLOAD_URL" -o "$TMP_DIR/krusty.$EXT"
+    curl -fsSL "$DOWNLOAD_URL" -o "$TMP_DIR/$ARCHIVE"
 
-    # Download and verify checksum if available
-    if curl -fsSL "$CHECKSUM_URL" -o "$TMP_DIR/krusty.$EXT.sha256" 2>/dev/null; then
-        echo "Verifying checksum..."
-        cd "$TMP_DIR"
-        if command -v sha256sum >/dev/null 2>&1; then
-            if ! sha256sum -c "krusty.$EXT.sha256" >/dev/null 2>&1; then
-                echo "Error: Checksum verification failed!"
-                echo "The downloaded file may be corrupted. Please try again."
-                rm -rf "$TMP_DIR"
-                exit 1
-            fi
-            echo "Checksum verified."
-        elif command -v shasum >/dev/null 2>&1; then
-            # macOS uses shasum
-            if ! shasum -a 256 -c "krusty.$EXT.sha256" >/dev/null 2>&1; then
-                echo "Error: Checksum verification failed!"
-                echo "The downloaded file may be corrupted. Please try again."
-                rm -rf "$TMP_DIR"
-                exit 1
-            fi
-            echo "Checksum verified."
-        else
-            echo "Warning: No sha256sum or shasum found, skipping verification."
-        fi
-    else
-        echo "Note: No checksum file available for verification."
+    echo "Downloading checksum from $CHECKSUM_URL..."
+    if ! curl -fsSL "$CHECKSUM_URL" -o "$TMP_DIR/$ARCHIVE.sha256"; then
+        echo "Error: Checksum file is required but could not be downloaded."
+        rm -rf "$TMP_DIR"
+        exit 1
     fi
 
-    echo "Extracting..."
+    echo "Verifying checksum..."
     cd "$TMP_DIR"
-    if [ "$EXT" = "tar.gz" ]; then
-        tar xzf "krusty.$EXT"
+    if command -v sha256sum >/dev/null 2>&1; then
+        if ! sha256sum -c "$ARCHIVE.sha256" >/dev/null 2>&1; then
+            echo "Error: Checksum verification failed!"
+            echo "The downloaded file may be corrupted. Please try again."
+            rm -rf "$TMP_DIR"
+            exit 1
+        fi
+    elif command -v shasum >/dev/null 2>&1; then
+        # macOS uses shasum
+        if ! shasum -a 256 -c "$ARCHIVE.sha256" >/dev/null 2>&1; then
+            echo "Error: Checksum verification failed!"
+            echo "The downloaded file may be corrupted. Please try again."
+            rm -rf "$TMP_DIR"
+            exit 1
+        fi
     else
-        unzip -q "krusty.$EXT"
+        echo "Error: sha256sum or shasum is required to verify downloads."
+        rm -rf "$TMP_DIR"
+        exit 1
+    fi
+    echo "Checksum verified."
+
+    echo "Extracting..."
+    if [ "$EXT" = "tar.gz" ]; then
+        tar xzf "$ARCHIVE"
+    else
+        unzip -q "$ARCHIVE"
     fi
 
     echo "Installing to $INSTALL_DIR..."


### PR DESCRIPTION
### Motivation
- Reduce supply-chain risk by narrowing workflow token scope and eliminating mutable third-party action refs during build/publish. 
- Prevent downstream arbitrary code execution by requiring signed-like integrity checks for published CLI artifacts. 
- Avoid encouraging insecure install patterns by removing the direct `curl | sh` quick-install recommendation.

### Description
- Reduced default workflow `permissions` from `contents: write` to `contents: read` and granted `contents: write` only to the publishing job that requires a protected tag via `if: github.ref_protected != true`.
- Replaced mutable or broad-action usage with pinned references and simpler commands by pinning `actions/checkout` to a commit SHA, pinning `actions/upload-artifact` to a commit, replacing `oven-sh/setup-bun@v2` and `dtolnay/rust-toolchain@stable` with explicit `npm install -g bun` and `rustup` commands, and replacing `softprops/action-gh-release` with `gh release create` (using `GITHUB_TOKEN`/`GH_TOKEN`).
- Generate SHA-256 sidecar files for each platform artifact in the build jobs (`sha256sum ... > ...sha256`) and upload them alongside artifacts so consumers can verify integrity.
- Update `install.sh` to download the platform-named archive and require the corresponding `.sha256` checksum file, fail if the checksum is missing or verification tools are unavailable, and verify the checksum before extracting and installing the binary.
- Update `README.md` to stop recommending piping the installer to a shell and instead download then run the installer (example: `curl -fsSLO ... && sh install.sh`) and document the checksum requirement.

### Testing
- `sh -n install.sh` succeeded (shell syntax check passed).
- Workflow YAML parse via `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"` succeeded.
- `cargo fmt --all -- --check` succeeded.
- Mocked installer success path (local `curl` shim that returned archive + matching `.sha256`) succeeded and installed the test binary; mocked missing-checksum path caused the installer to fail as expected.
- `cargo check --workspace` and `cargo test --workspace` were attempted but blocked/failed due to missing system `libudev.pc` (the environment could not install `libudev-dev` because apt repos returned `403 Forbidden`), so full Rust integration tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffe250da2c832dbc82906bc19ebd27)