### PR TITLE
Fix stream, auth, catalog, and chat render review findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "krusty"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4824,7 +4824,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client-state"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "krusty-client",
  "serde",
@@ -4848,7 +4848,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -4911,7 +4911,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-desktop"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -4925,7 +4925,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-mobile"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-mobile-ui"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "gpui",
  "krusty-client-state",
@@ -4948,7 +4948,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/desktop/shell/package.json
+++ b/apps/desktop/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krusty/desktop-shell",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "packageManager": "bun@1.3.0",
   "type": "module",

--- a/apps/desktop/shell/src-tauri/Cargo.toml
+++ b/apps/desktop/shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-desktop"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [build-dependencies]

--- a/apps/desktop/shell/src-tauri/tauri.conf.json
+++ b/apps/desktop/shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Krusty Desktop",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "identifier": "io.krusty.desktop",
   "build": {
     "beforeDevCommand": "cd ../../mobile && npx expo start --web --port 5173",

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -35,14 +35,7 @@ import { useEntranceAnimation } from "../../hooks/useEntranceAnimation";
 import { useLiveActivity } from "../../hooks/useLiveActivity";
 import { useWidgetSync } from "../../hooks/useWidgetSync";
 import { useNotifications } from "../../hooks/useNotifications";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  interpolate,
-  withSpring,
-  withTiming,
-  runOnJS,
-} from "react-native-reanimated";
+import Animated from "react-native-reanimated";
 
 import type {
   ModelInfo,
@@ -60,7 +53,6 @@ import { ChatBootScreen } from "./chat-screen/BootScreen";
 import {
   CHAT_BAR_ZONE,
   SELECTED_MODEL_KEY,
-  SPLIT_PANEL_HEIGHT,
   flattenToolCalls,
   getActiveToolCall,
   getLastAssistantMessage,
@@ -146,8 +138,6 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
   const [makoTopLevel, setMakoTopLevel] = useState<MakoTopLevelView>("mako");
   const [toolboxOpen, setToolboxOpen] = useState(false);
   const [toolboxTab, setToolboxTab] = useState(2);
-  const splitProgress = useSharedValue(0);
-  const [isSplit, setIsSplit] = useState(false);
   const [researchEnabled, setResearchEnabled] = useState(false);
   const [bottomControlsOpen, setBottomControlsOpen] = useState(false);
   const [composerReserveHeight, setComposerReserveHeight] =
@@ -613,34 +603,9 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
     );
   }, [sessionId, sessionStore, sessionTitle]);
 
-  const handleToolboxPin = useCallback(() => {
-    setIsSplit(true);
-    splitProgress.value = withSpring(1, { damping: 22, stiffness: 280, mass: 0.8 });
-  }, [splitProgress]);
-
-  const handleToolboxUnpin = useCallback(() => {
-    splitProgress.value = withTiming(0, { duration: 300 });
-    setIsSplit(false);
-  }, [splitProgress]);
-
-  const closeToolbox = useCallback(() => {
-    setToolboxOpen(false);
-    setIsSplit(false);
-  }, []);
-
   const handleToolboxClose = useCallback(() => {
-    if (splitProgress.value > 0.1) {
-      splitProgress.value = withTiming(0, { duration: 250 }, (finished) => {
-        if (finished) runOnJS(closeToolbox)();
-      });
-    } else {
-      setToolboxOpen(false);
-    }
-  }, [splitProgress, closeToolbox]);
-
-  const chatOffsetStyle = useAnimatedStyle(() => ({
-    marginTop: interpolate(splitProgress.value, [0, 1], [0, SPLIT_PANEL_HEIGHT]),
-  }));
+    setToolboxOpen(false);
+  }, []);
 
   const topBar = (
     <Animated.View style={[styles.topBar, entrance.topBarStyle]}>
@@ -679,7 +644,7 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
         }}
         style={styles.menuBtn}
       >
-        <Toolbox size={20} color={toolboxOpen ? t.userMessage : t.mutedForeground} strokeWidth={1.8} />
+        <Toolbox size={20} color={t.mutedForeground} strokeWidth={1.8} />
       </Pressable>
     </Animated.View>
   );
@@ -689,10 +654,10 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
       style={[styles.container, { backgroundColor: t.background }]}
       edges={isDesktop ? [] : ["top"]}
     >
-      {topBar}
+      {!toolboxOpen ? topBar : null}
 
       <View style={styles.flex}>
-        <Animated.View style={[styles.flex, entrance.contentStyle, chatOffsetStyle]}>
+        <Animated.View style={[styles.flex, entrance.contentStyle]}>
           <ChatTranscript
             messages={messages}
             sessionId={sessionId}
@@ -726,7 +691,7 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
           />
         </Animated.View>
 
-        {(!toolboxOpen || isSplit) && (
+        {!toolboxOpen && (
           <Animated.View style={[entrance.bottomBarStyle, { overflow: "visible", zIndex: 300 }]}>
             <ChatBar
               onSend={handleChatBarSend}
@@ -761,16 +726,14 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
           </Animated.View>
         )}
 
-        <ToolboxPanel
-          visible={toolboxOpen}
-          onClose={handleToolboxClose}
-          onTogglePin={isSplit ? handleToolboxUnpin : handleToolboxPin}
-          isSplit={isSplit}
-          splitProgress={splitProgress}
-          activeTab={toolboxTab}
-          onTabChange={setToolboxTab}
-        />
       </View>
+
+      <ToolboxPanel
+        visible={toolboxOpen}
+        onClose={handleToolboxClose}
+        activeTab={toolboxTab}
+        onTabChange={setToolboxTab}
+      />
     </SafeAreaView>
   );
 

--- a/apps/mobile/components/ToolboxPanel.tsx
+++ b/apps/mobile/components/ToolboxPanel.tsx
@@ -3,39 +3,37 @@ import {
   View,
   Pressable,
   StyleSheet,
-  Dimensions,
   Platform,
+  useWindowDimensions,
 } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { BlurView } from '../platform/blur';
 import Animated, {
-  type SharedValue,
   useSharedValue,
   useAnimatedStyle,
   withSpring,
   withTiming,
   interpolate,
   Easing,
+  runOnJS,
 } from 'react-native-reanimated';
-import { Pin, PinOff, X } from 'lucide-react-native';
+import { FileText, Search, TerminalSquare } from 'lucide-react-native';
 import * as Haptics from '../platform/haptics';
 import { useThemeContext } from '../hooks/useTheme';
-import { SegmentControl } from './ui/SegmentControl';
 import { ToolboxTerminal } from './toolbox/ToolboxTerminal';
 import { ToolboxBrowser } from './toolbox/ToolboxBrowser';
 import { ReportsContent } from './ReportsViewer';
 
-const SCREEN_HEIGHT = Dimensions.get('window').height;
-const PANEL_HEIGHT = SCREEN_HEIGHT * 0.88;
-const SPLIT_HEIGHT = SCREEN_HEIGHT * 0.42;
 const SPRING = { damping: 22, stiffness: 280, mass: 0.8 };
-const SEGMENTS = ['Terminal', 'Browser', 'Papers'];
+const TOOL_TABS = [
+  { label: 'Terminal', icon: TerminalSquare },
+  { label: 'Browser', icon: Search },
+  { label: 'Papers', icon: FileText },
+];
 
 interface ToolboxPanelProps {
   visible: boolean;
   onClose: () => void;
-  onTogglePin: () => void;
-  isSplit: boolean;
-  splitProgress: SharedValue<number>;
   activeTab: number;
   onTabChange: (tab: number) => void;
 }
@@ -43,59 +41,55 @@ interface ToolboxPanelProps {
 export function ToolboxPanel({
   visible,
   onClose,
-  onTogglePin,
-  isSplit,
-  splitProgress,
   activeTab,
   onTabChange,
 }: ToolboxPanelProps) {
   const { theme } = useThemeContext();
   const t = theme.colors;
   const isDark = theme.scheme === 'dark';
+  const { height: windowHeight } = useWindowDimensions();
+  const panelHeight = Math.max(windowHeight, 1);
 
   const progress = useSharedValue(0);
+  const dragY = useSharedValue(0);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     if (visible) {
       setMounted(true);
+      dragY.value = 0;
       progress.value = withSpring(1, SPRING);
     } else {
       progress.value = withTiming(0, { duration: 200, easing: Easing.out(Easing.cubic) });
-      const timer = setTimeout(() => setMounted(false), 220);
+      const timer = setTimeout(() => {
+        dragY.value = 0;
+        setMounted(false);
+      }, 220);
       return () => clearTimeout(timer);
     }
-  }, [visible, progress]);
+  }, [visible, progress, dragY]);
 
   const panelStyle = useAnimatedStyle(() => {
-    const height = interpolate(splitProgress.value, [0, 1], [PANEL_HEIGHT, SPLIT_HEIGHT]);
-    const radius = interpolate(splitProgress.value, [0, 1], [20, 0]);
+    const upwardDrag = Math.max(-panelHeight, Math.min(dragY.value, 0));
+    const translateY = interpolate(progress.value, [0, 1], [-panelHeight, 0]) + upwardDrag;
     return {
-      height,
-      borderBottomLeftRadius: radius,
-      borderBottomRightRadius: radius,
+      height: panelHeight,
+      borderBottomLeftRadius: 20,
+      borderBottomRightRadius: 20,
       transform: [
-        { translateY: interpolate(progress.value, [0, 1], [-PANEL_HEIGHT, 0]) },
+        { translateY },
       ],
       opacity: progress.value,
     };
   });
 
   const backdropStyle = useAnimatedStyle(() => {
-    const backdropOpacity = interpolate(progress.value, [0, 1], [0, 1])
-      * interpolate(splitProgress.value, [0, 0.3], [1, 0]);
+    const backdropOpacity = interpolate(progress.value, [0, 1], [0, 1]);
     return {
       opacity: backdropOpacity,
       pointerEvents: backdropOpacity > 0.05 ? ('auto' as const) : ('none' as const),
     };
   });
-
-  const showPin = activeTab < 2;
-
-  const handlePin = useCallback(() => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-    onTogglePin();
-  }, [onTogglePin]);
 
   const handleClose = useCallback(() => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -106,6 +100,21 @@ export function ToolboxPanel({
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     onTabChange(index);
   }, [onTabChange]);
+
+  const closeHandleGesture = Gesture.Pan()
+    .activeOffsetY([-8, 8])
+    .failOffsetX([-24, 24])
+    .onUpdate((event) => {
+      dragY.value = Math.min(event.translationY, 0);
+    })
+    .onEnd((event) => {
+      if (event.translationY < -44 || event.velocityY < -500) {
+        runOnJS(handleClose)();
+        return;
+      }
+
+      dragY.value = withSpring(0, SPRING);
+    });
 
   if (!mounted) return null;
 
@@ -129,29 +138,39 @@ export function ToolboxPanel({
         />
 
         <View style={[styles.header, { borderBottomColor: t.border }]}>
-          {showPin ? (
-            <Pressable onPress={handlePin} style={styles.headerBtn}>
-              {isSplit ? (
-                <PinOff size={18} color={t.userMessage} strokeWidth={1.8} />
-              ) : (
-                <Pin size={18} color={t.mutedForeground} strokeWidth={1.8} />
-              )}
-            </Pressable>
-          ) : (
-            <View style={styles.headerBtn} />
-          )}
-
-          <View style={styles.segmentWrapper}>
-            <SegmentControl
-              segments={SEGMENTS}
-              selected={activeTab}
-              onSelect={handleTabChange}
-            />
+          <View
+            style={[
+              styles.tabRail,
+              {
+                backgroundColor: t.glass.background,
+                borderColor: t.glass.border,
+              },
+            ]}
+          >
+            {TOOL_TABS.map((tab, index) => {
+              const Icon = tab.icon;
+              const active = index === activeTab;
+              return (
+                <Pressable
+                  key={tab.label}
+                  accessibilityRole="tab"
+                  accessibilityLabel={tab.label}
+                  accessibilityState={{ selected: active }}
+                  onPress={() => handleTabChange(index)}
+                  style={[
+                    styles.tabButton,
+                    active && { backgroundColor: t.glass.backgroundElevated },
+                  ]}
+                >
+                  <Icon
+                    size={18}
+                    color={active ? t.foreground : t.mutedForeground}
+                    strokeWidth={active ? 2.1 : 1.8}
+                  />
+                </Pressable>
+              );
+            })}
           </View>
-
-          <Pressable onPress={handleClose} style={styles.headerBtn}>
-            <X size={20} color={t.mutedForeground} strokeWidth={1.8} />
-          </Pressable>
         </View>
 
         <View style={styles.body}>
@@ -165,6 +184,17 @@ export function ToolboxPanel({
             <ReportsContent visible={activeTab === 2 && visible} />
           </View>
         </View>
+
+        <GestureDetector gesture={closeHandleGesture}>
+          <Animated.View style={styles.handleZone}>
+            <View
+              style={[
+                styles.handle,
+                { backgroundColor: t.mutedForeground },
+              ]}
+            />
+          </Animated.View>
+        </GestureDetector>
       </Animated.View>
     </>
   );
@@ -187,22 +217,44 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: 12,
-    paddingVertical: 10,
+    justifyContent: 'center',
+    paddingHorizontal: 10,
+    paddingVertical: 8,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    gap: 8,
   },
-  headerBtn: {
-    width: 36,
+  tabRail: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 2,
+    gap: 2,
+  },
+  tabButton: {
+    width: 44,
+    minHeight: 34,
+    borderRadius: 10,
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 4,
-  },
-  segmentWrapper: {
-    flex: 1,
   },
   body: {
     flex: 1,
+  },
+  handleZone: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 6,
+  },
+  handle: {
+    width: 44,
+    height: 5,
+    borderRadius: 999,
+    opacity: 0.48,
   },
   tabContent: {
     ...StyleSheet.absoluteFillObject,

--- a/apps/mobile/components/chat/MessageBubble.tsx
+++ b/apps/mobile/components/chat/MessageBubble.tsx
@@ -9,28 +9,16 @@ import { ToolApprovalWidget } from "./ToolApprovalWidget";
 import { AskUserQuestionWidget } from "./AskUserQuestionWidget";
 import { PlanConfirmWidget } from "./PlanConfirmWidget";
 import { ImagePreviewModal, imagePreviewUri } from "./ImagePreviewModal";
+import {
+  assistantVisualSegments,
+  isDelegatedTool,
+  isPlanConfirmTool,
+  isQuestionTool,
+  type AssistantVisualSegment,
+} from "./assistantRenderPlan";
 import type { ChatMessage, ChatMessageAttachment, ToolCall } from "@krusty/api";
 import * as Clipboard from "../../platform/clipboard";
 import * as Haptics from "../../platform/haptics";
-
-const INTERNAL_TOOL_NAMES = new Set([
-  "enter_plan_mode",
-  "set_work_mode",
-  "task_start",
-  "task_complete",
-  "add_subtask",
-  "set_dependency",
-]);
-
-const EXPLORATION_TOOL_NAMES = new Set([
-  "glob",
-  "grep",
-  "ls",
-  "list",
-  "list_files",
-  "read",
-  "search",
-]);
 
 interface MessageBubbleProps {
   message: ChatMessage;
@@ -66,37 +54,10 @@ export function MessageBubble({
   const isUser = message.role === "user";
   const [copied, setCopied] = useState(false);
 
-  const toolCalls = message.toolCalls ?? [];
-  const delegatedTools = toolCalls.filter(
-    (toolCall) =>
-      toolCall.name === "agent" ||
-      toolCall.name === "explore" ||
-      toolCall.name === "plan" ||
-      toolCall.name === "verify" ||
-      toolCall.name === "build",
-  );
-  const questionTools = toolCalls.filter(
-    (toolCall) => toolCall.name === "AskUserQuestion",
-  );
-  const planConfirmTools = toolCalls.filter(
-    (toolCall) => toolCall.name === "PlanConfirm",
-  );
-  const standardTools = toolCalls.filter(
-    (toolCall) =>
-      toolCall.name !== "explore" &&
-      toolCall.name !== "plan" &&
-      toolCall.name !== "verify" &&
-      toolCall.name !== "build" &&
-      toolCall.name !== "agent" &&
-      toolCall.name !== "AskUserQuestion" &&
-      toolCall.name !== "PlanConfirm" &&
-      !INTERNAL_TOOL_NAMES.has(toolCall.name),
-  );
-  const explorationTools = standardTools.filter((toolCall) =>
-    EXPLORATION_TOOL_NAMES.has(toolCall.name.toLowerCase()),
-  );
-  const visibleStandardTools = standardTools.filter(
-    (toolCall) => !EXPLORATION_TOOL_NAMES.has(toolCall.name.toLowerCase()),
+  const assistantSegments = assistantVisualSegments(
+    message,
+    isLast,
+    isThinking,
   );
   const handleCopy = () => {
     const value = message.content.trim();
@@ -108,6 +69,105 @@ export function MessageBubble({
     void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     setCopied(true);
     setTimeout(() => setCopied(false), 1200);
+  };
+
+  const renderToolSegment = (toolCall: ToolCall) => {
+    const toolIsStreaming =
+      isLast && isStreaming && toolCall.status === "running";
+    if (isQuestionTool(toolCall) && onSubmitToolResult) {
+      return (
+        <AskUserQuestionWidget
+          key={toolCall.id}
+          toolCall={toolCall}
+          isSubmitting={activeToolCallId === toolCall.id}
+          onSubmit={(result) => onSubmitToolResult(toolCall.id, result)}
+        />
+      );
+    }
+
+    if (isPlanConfirmTool(toolCall) && onPlanConfirm) {
+      return (
+        <PlanConfirmWidget
+          key={toolCall.id}
+          toolCall={toolCall}
+          isSubmitting={activeToolCallId === toolCall.id}
+          onConfirm={(choice) => onPlanConfirm(toolCall.id, choice)}
+        />
+      );
+    }
+
+    if (
+      toolCall.status === "awaiting_approval" &&
+      onApproveTool &&
+      onDenyTool
+    ) {
+      return (
+        <ToolApprovalWidget
+          key={toolCall.id}
+          toolCall={toolCall}
+          isSubmitting={activeToolCallId === toolCall.id}
+          onApprove={() => onApproveTool(toolCall.id)}
+          onDeny={() => onDenyTool(toolCall.id)}
+        />
+      );
+    }
+
+    return (
+      <ToolCallCard
+        key={toolCall.id}
+        toolCall={toolCall}
+        isStreaming={
+          toolIsStreaming || (isDelegatedTool(toolCall) && isLast && isStreaming)
+        }
+        defaultExpanded={shouldExpandTool(toolCall, isLast && isStreaming)}
+      />
+    );
+  };
+
+  const renderAssistantSegment = (segment: AssistantVisualSegment) => {
+    switch (segment.type) {
+      case "thinking":
+        return (
+          <ThinkingBlock
+            key={segment.id}
+            content={segment.content}
+            isStreaming={
+              isLast && (isThinking || (isStreaming && !message.content))
+            }
+          />
+        );
+      case "exploration":
+        return (
+          <ToolClusterCard
+            key={segment.id}
+            tools={segment.tools}
+            isStreaming={isLast && isStreaming}
+          />
+        );
+      case "tool":
+        return renderToolSegment(segment.toolCall);
+      case "attachments":
+        return (
+          <MessageAttachments
+            key={segment.id}
+            attachments={message.attachments ?? []}
+          />
+        );
+      case "text":
+        return (
+          <Pressable
+            key={segment.id}
+            onLongPress={handleCopy}
+            delayLongPress={250}
+            style={styles.assistantText}
+          >
+            <AssistantSegmentedContent
+              messageId={`${message.id}-${segment.id}`}
+              content={segment.content}
+            />
+          </Pressable>
+        );
+    }
   };
 
   return (
@@ -158,111 +218,7 @@ export function MessageBubble({
 
       {!isUser && (
         <View style={styles.assistantWrap}>
-          {(message.thinking || (isLast && isThinking)) && (
-            <ThinkingBlock
-              content={message.thinking ?? ""}
-              isStreaming={
-                isLast && (isThinking || (isStreaming && !message.content))
-              }
-            />
-          )}
-
-          {delegatedTools.length > 0 && (
-            <View style={styles.toolSection}>
-              {delegatedTools.map((toolCall) => (
-                <ToolCallCard
-                  key={toolCall.id}
-                  toolCall={toolCall}
-                  isStreaming={isLast && isStreaming}
-                  defaultExpanded={shouldExpandTool(
-                    toolCall,
-                    isLast && isStreaming,
-                  )}
-                />
-              ))}
-            </View>
-          )}
-
-          {explorationTools.length > 0 ? (
-            <ToolClusterCard
-              tools={explorationTools}
-              isStreaming={isLast && isStreaming}
-            />
-          ) : null}
-
-          {visibleStandardTools.length > 0 && (
-            <View style={styles.toolSection}>
-              <Text style={[styles.toolLabel, { color: t.mutedForeground }]}>
-                Actions
-              </Text>
-              {visibleStandardTools.map((toolCall) =>
-                toolCall.status === "awaiting_approval" &&
-                onApproveTool &&
-                onDenyTool ? (
-                  <ToolApprovalWidget
-                    key={toolCall.id}
-                    toolCall={toolCall}
-                    isSubmitting={activeToolCallId === toolCall.id}
-                    onApprove={() => onApproveTool(toolCall.id)}
-                    onDeny={() => onDenyTool(toolCall.id)}
-                  />
-                ) : (
-                  <ToolCallCard
-                    key={toolCall.id}
-                    toolCall={toolCall}
-                    isStreaming={isLast && isStreaming}
-                    defaultExpanded={shouldExpandTool(
-                      toolCall,
-                      isLast && isStreaming,
-                    )}
-                  />
-                ),
-              )}
-            </View>
-          )}
-
-          {(message.attachments?.length ?? 0) > 0 ? (
-            <MessageAttachments attachments={message.attachments ?? []} />
-          ) : null}
-
-          {message.content.length > 0 && (
-            <Pressable
-              onLongPress={handleCopy}
-              delayLongPress={250}
-              style={styles.assistantText}
-            >
-              <AssistantSegmentedContent
-                messageId={message.id}
-                content={message.content}
-              />
-            </Pressable>
-          )}
-
-          {questionTools.length > 0 && onSubmitToolResult && (
-            <View style={styles.toolSection}>
-              {questionTools.map((toolCall) => (
-                <AskUserQuestionWidget
-                  key={toolCall.id}
-                  toolCall={toolCall}
-                  isSubmitting={activeToolCallId === toolCall.id}
-                  onSubmit={(result) => onSubmitToolResult(toolCall.id, result)}
-                />
-              ))}
-            </View>
-          )}
-
-          {planConfirmTools.length > 0 && onPlanConfirm && (
-            <View style={styles.toolSection}>
-              {planConfirmTools.map((toolCall) => (
-                <PlanConfirmWidget
-                  key={toolCall.id}
-                  toolCall={toolCall}
-                  isSubmitting={activeToolCallId === toolCall.id}
-                  onConfirm={(choice) => onPlanConfirm(toolCall.id, choice)}
-                />
-              ))}
-            </View>
-          )}
+          {assistantSegments.map(renderAssistantSegment)}
 
           {copied ? (
             <Text style={[styles.copyStatus, { color: t.mutedForeground }]}>
@@ -542,15 +498,6 @@ const styles = StyleSheet.create({
     fontWeight: "500",
     marginTop: -2,
     marginLeft: 2,
-  },
-  toolSection: {
-    gap: 6,
-  },
-  toolLabel: {
-    fontSize: 12,
-    fontWeight: "500",
-    marginBottom: 2,
-    marginLeft: 4,
   },
   toolCluster: {
     borderRadius: 10,

--- a/apps/mobile/components/chat/assistantRenderPlan.ts
+++ b/apps/mobile/components/chat/assistantRenderPlan.ts
@@ -1,0 +1,290 @@
+import type { ChatMessage, ChatRenderPart, ToolCall } from "@krusty/api";
+
+/** Keep in sync with plan/mode tools filtered from UI in core tool policy. */
+const INTERNAL_TOOL_NAMES = new Set([
+  "enter_plan_mode",
+  "set_work_mode",
+  "set_workspace_context",
+  "task_start",
+  "task_complete",
+  "add_subtask",
+  "set_dependency",
+]);
+
+const EXPLORATION_TOOL_NAMES = new Set([
+  "glob",
+  "grep",
+  "ls",
+  "list",
+  "list_files",
+  "read",
+  "search",
+]);
+
+export type AssistantVisualSegment =
+  | {
+      type: "thinking";
+      id: string;
+      content: string;
+    }
+  | {
+      type: "text";
+      id: string;
+      content: string;
+    }
+  | {
+      type: "attachments";
+      id: string;
+    }
+  | {
+      type: "tool";
+      id: string;
+      toolCall: ToolCall;
+    }
+  | {
+      type: "exploration";
+      id: string;
+      tools: ToolCall[];
+    };
+
+export function isDelegatedTool(toolCall: ToolCall): boolean {
+  return (
+    toolCall.name === "agent" ||
+    toolCall.name === "explore" ||
+    toolCall.name === "plan" ||
+    toolCall.name === "verify" ||
+    toolCall.name === "build"
+  );
+}
+
+export function isQuestionTool(toolCall: ToolCall): boolean {
+  return toolCall.name === "AskUserQuestion";
+}
+
+export function isPlanConfirmTool(toolCall: ToolCall): boolean {
+  return toolCall.name === "PlanConfirm";
+}
+
+function isInternalTool(toolCall: ToolCall): boolean {
+  return INTERNAL_TOOL_NAMES.has(toolCall.name);
+}
+
+function isExplorationTool(toolCall: ToolCall): boolean {
+  return EXPLORATION_TOOL_NAMES.has(toolCall.name.toLowerCase());
+}
+
+function isSoftInterruption(segment: AssistantVisualSegment): boolean {
+  return (
+    segment.type === "exploration" ||
+    segment.type === "thinking" ||
+    segment.type === "tool"
+  );
+}
+
+export function startsLikeNewBlock(content: string): boolean {
+  return /^(#{1,6}\s|[-*+]\s|\d+[.)]\s|```|>|<\w)/.test(content);
+}
+
+/** Exported for unit tests — mid-stream tool interruptions rejoin prose. */
+export function shouldMergeContinuationText(
+  previousContent: string,
+  nextContent: string,
+  interveningSegments: AssistantVisualSegment[],
+): boolean {
+  if (interveningSegments.length === 0) return false;
+  if (!interveningSegments.every(isSoftInterruption)) return false;
+
+  const previous = previousContent.trimEnd();
+  const next = nextContent.trimStart();
+  if (!previous || !next || startsLikeNewBlock(next)) return false;
+
+  // Do not glue across closed code fences / list boundaries left unfinished.
+  if (/```\s*$/.test(previous) || /^```/.test(next)) return false;
+
+  const previousLooksUnfinished = /[A-Za-z0-9_'")\]]$/.test(previous);
+  const nextLooksContinued = /^[a-z,.;:!?'"()\]}]/.test(next);
+
+  return previousLooksUnfinished && nextLooksContinued;
+}
+
+export function appendContinuationText(previous: string, next: string): string {
+  if (!previous) return next;
+  if (!next) return previous;
+  if (/\s$/.test(previous) || /^\s/.test(next)) return previous + next;
+  return previous + next.trimStart();
+}
+
+/** Exported for unit tests. */
+export function smoothInterruptedText(
+  segments: AssistantVisualSegment[],
+): AssistantVisualSegment[] {
+  const smoothed: AssistantVisualSegment[] = [];
+
+  for (const segment of segments) {
+    if (segment.type !== "text") {
+      smoothed.push(segment);
+      continue;
+    }
+
+    let previousTextIndex = -1;
+    for (let index = smoothed.length - 1; index >= 0; index -= 1) {
+      if (smoothed[index]?.type === "text") {
+        previousTextIndex = index;
+        break;
+      }
+    }
+    const previousText = smoothed[previousTextIndex];
+    const interveningSegments =
+      previousTextIndex >= 0 ? smoothed.slice(previousTextIndex + 1) : [];
+
+    if (
+      previousText?.type === "text" &&
+      shouldMergeContinuationText(
+        previousText.content,
+        segment.content,
+        interveningSegments,
+      )
+    ) {
+      smoothed[previousTextIndex] = {
+        ...previousText,
+        content: appendContinuationText(previousText.content, segment.content),
+      };
+      continue;
+    }
+
+    smoothed.push(segment);
+  }
+
+  return smoothed;
+}
+
+function legacyRenderParts(
+  message: ChatMessage,
+  isLast: boolean,
+  isThinking?: boolean,
+): ChatRenderPart[] {
+  const parts: ChatRenderPart[] = [];
+
+  if (message.thinking || (isLast && isThinking)) {
+    parts.push({
+      type: "thinking",
+      id: "legacy-thinking",
+      content: message.thinking ?? "",
+    });
+  }
+
+  for (const toolCall of message.toolCalls ?? []) {
+    parts.push({
+      type: "tool",
+      id: `legacy-tool-${toolCall.id}`,
+      toolCallId: toolCall.id,
+    });
+  }
+
+  if ((message.attachments?.length ?? 0) > 0) {
+    parts.push({ type: "attachments", id: "legacy-attachments" });
+  }
+
+  if (message.content.length > 0) {
+    parts.push({
+      type: "text",
+      id: "legacy-text",
+      content: message.content,
+    });
+  }
+
+  return parts;
+}
+
+export function assistantVisualSegments(
+  message: ChatMessage,
+  isLast: boolean,
+  isThinking?: boolean,
+): AssistantVisualSegment[] {
+  const toolById = new Map(
+    (message.toolCalls ?? []).map((toolCall) => [toolCall.id, toolCall]),
+  );
+  const renderParts =
+    message.renderParts && message.renderParts.length > 0
+      ? message.renderParts
+      : legacyRenderParts(message, isLast, isThinking);
+  const segments: AssistantVisualSegment[] = [];
+  let explorationBuffer: ToolCall[] = [];
+
+  const flushExplorationBuffer = () => {
+    if (explorationBuffer.length === 0) return;
+    const first = explorationBuffer[0];
+    segments.push({
+      type: "exploration",
+      id: `exploration-${first?.id ?? segments.length}`,
+      tools: explorationBuffer,
+    });
+    explorationBuffer = [];
+  };
+
+  for (const part of renderParts) {
+    switch (part.type) {
+      case "thinking": {
+        if (!part.content && !(isLast && isThinking)) break;
+        flushExplorationBuffer();
+        segments.push({
+          type: "thinking",
+          id: part.id,
+          content: part.content,
+        });
+        break;
+      }
+      case "tool": {
+        const toolCall = toolById.get(part.toolCallId);
+        if (!toolCall || isInternalTool(toolCall)) break;
+        if (isExplorationTool(toolCall)) {
+          explorationBuffer.push(toolCall);
+        } else {
+          flushExplorationBuffer();
+          segments.push({
+            type: "tool",
+            id: part.id,
+            toolCall,
+          });
+        }
+        break;
+      }
+      case "attachments": {
+        if ((message.attachments?.length ?? 0) === 0) break;
+        flushExplorationBuffer();
+        segments.push({
+          type: "attachments",
+          id: part.id,
+        });
+        break;
+      }
+      case "text": {
+        if (part.content.length === 0) break;
+        flushExplorationBuffer();
+        segments.push({
+          type: "text",
+          id: part.id,
+          content: part.content,
+        });
+        break;
+      }
+    }
+  }
+
+  flushExplorationBuffer();
+
+  const smoothedSegments = smoothInterruptedText(segments);
+
+  if (
+    smoothedSegments.length === 0 &&
+    (message.thinking || (isLast && isThinking))
+  ) {
+    smoothedSegments.push({
+      type: "thinking",
+      id: "fallback-thinking",
+      content: message.thinking ?? "",
+    });
+  }
+
+  return smoothedSegments;
+}

--- a/apps/mobile/components/chat/assistantSegments.ts
+++ b/apps/mobile/components/chat/assistantSegments.ts
@@ -33,6 +33,18 @@ export function assistantMessageRevision(message: ChatMessage): string {
         ].join(":"),
       )
       .join("|") ?? "";
+  const renderPartSignature =
+    message.renderParts
+      ?.map((part) => {
+        if (part.type === "tool") {
+          return `${part.type}:${part.toolCallId}`;
+        }
+        if (part.type === "attachments") {
+          return part.type;
+        }
+        return `${part.type}:${part.content.length}`;
+      })
+      .join("|") ?? "";
 
   return [
     message.id,
@@ -40,6 +52,7 @@ export function assistantMessageRevision(message: ChatMessage): string {
     message.thinking?.length ?? 0,
     message.kind ?? "steady",
     toolSignature,
+    renderPartSignature,
   ].join("::");
 }
 

--- a/apps/mobile/components/desktop/Terminal.tsx
+++ b/apps/mobile/components/desktop/Terminal.tsx
@@ -11,7 +11,6 @@ import {
   AlertCircle,
   Plus,
   RefreshCw,
-  TerminalSquare,
   X,
 } from "lucide-react-native";
 
@@ -19,6 +18,7 @@ import * as Haptics from "../../platform/haptics";
 import { useConnection } from "../../hooks/useConnection";
 import { useWorkspaceStore } from "../../hooks/useStores";
 import { useThemeContext } from "../../hooks/useTheme";
+import { buildTerminalWebSocketUrl } from "../terminalUrl";
 
 const MAX_RECONNECT_ATTEMPTS = 8;
 const RECONNECT_INITIAL_DELAY_MS = 250;
@@ -79,7 +79,7 @@ function escapeShellPath(path: string): string {
 
 export function Terminal({ visible, style }: TerminalProps) {
   const { theme } = useThemeContext();
-  const { serverUrl } = useConnection();
+  const { serverUrl, serverToken } = useConnection();
   const workspaceDirectory = useWorkspaceStore((state) => state.directory) ?? null;
 
   const [tabs, setTabs] = useState<TerminalTab[]>([]);
@@ -143,8 +143,6 @@ export function Terminal({ visible, style }: TerminalProps) {
   return (
     <View style={[styles.container, { backgroundColor: t.background, borderTopColor: t.border }, style]}>
       <View style={[styles.tabBar, { borderBottomColor: t.border }]}>
-        <TerminalSquare size={16} color={t.mutedForeground} strokeWidth={1.8} />
-
         {tabs.map((tab) => {
           const active = activeTabId === tab.id;
           const statusColor = tab.connected
@@ -226,6 +224,7 @@ export function Terminal({ visible, style }: TerminalProps) {
               key={tab.id}
               active={activeTabId === tab.id}
               serverUrl={serverUrl}
+              serverToken={serverToken}
               tab={tab}
               themeColors={theme.colors}
               workspaceDirectory={workspaceDirectory}
@@ -241,6 +240,7 @@ export function Terminal({ visible, style }: TerminalProps) {
 function TerminalPane({
   active,
   serverUrl,
+  serverToken,
   tab,
   themeColors,
   workspaceDirectory,
@@ -248,6 +248,7 @@ function TerminalPane({
 }: {
   active: boolean;
   serverUrl: string;
+  serverToken: string | null;
   tab: TerminalTab;
   themeColors: ReturnType<typeof useThemeContext>["theme"]["colors"];
   workspaceDirectory: string | null;
@@ -261,6 +262,7 @@ function TerminalPane({
   const fitAddonRef = useRef<any>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const serverUrlRef = useRef(serverUrl);
+  const serverTokenRef = useRef(serverToken);
   const activeRef = useRef(active);
   const workspaceDirectoryRef = useRef(workspaceDirectory);
   const reconnectAttemptsRef = useRef(0);
@@ -401,7 +403,10 @@ function TerminalPane({
         onStatusChange(tab.id, { connected: false, error: null });
       }
 
-      const wsUrl = serverUrlRef.current.replace(/^http/i, "ws") + "/ws/terminal";
+      const wsUrl = buildTerminalWebSocketUrl(
+        serverUrlRef.current,
+        serverTokenRef.current,
+      );
       const ws = new WebSocket(wsUrl);
       ws.binaryType = "arraybuffer";
       wsRef.current = ws;
@@ -560,6 +565,10 @@ function TerminalPane({
   useEffect(() => {
     serverUrlRef.current = serverUrl;
   }, [serverUrl]);
+
+  useEffect(() => {
+    serverTokenRef.current = serverToken;
+  }, [serverToken]);
 
   useEffect(() => {
     if (Platform.OS !== "web" || !divRef.current) {

--- a/apps/mobile/components/desktop/WorkspacePreview.tsx
+++ b/apps/mobile/components/desktop/WorkspacePreview.tsx
@@ -3,7 +3,6 @@ import {
   ActivityIndicator,
   Platform,
   Pressable,
-  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -13,9 +12,6 @@ import {
   AlertCircle,
   ArrowLeft,
   ArrowRight,
-  Copy,
-  ExternalLink,
-  Globe,
   Plus,
   RefreshCw,
   X,
@@ -23,9 +19,7 @@ import {
 
 import type { PortEntry, PreviewSettings } from "@krusty/api";
 
-import * as Clipboard from "../../platform/clipboard";
 import * as Haptics from "../../platform/haptics";
-import { openURL } from "../../platform/linking";
 import { useConnection } from "../../hooks/useConnection";
 import { useThemeContext } from "../../hooks/useTheme";
 
@@ -39,7 +33,7 @@ const PREVIEW_IFRAME_SANDBOX =
 
 type PersistedPreviewTab = {
   id: string;
-  port: number;
+  port: number | null;
   title: string;
   history: string[];
   historyIndex: number;
@@ -64,6 +58,19 @@ function createPreviewTabId(): string {
   return `preview-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
+function createBlankPreviewTab(): PreviewTab {
+  return {
+    id: createPreviewTabId(),
+    port: null,
+    title: "New Tab",
+    history: [],
+    historyIndex: 0,
+    error: null,
+    isLoading: false,
+    reloadKey: 0,
+  };
+}
+
 function getPreviewUrl(serverUrl: string, port: number): string {
   return `${serverUrl.replace(/\/+$/, "")}/api/ports/${port}/proxy`;
 }
@@ -80,27 +87,42 @@ function extractPortFromProxyPath(pathname: string): number | null {
   return port;
 }
 
-function previewStatusText(port: PortEntry): string {
-  if (!port.active) return "Offline";
-  if (port.is_previewable_http) {
-    return port.last_probe_ms ? `HTTP ready • ${port.last_probe_ms}ms` : "HTTP ready";
+function extractPortFromInput(raw: string, serverUrl: string): number | null {
+  const input = raw.trim();
+  if (!input) return null;
+
+  const numeric = input.startsWith(":") ? input.slice(1) : input;
+  if (/^\d+$/.test(numeric)) {
+    const port = Number(numeric);
+    return Number.isInteger(port) && port > 0 && port <= 65535 ? port : null;
   }
 
-  switch (port.probe_status) {
-    case "timeout":
-      return "Probe timeout";
-    case "conn_refused":
-      return "Connection refused";
-    case "non_http":
-      return "Non-HTTP listener";
-    default:
-      return "Probe failed";
+  try {
+    const origin = new URL(serverUrl).origin;
+    const parsed = new URL(input, origin);
+    const proxyPort = extractPortFromProxyPath(parsed.pathname);
+    if (proxyPort !== null) {
+      return proxyPort;
+    }
+
+    if (parsed.port) {
+      const port = Number(parsed.port);
+      return Number.isInteger(port) && port > 0 && port <= 65535 ? port : null;
+    }
+  } catch {
+    return null;
   }
+
+  return null;
 }
 
 function syncTabTitlesWithPorts(tabs: PreviewTab[], ports: PortEntry[]): PreviewTab[] {
   let changed = false;
   const nextTabs = tabs.map((tab) => {
+    if (tab.port === null) {
+      return tab;
+    }
+
     const match = ports.find((port) => port.port === tab.port);
     if (!match || match.name === tab.title) {
       return tab;
@@ -179,8 +201,6 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
   const [previewTabs, setPreviewTabs] = useState<PreviewTab[]>([]);
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
   const [previewAddress, setPreviewAddress] = useState("");
-  const [showNewTab, setShowNewTab] = useState(false);
-  const [copiedPort, setCopiedPort] = useState<number | null>(null);
   const [tabsRestored, setTabsRestored] = useState(false);
 
   const isWeb = Platform.OS === "web";
@@ -189,7 +209,10 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
     previewTabs.find((tab) => tab.id === activeTabId) ?? null;
 
   useEffect(() => {
-    const url = activeTab ? activeTab.history[activeTab.historyIndex] ?? "" : "";
+    const url =
+      activeTab && activeTab.port !== null
+        ? activeTab.history[activeTab.historyIndex] ?? ""
+        : "";
     setPreviewAddress(url);
   }, [activeTab]);
 
@@ -198,8 +221,10 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
 
     const raw = sessionStorage.getItem(PREVIEW_SESSION_KEY);
     if (!raw) {
+      const blankTab = createBlankPreviewTab();
+      setPreviewTabs([blankTab]);
+      setActiveTabId(blankTab.id);
       setTabsRestored(true);
-      setShowNewTab(true);
       return;
     }
 
@@ -215,19 +240,33 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
               (tab) =>
                 tab &&
                 typeof tab.id === "string" &&
-                Number.isInteger(tab.port) &&
-                tab.port > 0 &&
-                tab.port <= 65535 &&
                 Array.isArray(tab.history) &&
-                tab.history.length > 0,
+                (
+                  tab.port === null ||
+                  (
+                    Number.isInteger(tab.port) &&
+                    tab.port > 0 &&
+                    tab.port <= 65535 &&
+                    tab.history.length > 0
+                  )
+                ),
             )
             .map((tab) => {
+              if (tab.port === null) {
+                return {
+                  ...createBlankPreviewTab(),
+                  id: tab.id,
+                  title: tab.title || "New Tab",
+                };
+              }
+
+              const restoredPort = tab.port;
               const safeHistory = tab.history
-                .map((entry) => normalizeProxyUrl(entry, tab.port, serverUrl, [], null))
+                .map((entry) => normalizeProxyUrl(entry, restoredPort, serverUrl, [], null))
                 .filter((entry): entry is string => Boolean(entry));
 
               if (safeHistory.length === 0) {
-                safeHistory.push(getPreviewUrl(serverUrl, tab.port));
+                safeHistory.push(getPreviewUrl(serverUrl, restoredPort));
               }
 
               const boundedIndex = Math.min(
@@ -237,8 +276,8 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
 
               return {
                 id: tab.id,
-                port: tab.port,
-                title: tab.title || `Port ${tab.port}`,
+                port: restoredPort,
+                title: tab.title || `Port ${restoredPort}`,
                 history: safeHistory,
                 historyIndex: boundedIndex,
                 error: null,
@@ -250,8 +289,9 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
 
       setPreviewTabs(restoredTabs);
       if (restoredTabs.length === 0) {
-        setActiveTabId(null);
-        setShowNewTab(true);
+        const blankTab = createBlankPreviewTab();
+        setPreviewTabs([blankTab]);
+        setActiveTabId(blankTab.id);
       } else if (
         parsed.activeTabId &&
         restoredTabs.some((tab) => tab.id === parsed.activeTabId)
@@ -262,7 +302,9 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
       }
     } catch {
       sessionStorage.removeItem(PREVIEW_SESSION_KEY);
-      setShowNewTab(true);
+      const blankTab = createBlankPreviewTab();
+      setPreviewTabs([blankTab]);
+      setActiveTabId(blankTab.id);
     } finally {
       setTabsRestored(true);
     }
@@ -283,6 +325,13 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
     });
     sessionStorage.setItem(PREVIEW_SESSION_KEY, payload);
   }, [activeTabId, isWeb, previewTabs]);
+
+  const createNewTab = useCallback(() => {
+    const tab = createBlankPreviewTab();
+    setPreviewTabs((current) => [...current, tab]);
+    setActiveTabId(tab.id);
+    setError(null);
+  }, []);
 
   const loadPorts = useCallback(
     async (background = false) => {
@@ -345,10 +394,31 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
         return;
       }
 
+      if (activeTab?.port === null) {
+        setPreviewTabs((current) =>
+          current.map((tab) =>
+            tab.id === activeTab.id
+              ? {
+                  ...tab,
+                  port: port.port,
+                  title: port.name,
+                  history: [getPreviewUrl(serverUrl, port.port)],
+                  historyIndex: 0,
+                  error: null,
+                  isLoading: true,
+                  reloadKey: 0,
+                }
+              : tab,
+          ),
+        );
+        setActiveTabId(activeTab.id);
+        setError(null);
+        return;
+      }
+
       const existing = previewTabs.find((tab) => tab.port === port.port);
       if (existing) {
         setActiveTabId(existing.id);
-        setShowNewTab(false);
         return;
       }
 
@@ -364,10 +434,9 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
       };
       setPreviewTabs((current) => [...current, nextTab]);
       setActiveTabId(nextTab.id);
-      setShowNewTab(false);
       setError(null);
     },
-    [previewTabs, serverUrl, settings?.allow_force_open_non_http],
+    [activeTab, previewTabs, serverUrl, settings?.allow_force_open_non_http],
   );
 
   const closeTab = useCallback(
@@ -379,6 +448,12 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
         }
 
         const nextTabs = current.filter((tab) => tab.id !== tabId);
+        if (nextTabs.length === 0) {
+          const blankTab = createBlankPreviewTab();
+          setActiveTabId(blankTab.id);
+          return [blankTab];
+        }
+
         setActiveTabId((currentActive) => {
           if (currentActive !== tabId) {
             return currentActive;
@@ -386,7 +461,6 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
 
           const nextActive =
             nextTabs[Math.max(0, index - 1)]?.id ?? nextTabs[0]?.id ?? null;
-          setShowNewTab(nextTabs.length === 0);
           return nextActive;
         });
 
@@ -402,6 +476,10 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
 
       const current = previewTabs.find((tab) => tab.id === tabId);
       if (!current) return;
+      if (current.port === null) {
+        setError("Select an available preview port.");
+        return;
+      }
 
       const normalized = normalizeProxyUrl(
         rawUrl,
@@ -453,38 +531,61 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
         }),
       );
       setActiveTabId(tabId);
-      setShowNewTab(false);
       setError(null);
     },
     [ports, previewTabs, serverUrl, settings],
   );
 
-  const copyPortUrl = useCallback(
-    async (port: number) => {
-      if (!serverUrl) return;
-
-      try {
-        await Clipboard.setStringAsync(getPreviewUrl(serverUrl, port));
-        setCopiedPort(port);
-        setTimeout(() => {
-          setCopiedPort((current) => (current === port ? null : current));
-        }, 1500);
-      } catch {
-        setError("Failed to copy preview URL.");
-      }
-    },
-    [serverUrl],
-  );
-
   const availablePorts = useMemo(
     () =>
       ports.filter(
-        (port) =>
-          port.active &&
-          (port.is_previewable_http || settings?.allow_force_open_non_http),
+        (port) => port.active && port.is_previewable_http,
       ),
-    [ports, settings?.allow_force_open_non_http],
+    [ports],
   );
+  const showPortLauncher = !activeTab || activeTab.port === null;
+
+  const handleAddressSubmit = useCallback(() => {
+    if (!serverUrl) return;
+
+    if (showPortLauncher) {
+      const port = extractPortFromInput(previewAddress, serverUrl);
+      const match = port
+        ? availablePorts.find((candidate) => candidate.port === port)
+        : null;
+      if (!match) {
+        setError("Select an available preview port.");
+        return;
+      }
+
+      openPortInPreview(match);
+      return;
+    }
+
+    if (activeTab) {
+      updateTabNavigation(activeTab.id, previewAddress, true);
+      return;
+    }
+
+    const port = extractPortFromInput(previewAddress, serverUrl);
+    const match = port
+      ? availablePorts.find((candidate) => candidate.port === port)
+      : null;
+    if (!match) {
+      setError("Select an available preview port.");
+      return;
+    }
+
+    openPortInPreview(match);
+  }, [
+    activeTab,
+    availablePorts,
+    openPortInPreview,
+    previewAddress,
+    serverUrl,
+    showPortLauncher,
+    updateTabNavigation,
+  ]);
 
   if (!isWeb || !visible) {
     return null;
@@ -493,10 +594,8 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
   return (
     <View style={[styles.container, { backgroundColor: t.background, borderTopColor: t.border }, style]}>
       <View style={[styles.tabBar, { borderBottomColor: t.border }]}>
-        <Globe size={16} color={t.mutedForeground} strokeWidth={1.8} />
-
         {previewTabs.map((tab) => {
-          const active = activeTabId === tab.id && !showNewTab;
+          const active = activeTabId === tab.id;
           return (
             <View
               key={tab.id}
@@ -512,7 +611,6 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
                 onPress={() => {
                   void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                   setActiveTabId(tab.id);
-                  setShowNewTab(false);
                 }}
                 style={styles.tabPressable}
               >
@@ -542,8 +640,7 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
         <Pressable
           onPress={() => {
             void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-            setShowNewTab(true);
-            setActiveTabId(null);
+            createNewTab();
           }}
           style={styles.iconBtn}
         >
@@ -576,278 +673,215 @@ export function WorkspacePreview({ visible, style }: WorkspacePreviewProps) {
         </View>
       ) : null}
 
-      {showNewTab || !activeTab ? (
-        <View style={styles.browserPane}>
-          <View style={[styles.browserToolbar, { borderBottomColor: t.border }]}>
-            <Text style={[styles.browserTitle, { color: t.foreground }]}>
-              Preview Ports
-            </Text>
-            <Pressable
-              onPress={() => void loadPorts()}
-              style={[styles.iconBtn, styles.toolbarBtn]}
-            >
-              <RefreshCw size={15} color={t.mutedForeground} strokeWidth={1.8} />
-            </Pressable>
-          </View>
+      <View style={styles.browserPane}>
+        <View style={[styles.browserToolbar, { borderBottomColor: t.border }]}>
+          <Pressable
+            onPress={() => {
+              if (!activeTab || activeTab.historyIndex === 0) return;
+              setPreviewTabs((tabs) =>
+                tabs.map((tab) =>
+                  tab.id === activeTab.id
+                    ? {
+                        ...tab,
+                        historyIndex: tab.historyIndex - 1,
+                        isLoading: true,
+                        error: null,
+                      }
+                    : tab,
+                ),
+              );
+            }}
+            disabled={!activeTab || activeTab.historyIndex === 0}
+            style={[styles.iconBtn, styles.toolbarBtn]}
+          >
+            <ArrowLeft
+              size={15}
+              color={!activeTab || activeTab.historyIndex === 0 ? t.border : t.mutedForeground}
+              strokeWidth={1.8}
+            />
+          </Pressable>
 
-          {loading ? (
-            <View style={styles.centerState}>
-              <ActivityIndicator color={t.userMessage} size="small" />
-              <Text style={[styles.stateText, { color: t.mutedForeground }]}>
-                Loading forwardable ports…
-              </Text>
-            </View>
-          ) : availablePorts.length === 0 ? (
-            <View style={styles.centerState}>
-              <Text style={[styles.stateText, { color: t.mutedForeground }]}>
-                No previewable ports are active right now.
-              </Text>
-            </View>
-          ) : (
-            <ScrollView
-              contentContainerStyle={styles.portList}
-              showsVerticalScrollIndicator={false}
-            >
-              {availablePorts.map((port) => (
-                <View
-                  key={port.port}
-                  style={[
-                    styles.portCard,
-                    { backgroundColor: t.card, borderColor: t.border },
-                  ]}
-                >
-                  <View style={styles.portHeader}>
-                    <View style={styles.grow}>
-                      <Text style={[styles.portName, { color: t.foreground }]}>
-                        {port.name}
-                      </Text>
-                      <Text style={[styles.portMeta, { color: t.mutedForeground }]}>
-                        :{port.port} • {previewStatusText(port)}
-                      </Text>
-                    </View>
-                    {port.pinned ? (
-                      <Text style={[styles.badge, { color: t.userMessage }]}>Pinned</Text>
-                    ) : null}
-                  </View>
+          <Pressable
+            onPress={() => {
+              if (!activeTab || activeTab.historyIndex >= activeTab.history.length - 1) return;
+              setPreviewTabs((tabs) =>
+                tabs.map((tab) =>
+                  tab.id === activeTab.id
+                    ? {
+                        ...tab,
+                        historyIndex: tab.historyIndex + 1,
+                        isLoading: true,
+                        error: null,
+                      }
+                    : tab,
+                ),
+              );
+            }}
+            disabled={!activeTab || activeTab.historyIndex >= activeTab.history.length - 1}
+            style={[styles.iconBtn, styles.toolbarBtn]}
+          >
+            <ArrowRight
+              size={15}
+              color={
+                !activeTab || activeTab.historyIndex >= activeTab.history.length - 1
+                  ? t.border
+                  : t.mutedForeground
+              }
+              strokeWidth={1.8}
+            />
+          </Pressable>
 
-                  {port.description ? (
-                    <Text style={[styles.portDescription, { color: t.mutedForeground }]}>
-                      {port.description}
-                    </Text>
-                  ) : null}
+          <Pressable
+            onPress={() => {
+              if (!activeTab || activeTab.port === null) return;
+              setPreviewTabs((tabs) =>
+                tabs.map((tab) =>
+                  tab.id === activeTab.id
+                    ? {
+                        ...tab,
+                        isLoading: true,
+                        error: null,
+                        reloadKey: tab.reloadKey + 1,
+                      }
+                    : tab,
+                ),
+              );
+            }}
+            disabled={!activeTab || activeTab.port === null}
+            style={[styles.iconBtn, styles.toolbarBtn]}
+          >
+            <RefreshCw
+              size={15}
+              color={activeTab?.port !== null ? t.mutedForeground : t.border}
+              strokeWidth={1.8}
+            />
+          </Pressable>
 
-                  <View style={styles.portActions}>
+          <TextInput
+            value={previewAddress}
+            onChangeText={setPreviewAddress}
+            onSubmitEditing={() => {
+              void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+              handleAddressSubmit();
+            }}
+            style={[
+              styles.addressInput,
+              {
+                color: t.foreground,
+                borderColor: t.border,
+                backgroundColor: t.card,
+              },
+            ]}
+            placeholder={showPortLauncher ? "Select a port or enter :5173" : "Preview URL"}
+            placeholderTextColor={`${t.mutedForeground}88`}
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </View>
+
+        <View style={styles.previewArea}>
+          {showPortLauncher ? (
+            <View style={styles.portLauncherPage}>
+              {loading && availablePorts.length === 0 ? (
+                <View style={styles.inlineState}>
+                  <ActivityIndicator color={t.userMessage} size="small" />
+                  <Text style={[styles.stateText, { color: t.mutedForeground }]}>
+                    Looking for previewable ports...
+                  </Text>
+                </View>
+              ) : availablePorts.length === 0 ? (
+                <Text style={[styles.stateText, { color: t.mutedForeground }]}>
+                  Waiting for previewable ports.
+                </Text>
+              ) : (
+                <View style={styles.portStack}>
+                  {availablePorts.map((port) => (
                     <Pressable
+                      key={port.port}
                       onPress={() => {
                         void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                         openPortInPreview(port);
                       }}
-                      style={[styles.actionBtn, { borderColor: t.border }]}
+                      style={[
+                        styles.portButton,
+                        {
+                          backgroundColor: t.card,
+                          borderColor: t.border,
+                        },
+                      ]}
                     >
-                      <Text style={[styles.actionText, { color: t.foreground }]}>
-                        Preview
+                      <Text style={[styles.portButtonText, { color: t.foreground }]}>
+                        :{port.port}
                       </Text>
                     </Pressable>
-
-                    <Pressable
-                      onPress={() => void copyPortUrl(port.port)}
-                      style={[styles.actionBtn, { borderColor: t.border }]}
-                    >
-                      <Copy size={14} color={t.mutedForeground} strokeWidth={1.8} />
-                      <Text style={[styles.actionText, { color: t.mutedForeground }]}>
-                        {copiedPort === port.port ? "Copied" : "Copy URL"}
-                      </Text>
-                    </Pressable>
-
-                    <Pressable
-                      onPress={() => void openURL(getPreviewUrl(serverUrl ?? "", port.port))}
-                      style={[styles.actionBtn, { borderColor: t.border }]}
-                    >
-                      <ExternalLink
-                        size={14}
-                        color={t.userMessage}
-                        strokeWidth={1.8}
-                      />
-                      <Text style={[styles.actionText, { color: t.userMessage }]}>
-                        Open
-                      </Text>
-                    </Pressable>
-                  </View>
+                  ))}
                 </View>
-              ))}
-            </ScrollView>
-          )}
-        </View>
-      ) : (
-        <View style={styles.browserPane}>
-          <View style={[styles.browserToolbar, { borderBottomColor: t.border }]}>
-            <Pressable
-              onPress={() => {
-                if (!activeTab || activeTab.historyIndex === 0) return;
-                setPreviewTabs((tabs) =>
-                  tabs.map((tab) =>
-                    tab.id === activeTab.id
-                      ? {
-                          ...tab,
-                          historyIndex: tab.historyIndex - 1,
-                          isLoading: true,
-                          error: null,
-                        }
-                      : tab,
-                  ),
-                );
-              }}
-              disabled={activeTab.historyIndex === 0}
-              style={[styles.iconBtn, styles.toolbarBtn]}
-            >
-              <ArrowLeft
-                size={15}
-                color={activeTab.historyIndex === 0 ? t.border : t.mutedForeground}
-                strokeWidth={1.8}
-              />
-            </Pressable>
-
-            <Pressable
-              onPress={() => {
-                if (activeTab.historyIndex >= activeTab.history.length - 1) return;
-                setPreviewTabs((tabs) =>
-                  tabs.map((tab) =>
-                    tab.id === activeTab.id
-                      ? {
-                          ...tab,
-                          historyIndex: tab.historyIndex + 1,
-                          isLoading: true,
-                          error: null,
-                        }
-                      : tab,
-                  ),
-                );
-              }}
-              disabled={activeTab.historyIndex >= activeTab.history.length - 1}
-              style={[styles.iconBtn, styles.toolbarBtn]}
-            >
-              <ArrowRight
-                size={15}
-                color={
-                  activeTab.historyIndex >= activeTab.history.length - 1
-                    ? t.border
-                    : t.mutedForeground
-                }
-                strokeWidth={1.8}
-              />
-            </Pressable>
-
-            <Pressable
-              onPress={() => {
-                setPreviewTabs((tabs) =>
-                  tabs.map((tab) =>
-                    tab.id === activeTab.id
-                      ? {
-                          ...tab,
-                          isLoading: true,
-                          error: null,
-                          reloadKey: tab.reloadKey + 1,
-                        }
-                      : tab,
-                  ),
-                );
-              }}
-              style={[styles.iconBtn, styles.toolbarBtn]}
-            >
-              <RefreshCw size={15} color={t.mutedForeground} strokeWidth={1.8} />
-            </Pressable>
-
-            <TextInput
-              value={previewAddress}
-              onChangeText={setPreviewAddress}
-              onSubmitEditing={() => {
-                void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                updateTabNavigation(activeTab.id, previewAddress, true);
-              }}
-              style={[
-                styles.addressInput,
-                {
-                  color: t.foreground,
-                  borderColor: t.border,
-                  backgroundColor: t.card,
-                },
-              ]}
-              placeholder="Preview URL"
-              placeholderTextColor={`${t.mutedForeground}88`}
-              autoCapitalize="none"
-              autoCorrect={false}
-            />
-
-            <Pressable
-              onPress={() => void openURL(activeTab.history[activeTab.historyIndex] ?? "")}
-              style={[styles.iconBtn, styles.toolbarBtn]}
-            >
-              <ExternalLink size={15} color={t.userMessage} strokeWidth={1.8} />
-            </Pressable>
-          </View>
-
-          <View style={styles.previewArea}>
-            {previewTabs.map((tab) => {
-              const active = activeTabId === tab.id && !showNewTab;
+              )}
+            </View>
+          ) : (
+            previewTabs
+              .filter((tab) => tab.port !== null)
+              .map((tab) => {
+              const active = activeTabId === tab.id;
               return (
                 <View
                   key={tab.id}
                   style={[styles.previewFrameWrap, !active && styles.hiddenFrame]}
                 >
-                  {tab.isLoading ? (
-                    <View style={styles.previewOverlay}>
-                      <ActivityIndicator color={t.userMessage} size="small" />
-                      <Text style={[styles.stateText, { color: t.mutedForeground }]}>
-                        Loading preview…
-                      </Text>
-                    </View>
-                  ) : null}
+                {tab.isLoading ? (
+                  <View style={styles.previewOverlay}>
+                    <ActivityIndicator color={t.userMessage} size="small" />
+                    <Text style={[styles.stateText, { color: t.mutedForeground }]}>
+                      Loading preview…
+                    </Text>
+                  </View>
+                ) : null}
 
-                  {tab.error ? (
-                    <View style={styles.previewOverlay}>
-                      <Text style={[styles.stateText, { color: t.error }]}>
-                        {tab.error}
-                      </Text>
-                    </View>
-                  ) : null}
+                {tab.error ? (
+                  <View style={styles.previewOverlay}>
+                    <Text style={[styles.stateText, { color: t.error }]}>
+                      {tab.error}
+                    </Text>
+                  </View>
+                ) : null}
 
-                  <div style={{ width: "100%", height: "100%" }}>
-                      <iframe
-                        key={`${tab.id}:${tab.historyIndex}:${tab.reloadKey}`}
-                        src={tab.history[tab.historyIndex]}
-                        sandbox={PREVIEW_IFRAME_SANDBOX}
-                        style={{ width: "100%", height: "100%", border: "none" }}
-                        title={tab.title}
-                        onLoad={() => {
-                        setPreviewTabs((tabs) =>
-                          tabs.map((entry) =>
-                            entry.id === tab.id
-                              ? { ...entry, isLoading: false, error: null }
-                              : entry,
-                          ),
-                        );
-                      }}
-                      onError={() => {
-                        setPreviewTabs((tabs) =>
-                          tabs.map((entry) =>
-                            entry.id === tab.id
-                              ? {
-                                  ...entry,
-                                  isLoading: false,
-                                  error: "Preview failed to render in embedded mode.",
-                                }
-                              : entry,
-                          ),
-                        );
-                      }}
-                    />
-                  </div>
-                </View>
+                <div style={{ width: "100%", height: "100%" }}>
+                    <iframe
+                      key={`${tab.id}:${tab.historyIndex}:${tab.reloadKey}`}
+                      src={tab.history[tab.historyIndex]}
+                      sandbox={PREVIEW_IFRAME_SANDBOX}
+                      style={{ width: "100%", height: "100%", border: "none" }}
+                      title={tab.title}
+                      onLoad={() => {
+                      setPreviewTabs((tabs) =>
+                        tabs.map((entry) =>
+                          entry.id === tab.id
+                            ? { ...entry, isLoading: false, error: null }
+                            : entry,
+                        ),
+                      );
+                    }}
+                    onError={() => {
+                      setPreviewTabs((tabs) =>
+                        tabs.map((entry) =>
+                          entry.id === tab.id
+                            ? {
+                                ...entry,
+                                isLoading: false,
+                                error: "Preview failed to render in embedded mode.",
+                              }
+                            : entry,
+                        ),
+                      );
+                    }}
+                  />
+                </div>
+              </View>
               );
-            })}
-          </View>
+            })
+          )}
         </View>
-      )}
+      </View>
     </View>
   );
 }
@@ -914,10 +948,6 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
-  browserTitle: {
-    fontSize: 14,
-    fontWeight: "700",
-  },
   toolbarBtn: {
     borderWidth: StyleSheet.hairlineWidth,
   },
@@ -929,63 +959,38 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     fontSize: 13,
   },
-  centerState: {
-    flex: 1,
+  inlineState: {
+    minHeight: 38,
+    flexDirection: "row",
     alignItems: "center",
-    justifyContent: "center",
     gap: 10,
   },
   stateText: {
     fontSize: 13,
   },
-  portList: {
-    padding: 14,
-    gap: 12,
+  portLauncherPage: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
   },
-  portCard: {
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 16,
-    padding: 14,
+  portStack: {
+    width: "100%",
+    maxWidth: 220,
     gap: 10,
   },
-  portHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-  },
-  portName: {
-    fontSize: 15,
-    fontWeight: "700",
-  },
-  portMeta: {
-    fontSize: 12,
-    lineHeight: 18,
-  },
-  portDescription: {
-    fontSize: 12,
-    lineHeight: 18,
-  },
-  portActions: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 8,
-  },
-  actionBtn: {
-    minHeight: 34,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
+  portButton: {
+    minHeight: 44,
+    paddingHorizontal: 18,
+    paddingVertical: 11,
     borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 10,
+    borderRadius: 12,
     flexDirection: "row",
     alignItems: "center",
-    gap: 6,
+    justifyContent: "center",
   },
-  actionText: {
-    fontSize: 12,
-    fontWeight: "600",
-  },
-  badge: {
-    fontSize: 11,
+  portButtonText: {
+    fontSize: 15,
     fontWeight: "700",
   },
   previewArea: {

--- a/apps/mobile/components/terminalUrl.ts
+++ b/apps/mobile/components/terminalUrl.ts
@@ -1,0 +1,24 @@
+/**
+ * Build the terminal WebSocket URL for the current connection.
+ *
+ * Remote auth currently passes the token as a query parameter because browser
+ * WebSocket constructors cannot set arbitrary Authorization headers (and the
+ * xterm iframe path has the same limitation). The server only accepts query
+ * tokens on WebSocket upgrade requests.
+ *
+ * Tradeoffs / leakage risk: query tokens can appear in proxy logs, browser
+ * history, and crash reports. Keep remote tokens high-entropy and short-lived
+ * where possible; prefer bearer headers for non-WebSocket HTTP APIs.
+ */
+export function buildTerminalWebSocketUrl(
+  serverUrl: string,
+  token?: string | null,
+): string {
+  const base = serverUrl.replace(/^http/i, "ws").replace(/\/+$/, "");
+  const trimmedToken = token?.trim();
+  if (!trimmedToken) {
+    return `${base}/ws/terminal`;
+  }
+
+  return `${base}/ws/terminal?token=${encodeURIComponent(trimmedToken)}`;
+}

--- a/apps/mobile/components/toolbox/ToolboxBrowser.tsx
+++ b/apps/mobile/components/toolbox/ToolboxBrowser.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback } from 'react';
-import { View, Text, Pressable, StyleSheet, Platform } from 'react-native';
-import { Globe, X, ExternalLink } from 'lucide-react-native';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { ActivityIndicator, View, Text, Pressable, StyleSheet, Platform } from 'react-native';
+import { Plus, X } from 'lucide-react-native';
 import type { WebViewProps } from 'react-native-webview';
+import type { PortEntry, PreviewSettings } from '@krusty/api';
 import * as Haptics from '../../platform/haptics';
 import { useThemeContext } from '../../hooks/useTheme';
 import { useConnection } from '../../hooks/useConnection';
@@ -16,14 +17,9 @@ if (Platform.OS !== 'web') {
   }
 }
 
-interface PortEntry {
-  port: number;
-  type: string;
-  status: string;
-}
-
 interface PreviewTab {
-  port: number;
+  id: string;
+  port: number | null;
   label: string;
 }
 
@@ -41,43 +37,139 @@ export function ToolboxBrowser({ visible }: ToolboxBrowserProps) {
 
 function NativeBrowser({ visible }: { visible: boolean }) {
   const { theme } = useThemeContext();
-  const { serverUrl } = useConnection();
+  const { client, serverUrl, serverToken } = useConnection();
   const t = theme.colors;
 
   const [ports, setPorts] = useState<PortEntry[]>([]);
+  const [settings, setSettings] = useState<PreviewSettings | null>(null);
   const [tabs, setTabs] = useState<PreviewTab[]>([]);
-  const [activePort, setActivePort] = useState<number | null>(null);
+  const [activeTabId, setActiveTabId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? null;
+
+  const previewUrl = useMemo(() => {
+    if (!serverUrl || activeTab?.port === null || activeTab?.port === undefined) {
+      return null;
+    }
+    return `${serverUrl.replace(/\/+$/, '')}/api/ports/${activeTab.port}/proxy`;
+  }, [activeTab?.port, serverUrl]);
+
+  const availablePorts = useMemo(
+    () =>
+      ports.filter(
+        (port) => port.active && port.is_previewable_http,
+      ),
+    [ports],
+  );
+
+  const loadPorts = useCallback(async (background = false) => {
+    if (!client) return;
+
+    if (background) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+
+    try {
+      const response = await client.getPorts();
+      setPorts(response.ports);
+      setSettings(response.settings);
+      setError(response.discovery_error ?? null);
+      setTabs((current) =>
+        current.map((tab) => {
+          if (tab.port === null) return tab;
+          const match = response.ports.find((port) => port.port === tab.port);
+          return match ? { ...tab, label: match.name } : tab;
+        }),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load preview ports.');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [client]);
 
   useEffect(() => {
-    if (!serverUrl || !visible) return;
-    let mounted = true;
+    if (!client || !visible) return;
 
-    const poll = async () => {
-      try {
-        const res = await fetch(`${serverUrl}/api/workspace/ports`);
-        const data = await res.json();
-        if (mounted && data.ports) setPorts(data.ports);
-      } catch { /* silent */ }
+    void loadPorts();
+    const intervalMs = Math.max(2, settings?.auto_refresh_secs ?? 5) * 1000;
+    const interval = setInterval(() => {
+      void loadPorts(true);
+    }, intervalMs);
+    return () => clearInterval(interval);
+  }, [client, loadPorts, settings?.auto_refresh_secs, visible]);
+
+  const createBlankTab = useCallback(() => {
+    const tab: PreviewTab = {
+      id: `preview-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+      port: null,
+      label: 'New Tab',
     };
-
-    poll();
-    const interval = setInterval(poll, 5000);
-    return () => { mounted = false; clearInterval(interval); };
-  }, [serverUrl, visible]);
-
-  const openPort = useCallback((port: number) => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    setTabs(prev => {
-      if (prev.some(t => t.port === port)) return prev;
-      return [...prev, { port, label: `localhost:${port}` }];
-    });
-    setActivePort(port);
+    setTabs((current) => [...current, tab]);
+    setActiveTabId(tab.id);
+    setError(null);
   }, []);
 
-  const closePort = useCallback((port: number) => {
+  useEffect(() => {
+    if (!visible || tabs.length > 0) return;
+
+    const tab: PreviewTab = {
+      id: `preview-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+      port: null,
+      label: 'New Tab',
+    };
+    setTabs([tab]);
+    setActiveTabId(tab.id);
+  }, [tabs.length, visible]);
+
+  const openPort = useCallback((port: PortEntry) => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     setTabs(prev => {
-      const next = prev.filter(t => t.port !== port);
-      setActivePort(current => current === port ? (next[0]?.port ?? null) : current);
+      if (activeTab?.port === null) {
+        return prev.map((tab) =>
+          tab.id === activeTab.id
+            ? { ...tab, port: port.port, label: port.name || `Port ${port.port}` }
+            : tab,
+        );
+      }
+
+      const tab: PreviewTab = {
+        id: `preview-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+        port: port.port,
+        label: port.name || `Port ${port.port}`,
+      };
+      setActiveTabId(tab.id);
+      return [...prev, tab];
+    });
+    if (activeTab?.port === null) {
+      setActiveTabId(activeTab.id);
+    }
+  }, [activeTab]);
+
+  const closeTab = useCallback((tabId: string) => {
+    setTabs(prev => {
+      const index = prev.findIndex((tab) => tab.id === tabId);
+      const next = prev.filter(t => t.id !== tabId);
+      if (next.length === 0) {
+        const blankTab: PreviewTab = {
+          id: `preview-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+          port: null,
+          label: 'New Tab',
+        };
+        setActiveTabId(blankTab.id);
+        return [blankTab];
+      }
+      setActiveTabId(current =>
+        current === tabId
+          ? (next[Math.max(0, index - 1)]?.id ?? next[0]?.id ?? null)
+          : current,
+      );
       return next;
     });
   }, []);
@@ -85,50 +177,78 @@ function NativeBrowser({ visible }: { visible: boolean }) {
   return (
     <View style={[styles.container, { backgroundColor: t.background }]}>
       <View style={[styles.tabBar, { borderBottomColor: t.border }]}>
-        <Globe size={16} color={t.mutedForeground} strokeWidth={1.8} />
         {tabs.map(tab => (
           <Pressable
-            key={tab.port}
-            onPress={() => setActivePort(tab.port)}
-            style={[styles.tab, activePort === tab.port && { backgroundColor: `${t.userMessage}18` }]}
+            key={tab.id}
+            onPress={() => setActiveTabId(tab.id)}
+            style={[styles.tab, activeTabId === tab.id && { backgroundColor: `${t.userMessage}18` }]}
           >
             <Text
-              style={[styles.tabLabel, { color: activePort === tab.port ? t.foreground : t.mutedForeground }]}
+              style={[styles.tabLabel, { color: activeTabId === tab.id ? t.foreground : t.mutedForeground }]}
               numberOfLines={1}
             >
               {tab.label}
             </Text>
-            <Pressable onPress={() => closePort(tab.port)} hitSlop={8}>
+            <Pressable onPress={() => closeTab(tab.id)} hitSlop={8}>
               <X size={12} color={t.mutedForeground} strokeWidth={2} />
             </Pressable>
           </Pressable>
         ))}
-        {ports
-          .filter(p => p.status === 'ok' && !tabs.some(t => t.port === p.port))
-          .map(p => (
-            <Pressable key={p.port} onPress={() => openPort(p.port)} style={styles.portChip}>
-              <Text style={[styles.portChipText, { color: t.mutedForeground }]}>:{p.port}</Text>
-              <ExternalLink size={10} color={t.mutedForeground} strokeWidth={2} />
-            </Pressable>
-          ))}
+        <Pressable onPress={createBlankTab} style={styles.iconBtn}>
+          <Plus size={16} color={t.mutedForeground} strokeWidth={2} />
+        </Pressable>
+        <View style={styles.grow} />
+        {refreshing ? <ActivityIndicator color={t.userMessage} size="small" /> : null}
       </View>
 
       <View style={styles.previewArea}>
-        {activePort && visible && WebViewComponent ? (
+        {previewUrl && visible && WebViewComponent ? (
           <WebViewComponent
-            key={activePort}
-            source={{ uri: `http://localhost:${activePort}` }}
+            key={activeTab?.id}
+            source={{
+              uri: previewUrl,
+              headers: serverToken ? { Authorization: `Bearer ${serverToken}` } : undefined,
+            }}
             style={{ flex: 1 }}
             originWhitelist={['*']}
             javaScriptEnabled
             domStorageEnabled
           />
         ) : (
-          <View style={styles.empty}>
-            <Globe size={32} color={t.mutedForeground} strokeWidth={1.5} />
-            <Text style={[styles.emptyText, { color: t.mutedForeground }]}>
-              {!visible ? '' : ports.length > 0 ? 'Select a port to preview' : 'No dev servers detected'}
-            </Text>
+          <View style={styles.quickPage}>
+            {loading ? (
+              <>
+                <ActivityIndicator color={t.userMessage} size="small" />
+                <Text style={[styles.emptyText, { color: t.mutedForeground }]}>
+                  Loading preview ports...
+                </Text>
+              </>
+            ) : availablePorts.length > 0 ? (
+              <View style={styles.portStack}>
+                {availablePorts.map((port) => (
+                  <Pressable
+                    key={port.port}
+                    onPress={() => openPort(port)}
+                    style={[
+                      styles.portButton,
+                      { backgroundColor: t.card, borderColor: t.border },
+                    ]}
+                  >
+                    <Text style={[styles.portButtonText, { color: t.foreground }]}>
+                      :{port.port}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            ) : (
+              <Text style={[styles.emptyText, { color: t.mutedForeground }]}>
+                {!visible
+                  ? ''
+                  : error
+                    ? error
+                    : 'No previewable ports are active right now.'}
+              </Text>
+            )}
           </View>
         )}
       </View>
@@ -149,6 +269,9 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
     flexWrap: 'wrap',
   },
+  grow: {
+    flex: 1,
+  },
   tab: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -162,30 +285,40 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     maxWidth: 120,
   },
-  portChip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 4,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: 'rgba(255,255,255,0.1)',
-  },
-  portChipText: {
-    fontSize: 11,
-    fontWeight: '500',
+  iconBtn: {
+    padding: 6,
+    borderRadius: 8,
   },
   previewArea: {
     flex: 1,
   },
-  empty: {
+  quickPage: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     gap: 12,
+    padding: 24,
   },
   emptyText: {
     fontSize: 14,
+  },
+  portStack: {
+    width: '100%',
+    maxWidth: 220,
+    gap: 10,
+  },
+  portButton: {
+    minHeight: 44,
+    paddingHorizontal: 18,
+    paddingVertical: 11,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  portButtonText: {
+    fontSize: 15,
+    fontWeight: '700',
   },
 });

--- a/apps/mobile/components/toolbox/ToolboxTerminal.tsx
+++ b/apps/mobile/components/toolbox/ToolboxTerminal.tsx
@@ -6,6 +6,7 @@ import * as Haptics from '../../platform/haptics';
 import { useThemeContext } from '../../hooks/useTheme';
 import { useConnection } from '../../hooks/useConnection';
 import { Terminal } from '../desktop/Terminal';
+import { buildTerminalWebSocketUrl } from '../terminalUrl';
 import { getTerminalHtml } from './terminalHtml';
 
 let WebViewComponent: React.ComponentType<WebViewProps> | null = null;
@@ -36,27 +37,19 @@ interface NativeTerminalTab {
 
 function NativeTerminal({ visible }: { visible: boolean }) {
   const { theme } = useThemeContext();
-  const { client, serverUrl } = useConnection();
+  const { serverUrl, serverToken } = useConnection();
   const t = theme.colors;
 
   const [tabs, setTabs] = useState<NativeTerminalTab[]>([]);
   const [activeTab, setActiveTab] = useState<string | null>(null);
 
-  const createTab = useCallback(async () => {
-    if (!client || !serverUrl) return;
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    try {
-      const response = await fetch(`${serverUrl}/api/terminal`, { method: 'POST' });
-      const data = await response.json();
-      const id = data.id || `term-${Date.now()}`;
-      setTabs(prev => [...prev, { id, label: `Terminal ${prev.length + 1}` }]);
-      setActiveTab(id);
-    } catch {
-      const id = `term-${Date.now()}`;
-      setTabs(prev => [...prev, { id, label: `Terminal ${prev.length + 1}` }]);
-      setActiveTab(id);
-    }
-  }, [client, serverUrl]);
+  const createTab = useCallback(() => {
+    if (!serverUrl) return;
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    const id = createTerminalId();
+    setTabs(prev => [...prev, { id, label: `Terminal ${prev.length + 1}` }]);
+    setActiveTab(id);
+  }, [serverUrl]);
 
   const closeTab = useCallback((id: string) => {
     setTabs(prev => {
@@ -67,13 +60,13 @@ function NativeTerminal({ visible }: { visible: boolean }) {
   }, []);
 
   useEffect(() => {
-    if (visible && tabs.length === 0 && client) {
+    if (visible && tabs.length === 0 && serverUrl) {
       createTab();
     }
-  }, [visible, client, createTab, tabs.length]);
+  }, [visible, createTab, serverUrl, tabs.length]);
 
   const wsUrl = serverUrl && activeTab
-    ? serverUrl.replace(/^http/, 'ws') + `/api/terminal/${activeTab}/ws`
+    ? buildTerminalWebSocketUrl(serverUrl, serverToken)
     : '';
 
   const html = activeTab
@@ -87,7 +80,6 @@ function NativeTerminal({ visible }: { visible: boolean }) {
   return (
     <View style={[styles.container, { backgroundColor: t.background }]}>
       <View style={[styles.tabBar, { borderBottomColor: t.border }]}>
-        <TerminalSquare size={16} color={t.mutedForeground} strokeWidth={1.8} />
         {tabs.map(tab => (
           <Pressable
             key={tab.id}
@@ -124,7 +116,13 @@ function NativeTerminal({ visible }: { visible: boolean }) {
           <View style={styles.empty}>
             <TerminalSquare size={32} color={t.mutedForeground} strokeWidth={1.5} />
             <Text style={[styles.emptyText, { color: t.mutedForeground }]}>
-              {!WebViewComponent ? 'WebView not available' : !visible ? '' : 'No terminal open'}
+              {!WebViewComponent
+                ? 'WebView not available'
+                : !serverUrl
+                  ? 'Connect to a server to open a terminal.'
+                  : !visible
+                    ? ''
+                    : 'No terminal open'}
             </Text>
           </View>
         )}
@@ -174,3 +172,11 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
 });
+
+function createTerminalId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `term-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/apps/mobile/components/toolbox/terminalHtml.ts
+++ b/apps/mobile/components/toolbox/terminalHtml.ts
@@ -5,13 +5,18 @@ interface TerminalTheme {
 }
 
 export function getTerminalHtml(wsUrl: string, theme: TerminalTheme): string {
+  const wsUrlJson = JSON.stringify(wsUrl);
+  const backgroundJson = JSON.stringify(theme.background);
+  const foregroundJson = JSON.stringify(theme.foreground);
+  const cursorJson = JSON.stringify(theme.cursor);
+
   return `<!DOCTYPE html>
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.min.css">
   <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.11.0/lib/addon-fit.min.js"></script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html, body { width: 100%; height: 100%; overflow: hidden; background: ${theme.background}; }
@@ -28,9 +33,9 @@ export function getTerminalHtml(wsUrl: string, theme: TerminalTheme): string {
         fontSize: 13,
         fontFamily: 'Menlo, Monaco, monospace',
         theme: {
-          background: '${theme.background}',
-          foreground: '${theme.foreground}',
-          cursor: '${theme.cursor}',
+          background: ${backgroundJson},
+          foreground: ${foregroundJson},
+          cursor: ${cursorJson},
         },
         allowProposedApi: true,
       });
@@ -40,31 +45,73 @@ export function getTerminalHtml(wsUrl: string, theme: TerminalTheme): string {
       term.open(document.getElementById('terminal'));
       fitAddon.fit();
 
-      var ws = new WebSocket('${wsUrl}');
+      var ws = new WebSocket(${wsUrlJson});
+      var heartbeat = null;
+
+      function sendJson(payload) {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify(payload));
+        }
+      }
+
+      function sendResize() {
+        sendJson({ type: 'resize', cols: term.cols, rows: term.rows });
+      }
 
       ws.onopen = function() {
         fitAddon.fit();
+        sendJson({ type: 'hello', binary_output: false });
+        sendResize();
+        heartbeat = setInterval(function() {
+          sendJson({ type: 'ping' });
+        }, 15000);
       };
 
       ws.onmessage = function(event) {
-        term.write(typeof event.data === 'string' ? event.data : new Uint8Array(event.data));
+        if (typeof event.data !== 'string') {
+          term.write(new Uint8Array(event.data));
+          return;
+        }
+
+        try {
+          var message = JSON.parse(event.data);
+          if (message.type === 'output' && typeof message.data === 'string') {
+            term.write(message.data);
+            return;
+          }
+          if (message.type === 'error' && typeof message.error === 'string') {
+            term.write('\\r\\n' + message.error + '\\r\\n');
+            return;
+          }
+          if (message.type === 'pong') {
+            return;
+          }
+        } catch (error) {
+          term.write(event.data);
+          return;
+        }
       };
 
       ws.onclose = function() {
+        if (heartbeat) {
+          clearInterval(heartbeat);
+          heartbeat = null;
+        }
         term.write('\\r\\n[Connection closed]\\r\\n');
       };
 
       term.onData(function(data) {
-        if (ws.readyState === WebSocket.OPEN) ws.send(data);
+        sendJson({ type: 'input', data: data });
       });
 
       term.onResize(function(size) {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: 'resize', cols: size.cols, rows: size.rows }));
-        }
+        sendJson({ type: 'resize', cols: size.cols, rows: size.rows });
       });
 
-      window.addEventListener('resize', function() { fitAddon.fit(); });
+      window.addEventListener('resize', function() {
+        fitAddon.fit();
+        sendResize();
+      });
 
       window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'ready' }));
     })();

--- a/apps/mobile/hooks/useConnection.tsx
+++ b/apps/mobile/hooks/useConnection.tsx
@@ -11,6 +11,7 @@ interface ConnectionContextValue {
   isConnected: boolean;
   isConfigured: boolean;
   serverUrl: string | null;
+  serverToken: string | null;
   error: string | null;
   connect: (url: string, token: string) => Promise<boolean>;
   disconnect: () => void;
@@ -23,6 +24,7 @@ const ConnectionContext = createContext<ConnectionContextValue>({
   isConnected: false,
   isConfigured: false,
   serverUrl: null,
+  serverToken: null,
   error: null,
   connect: async () => false,
   disconnect: () => {},
@@ -38,6 +40,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   const [client, setClient] = useState<KrustyClient | null>(null);
   const [status, setStatus] = useState<ConnectionStatus>('disconnected');
   const [serverUrl, setServerUrl] = useState<string | null>(null);
+  const [serverToken, setServerToken] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isConfigured, setIsConfigured] = useState(false);
   const [loaded, setLoaded] = useState(false);
@@ -77,6 +80,8 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
       // Verify connection with health check
       const healthy = await newClient.checkHealth();
       if (!healthy) {
+        setClient(null);
+        setServerToken(null);
         setStatus('error');
         setError('Server not reachable');
         return false;
@@ -85,6 +90,8 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
       // Bootstrap remote auth
       const authed = await newClient.bootstrapAuth();
       if (!authed) {
+        setClient(null);
+        setServerToken(null);
         setStatus('error');
         setError('Authentication failed — check your token');
         return false;
@@ -92,9 +99,12 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
 
       setClient(newClient);
       setServerUrl(url);
+      setServerToken(token);
       setStatus('connected');
       return true;
     } catch (err) {
+      setClient(null);
+      setServerToken(null);
       setStatus('error');
       setError(err instanceof Error ? err.message : 'Connection failed');
       return false;
@@ -115,6 +125,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
     setClient(null);
     setStatus('disconnected');
     setServerUrl(null);
+    setServerToken(null);
     setError(null);
     SecureStore.deleteItemAsync(STORAGE_KEYS.serverUrl);
     SecureStore.deleteItemAsync(STORAGE_KEYS.serverToken);
@@ -139,6 +150,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
         isConnected: status === 'connected',
         isConfigured,
         serverUrl,
+        serverToken,
         error,
         connect,
         disconnect,

--- a/crates/krusty-cli/Cargo.toml
+++ b/crates/krusty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "The most elegant coding CLI to ever exist"
 default-run = "krusty"

--- a/crates/krusty-cli/src/tui/app/lifecycle.rs
+++ b/crates/krusty-cli/src/tui/app/lifecycle.rs
@@ -60,14 +60,10 @@ impl App {
         // Check for updates in background
         self.start_update_check();
 
-        // Start background refresh of OpenRouter models if configured and cache is stale
-        if self.should_refresh_dynamic_models(self.runtime.active_provider) {
-            tracing::info!(
-                "Starting background {:?} model refresh",
-                self.runtime.active_provider
-            );
-            self.start_dynamic_model_fetch(self.runtime.active_provider);
-        }
+        // Refresh all dynamic catalogs (OpenRouter, OpenAI, Grok, …) that have
+        // credentials and a stale/missing cache — same policy as server bootstrap.
+        tracing::info!("Starting background dynamic model catalog refresh");
+        self.refresh_stale_dynamic_model_catalogs();
 
         enable_raw_mode()?;
         let mut stdout = io::stdout();

--- a/crates/krusty-cli/src/tui/app_builder.rs
+++ b/crates/krusty-cli/src/tui/app_builder.rs
@@ -285,9 +285,10 @@ fn init_model_registry(preferences: &Option<Preferences>) -> SharedModelRegistry
     }
     tracing::info!("Model registry initialized with static models");
 
-    // Load cached models for dynamic providers
+    // Load cached models for all dynamic providers (OpenRouter, OpenAI, Grok, …)
+    // so CLI model select matches server catalogs across restarts.
     if let Some(ref prefs) = preferences {
-        for provider in [ProviderId::OpenRouter, ProviderId::OpenAI] {
+        for provider in krusty_core::ai::catalog::dynamic_model_providers() {
             if let Some(cached_models) = prefs.get_cached_models(provider) {
                 futures::executor::block_on(
                     model_registry.set_models(provider, cached_models.clone()),

--- a/crates/krusty-cli/src/tui/handlers/commands/ui.rs
+++ b/crates/krusty-cli/src/tui/handlers/commands/ui.rs
@@ -51,11 +51,9 @@ impl App {
 
         self.ui.popup = Popup::ModelSelect;
 
-        if configured.contains(&self.runtime.active_provider)
-            && self.should_refresh_dynamic_models(self.runtime.active_provider)
-        {
-            self.start_dynamic_model_fetch(self.runtime.active_provider);
-        }
+        // Refresh every dynamic provider with credentials so the picker matches
+        // the server model list, not only the currently active provider.
+        self.refresh_stale_dynamic_model_catalogs();
     }
 
     pub(super) fn open_auth_popup(&mut self) {

--- a/crates/krusty-cli/src/tui/handlers/event_loop.rs
+++ b/crates/krusty-cli/src/tui/handlers/event_loop.rs
@@ -115,6 +115,11 @@ impl App {
                 PollAction::SwitchProvider(provider) => {
                     self.switch_provider(provider);
                 }
+                PollAction::RefreshDynamicModels(provider) => {
+                    // Force a refresh after new credentials (ignore cache freshness).
+                    self.runtime.dynamic_model_fetches.remove(&provider);
+                    self.start_dynamic_model_fetch(provider);
+                }
             }
         }
     }

--- a/crates/krusty-cli/src/tui/handlers/models.rs
+++ b/crates/krusty-cli/src/tui/handlers/models.rs
@@ -1,6 +1,11 @@
 //! Model fetching handlers
 //!
-//! Async model fetching from dynamic providers such as OpenRouter and OpenAI.
+//! Async model fetching from dynamic providers (OpenRouter, OpenAI, Grok, …).
+//! Catalog refresh is aligned with the server: any provider with live models
+//! and valid catalog credentials can be refreshed, including concurrently.
+//!
+//! Registry mutations happen on the async fetch tasks — never `block_on` on the
+//! TUI poll path — so model refresh cannot hitch the terminal event loop.
 
 use crate::ai::client::CallOptions;
 use crate::ai::models::ModelMetadata;
@@ -30,8 +35,11 @@ impl App {
         });
 
         let registry = self.services.model_registry.clone();
+        let metadata_for_registry = metadata.clone();
+        // User-initiated selection can afford a short sync apply; still avoid
+        // holding locks across the whole UI frame by spawning when possible.
         futures::executor::block_on(async {
-            registry.upsert_model(metadata.clone()).await;
+            registry.upsert_model(metadata_for_registry).await;
             registry.mark_recent(&model_id).await;
         });
 
@@ -65,13 +73,29 @@ impl App {
         Some(self.runtime.fast_mode)
     }
 
+    /// Refresh every dynamic provider that has catalog credentials and a stale cache.
+    ///
+    /// Mirrors server `initialize_models` so CLI and server model pickers stay aligned.
+    pub fn refresh_stale_dynamic_model_catalogs(&mut self) {
+        for provider in crate::ai::catalog::dynamic_model_providers() {
+            if !self.should_refresh_dynamic_models(provider) {
+                continue;
+            }
+            if crate::ai::catalog::credential_for_dynamic_models(
+                provider,
+                &self.services.credential_store,
+            )
+            .is_none()
+            {
+                continue;
+            }
+            self.start_dynamic_model_fetch(provider);
+        }
+    }
+
     /// Start async fetch of models for a dynamic provider.
     pub fn start_dynamic_model_fetch(&mut self, provider: ProviderId) {
         if !crate::ai::catalog::supports_dynamic_models(provider) {
-            return;
-        }
-
-        if self.runtime.channels.dynamic_models.is_some() {
             return;
         }
 
@@ -93,21 +117,31 @@ impl App {
             return;
         };
 
+        let custom_models = self
+            .services
+            .preferences
+            .as_ref()
+            .map(|prefs| prefs.get_custom_models(provider))
+            .unwrap_or_default();
+
+        let tx = self.ensure_dynamic_model_tx();
         self.ui.popups.model.set_loading(true);
 
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        self.runtime.channels.dynamic_models = Some(rx);
-
         let registry = self.services.model_registry.clone();
-
         tokio::spawn(async move {
             let result = crate::ai::catalog::fetch_dynamic_models(provider, &credential).await;
 
-            if let Ok(models) = &result {
-                registry.set_models(provider, models.clone()).await;
-                tracing::info!("Fetched {} {:?} models", models.len(), provider);
-            } else if let Err(error) = &result {
-                tracing::error!("Failed to fetch {:?} models: {}", provider, error);
+            match &result {
+                Ok(models) => {
+                    registry.set_models(provider, models.clone()).await;
+                    for metadata in custom_models {
+                        registry.upsert_model(metadata).await;
+                    }
+                    tracing::info!("Fetched {} {:?} models", models.len(), provider);
+                }
+                Err(error) => {
+                    tracing::error!("Failed to fetch {:?} models: {}", provider, error);
+                }
             }
 
             let _ = tx.send(DynamicModelUpdate {
@@ -117,32 +151,77 @@ impl App {
         });
     }
 
+    fn ensure_dynamic_model_tx(
+        &mut self,
+    ) -> tokio::sync::mpsc::UnboundedSender<DynamicModelUpdate> {
+        if let Some(tx) = &self.runtime.channels.dynamic_models_tx {
+            return tx.clone();
+        }
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        self.runtime.channels.dynamic_models = Some(rx);
+        self.runtime.channels.dynamic_models_tx = Some(tx.clone());
+        tx
+    }
+
     /// Poll for dynamic model fetch completion.
     pub fn poll_dynamic_model_fetch(&mut self) {
         let Some(rx) = &mut self.runtime.channels.dynamic_models else {
             return;
         };
 
-        match rx.try_recv() {
-            Ok(update) => {
-                self.runtime.dynamic_model_fetches.remove(&update.provider);
-                match update.result {
-                    Ok(models) => {
-                        self.cache_dynamic_models(update.provider, &models);
-                        self.reapply_custom_models(update.provider);
-                        self.refresh_model_popup();
-                    }
-                    Err(error) => {
-                        self.ui.popups.model.set_error(error);
-                    }
+        let mut received = Vec::new();
+        loop {
+            match rx.try_recv() {
+                Ok(update) => received.push(update),
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                    self.runtime.dynamic_model_fetches.clear();
+                    self.runtime.channels.dynamic_models = None;
+                    self.runtime.channels.dynamic_models_tx = None;
+                    self.ui.popups.model.set_loading(false);
+                    return;
                 }
-                self.runtime.channels.dynamic_models = None;
             }
-            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {}
-            Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
-                self.runtime.dynamic_model_fetches.clear();
-                self.runtime.channels.dynamic_models = None;
+        }
+
+        if received.is_empty() {
+            return;
+        }
+
+        let mut any_success = false;
+        let mut last_error: Option<String> = None;
+
+        for update in received {
+            self.runtime.dynamic_model_fetches.remove(&update.provider);
+            match update.result {
+                Ok(models) => {
+                    // Registry already updated on the async task — only cache + UI here.
+                    self.cache_dynamic_models(update.provider, &models);
+                    any_success = true;
+                }
+                Err(error) => {
+                    last_error = Some(format!("{:?}: {error}", update.provider));
+                }
             }
+        }
+
+        if any_success {
+            self.refresh_model_popup();
+        }
+
+        if self.runtime.dynamic_model_fetches.is_empty() {
+            self.ui.popups.model.set_loading(false);
+            if let Some(error) = last_error {
+                if !any_success {
+                    self.ui.popups.model.set_error(error);
+                } else {
+                    tracing::warn!("Partial dynamic model refresh failure: {error}");
+                }
+            }
+            // Drop channel halves when idle so the next refresh recreates cleanly.
+            self.runtime.channels.dynamic_models = None;
+            self.runtime.channels.dynamic_models_tx = None;
         }
     }
 
@@ -154,24 +233,6 @@ impl App {
         if let Err(error) = prefs.cache_models(provider, models) {
             tracing::warn!("Failed to cache {:?} models: {}", provider, error);
         }
-    }
-
-    fn reapply_custom_models(&self, provider: ProviderId) {
-        let Some(ref prefs) = self.services.preferences else {
-            return;
-        };
-
-        let custom_models = prefs.get_custom_models(provider);
-        if custom_models.is_empty() {
-            return;
-        }
-
-        let registry = self.services.model_registry.clone();
-        futures::executor::block_on(async move {
-            for metadata in custom_models {
-                registry.upsert_model(metadata).await;
-            }
-        });
     }
 
     pub fn should_refresh_dynamic_models(&self, provider: ProviderId) -> bool {

--- a/crates/krusty-cli/src/tui/polling/mod.rs
+++ b/crates/krusty-cli/src/tui/polling/mod.rs
@@ -44,6 +44,8 @@ pub enum PollAction {
     RefreshAiTools,
     /// Switch to a provider (after OAuth success)
     SwitchProvider(ProviderId),
+    /// Refresh live model catalog for a provider after credentials change
+    RefreshDynamicModels(ProviderId),
 }
 
 impl PollResult {

--- a/crates/krusty-cli/src/tui/polling/oauth.rs
+++ b/crates/krusty-cli/src/tui/polling/oauth.rs
@@ -55,6 +55,14 @@ pub fn poll_oauth_status(
                                     result.with_action(PollAction::SwitchProvider(update.provider));
                             }
 
+                            // Reload live model catalogs after OAuth (Grok, OpenAI, …)
+                            // so CLI model select matches the server path.
+                            if crate::ai::catalog::supports_dynamic_models(update.provider) {
+                                result = result.with_action(PollAction::RefreshDynamicModels(
+                                    update.provider,
+                                ));
+                            }
+
                             result = result.with_message(
                                 "system",
                                 format!("{} authenticated via OAuth!", update.provider),

--- a/crates/krusty-cli/src/tui/polling/oauth.rs
+++ b/crates/krusty-cli/src/tui/polling/oauth.rs
@@ -58,9 +58,8 @@ pub fn poll_oauth_status(
                             // Reload live model catalogs after OAuth (Grok, OpenAI, …)
                             // so CLI model select matches the server path.
                             if crate::ai::catalog::supports_dynamic_models(update.provider) {
-                                result = result.with_action(PollAction::RefreshDynamicModels(
-                                    update.provider,
-                                ));
+                                result = result
+                                    .with_action(PollAction::RefreshDynamicModels(update.provider));
                             }
 
                             result = result.with_message(

--- a/crates/krusty-cli/src/tui/utils/channels.rs
+++ b/crates/krusty-cli/src/tui/utils/channels.rs
@@ -85,8 +85,12 @@ pub struct AsyncChannels {
     pub explore_progress: Option<mpsc::Receiver<AgentProgress>>,
     /// Build tool builder agent progress updates (bounded for backpressure)
     pub build_progress: Option<mpsc::Receiver<AgentProgress>>,
-    /// Dynamic provider model fetch result receiver
-    pub dynamic_models: Option<oneshot::Receiver<DynamicModelUpdate>>,
+    /// Dynamic provider model fetch results (supports concurrent provider refreshes).
+    /// Unbounded is intentional: refreshes are rare (startup/OAuth/model popup) and
+    /// coalesced by `dynamic_model_fetches` so only one in-flight fetch per provider.
+    pub dynamic_models: Option<mpsc::UnboundedReceiver<DynamicModelUpdate>>,
+    /// Sender half for concurrent dynamic model fetches
+    pub dynamic_models_tx: Option<mpsc::UnboundedSender<DynamicModelUpdate>>,
     /// /init codebase exploration result receiver
     pub init_exploration: Option<oneshot::Receiver<InitExplorationResult>>,
     /// /init exploration progress updates

--- a/crates/krusty-client-state/Cargo.toml
+++ b/crates/krusty-client-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client-state"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Headless Rust state machine for Krusty chat clients"
 

--- a/crates/krusty-client/Cargo.toml
+++ b/crates/krusty-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Async Rust client for the Krusty server API"
 

--- a/crates/krusty-core/Cargo.toml
+++ b/crates/krusty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-core"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Core library for Krusty - AI, storage, tools, and extensions"
 

--- a/crates/krusty-core/src/ai/catalog.rs
+++ b/crates/krusty-core/src/ai/catalog.rs
@@ -14,6 +14,18 @@ pub fn supports_dynamic_models(provider: ProviderId) -> bool {
         .unwrap_or(false)
 }
 
+/// Providers that expose a live `/models` (or equivalent) catalog at runtime.
+///
+/// Used by CLI and server so catalog bootstrap, cache restore, and refresh
+/// stay aligned across surfaces.
+pub fn dynamic_model_providers() -> Vec<ProviderId> {
+    ProviderId::all()
+        .iter()
+        .copied()
+        .filter(|provider| supports_dynamic_models(*provider))
+        .collect()
+}
+
 /// Resolve the credential that is valid for runtime model discovery.
 ///
 /// This intentionally differs from chat auth resolution. For example, OpenAI's
@@ -107,5 +119,15 @@ mod tests {
             });
 
         assert!(credential.is_none());
+    }
+
+    #[test]
+    fn dynamic_model_providers_includes_openrouter_openai_and_grok() {
+        let providers = crate::ai::catalog::dynamic_model_providers();
+        assert!(providers.contains(&ProviderId::OpenRouter));
+        assert!(providers.contains(&ProviderId::OpenAI));
+        assert!(providers.contains(&ProviderId::Grok));
+        assert!(!providers.contains(&ProviderId::MiniMax));
+        assert!(!providers.contains(&ProviderId::Anthropic));
     }
 }

--- a/crates/krusty-desktop/Cargo.toml
+++ b/crates/krusty-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-desktop"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Native GPUI desktop workspace for Krusty"
 default-run = "krusty-desktop"

--- a/crates/krusty-mobile-ui/Cargo.toml
+++ b/crates/krusty-mobile-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-mobile-ui"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Lightweight GPUI mobile primitives for Krusty"
 

--- a/crates/krusty-mobile/Cargo.toml
+++ b/crates/krusty-mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-mobile"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Native GPUI mobile preview client for Krusty"
 default-run = "krusty-mobile"

--- a/crates/krusty-server/Cargo.toml
+++ b/crates/krusty-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-server"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Self-hosted Krusty API server library"
 

--- a/crates/krusty-server/src/ai_bootstrap.rs
+++ b/crates/krusty-server/src/ai_bootstrap.rs
@@ -320,7 +320,7 @@ pub async fn initialize_models(registry: &SharedModelRegistry, credentials: &Cre
         registry.set_models(provider.id, models).await;
     }
 
-    for provider in [ProviderId::OpenRouter, ProviderId::OpenAI, ProviderId::Grok] {
+    for provider in krusty_core::ai::catalog::dynamic_model_providers() {
         let Some(credential) =
             krusty_core::ai::catalog::credential_for_dynamic_models(provider, credentials)
         else {

--- a/crates/krusty-server/src/auth.rs
+++ b/crates/krusty-server/src/auth.rs
@@ -7,7 +7,7 @@
 use axum::{
     async_trait,
     extract::{ConnectInfo, FromRequestParts, Request, State},
-    http::{header, request::Parts, HeaderMap, StatusCode},
+    http::{header, request::Parts, HeaderMap, StatusCode, Uri},
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -60,7 +60,9 @@ pub async fn auth_middleware(
     mut request: Request,
     next: Next,
 ) -> Response {
-    if let Err(rejection) = authorize_request_surface(&state, addr, request.headers()).await {
+    if let Err(rejection) =
+        authorize_request_surface(&state, addr, request.headers(), request.uri()).await
+    {
         tracing::warn!(
             remote_ip = %addr.ip(),
             "Rejected non-loopback API request"
@@ -95,6 +97,7 @@ async fn authorize_request_surface(
     state: &AppState,
     addr: SocketAddr,
     headers: &HeaderMap,
+    uri: &Uri,
 ) -> Result<(), (StatusCode, &'static str)> {
     let host = headers
         .get(header::HOST)
@@ -104,7 +107,7 @@ async fn authorize_request_surface(
     if addr.ip().is_loopback() && is_local_host(host) {
         authorize_local_browser_origin(headers)
     } else {
-        authorize_remote_request(state, headers).await
+        authorize_remote_request(state, headers, uri).await
     }
 }
 
@@ -129,6 +132,7 @@ fn authorize_local_browser_origin(headers: &HeaderMap) -> Result<(), (StatusCode
 async fn authorize_remote_request(
     state: &AppState,
     headers: &HeaderMap,
+    uri: &Uri,
 ) -> Result<(), (StatusCode, &'static str)> {
     let remote_access = state.remote_access.read().await.clone();
     if !remote_access.enabled {
@@ -138,7 +142,11 @@ async fn authorize_remote_request(
         ));
     }
 
-    let Some(provided_token) = bearer_token(headers) else {
+    let provided_token = bearer_token(headers)
+        .map(str::to_owned)
+        .or_else(|| websocket_query_token(headers, uri));
+
+    let Some(provided_token) = provided_token else {
         return Err((
             StatusCode::UNAUTHORIZED,
             "Remote API access requires a valid bearer token",
@@ -153,6 +161,83 @@ async fn authorize_remote_request(
             "Remote API access requires a valid bearer token",
         ))
     }
+}
+
+/// Extract a remote-access token from the WebSocket upgrade query string.
+///
+/// Browser WebSocket clients cannot set arbitrary Authorization headers, so the
+/// terminal UI passes `?token=` (URL-encoded). Values are percent-decoded before
+/// comparison so tokens containing `+`, `/`, `=`, etc. survive `encodeURIComponent`.
+///
+/// Only honored on WebSocket upgrades — never on ordinary HTTP requests — to
+/// reduce accidental leakage of tokens via shared query-parameter auth.
+fn websocket_query_token(headers: &HeaderMap, uri: &Uri) -> Option<String> {
+    if !is_websocket_upgrade(headers) {
+        return None;
+    }
+
+    uri.query()?.split('&').find_map(|part| {
+        let (key, value) = part.split_once('=')?;
+        if key != "token" {
+            return None;
+        }
+        let decoded = percent_decode_query_component(value)?;
+        let trimmed = decoded.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+/// Percent-decode a single application/x-www-form-urlencoded query component.
+///
+/// Handles `%XX` escapes and `+` as space (common form encoding). Returns `None`
+/// on malformed sequences so we never accept a half-decoded token.
+fn percent_decode_query_component(input: &str) -> Option<String> {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' => {
+                if i + 2 >= bytes.len() {
+                    return None;
+                }
+                let hi = (bytes[i + 1] as char).to_digit(16)?;
+                let lo = (bytes[i + 2] as char).to_digit(16)?;
+                out.push(((hi << 4) | lo) as u8);
+                i += 3;
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
+fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
+    let upgrade = headers
+        .get(header::UPGRADE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("websocket"));
+    let connection = headers
+        .get(header::CONNECTION)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value
+                .split(',')
+                .any(|part| part.trim().eq_ignore_ascii_case("upgrade"))
+        });
+
+    upgrade && connection
 }
 
 fn bearer_token(headers: &HeaderMap) -> Option<&str> {
@@ -228,7 +313,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::{atomic::AtomicUsize, Arc};
 
-    use axum::http::{header, HeaderMap, HeaderValue};
+    use axum::http::{header, HeaderMap, HeaderValue, Uri};
     use tokio::sync::{Mutex, RwLock};
 
     use krusty_core::agent::{AgentCancellation, UserHookManager};
@@ -240,7 +325,8 @@ mod tests {
     use krusty_core::tools::registry::ToolRegistry;
 
     use super::{
-        authorize_request_surface, is_local_host, is_trusted_local_origin, resolve_workspace_dir,
+        authorize_request_surface, is_local_host, is_trusted_local_origin,
+        percent_decode_query_component, resolve_workspace_dir,
     };
     use crate::{remote_access::RemoteAccessConfig, AppState};
 
@@ -333,7 +419,8 @@ mod tests {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 8)), 3000);
         let headers = HeaderMap::new();
 
-        let result = authorize_request_surface(&state, addr, &headers).await;
+        let uri = Uri::from_static("/api/sessions");
+        let result = authorize_request_surface(&state, addr, &headers, &uri).await;
         assert!(result.is_err());
     }
 
@@ -347,8 +434,72 @@ mod tests {
             HeaderValue::from_static("Bearer secret"),
         );
 
-        let result = authorize_request_surface(&state, addr, &headers).await;
+        let uri = Uri::from_static("/api/sessions");
+        let result = authorize_request_surface(&state, addr, &headers, &uri).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn authorize_request_surface_accepts_remote_websocket_query_token() {
+        let state = test_state();
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 8)), 3000);
+        let mut headers = HeaderMap::new();
+        headers.insert(header::UPGRADE, HeaderValue::from_static("websocket"));
+        headers.insert(header::CONNECTION, HeaderValue::from_static("Upgrade"));
+        let uri = Uri::from_static("/ws/terminal?token=secret");
+
+        let result = authorize_request_surface(&state, addr, &headers, &uri).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn authorize_request_surface_accepts_url_encoded_websocket_query_token() {
+        // Token "a+b/c=d" encodes as a%2Bb%2Fc%3Dd via encodeURIComponent.
+        let state = {
+            let mut state = test_state();
+            state.remote_access = Arc::new(RwLock::new(RemoteAccessConfig {
+                enabled: true,
+                token: "a+b/c=d".to_string(),
+            }));
+            state
+        };
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 8)), 3000);
+        let mut headers = HeaderMap::new();
+        headers.insert(header::UPGRADE, HeaderValue::from_static("websocket"));
+        headers.insert(header::CONNECTION, HeaderValue::from_static("Upgrade"));
+        let uri = Uri::from_static("/ws/terminal?token=a%2Bb%2Fc%3Dd");
+
+        let result = authorize_request_surface(&state, addr, &headers, &uri).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn percent_decode_query_component_handles_reserved_chars() {
+        assert_eq!(
+            percent_decode_query_component("a%2Bb%2Fc%3Dd").as_deref(),
+            Some("a+b/c=d")
+        );
+        assert_eq!(
+            percent_decode_query_component("hello%20world").as_deref(),
+            Some("hello world")
+        );
+        assert_eq!(
+            percent_decode_query_component("plus+space").as_deref(),
+            Some("plus space")
+        );
+        assert!(percent_decode_query_component("%zz").is_none());
+        assert!(percent_decode_query_component("%2").is_none());
+    }
+
+    #[tokio::test]
+    async fn authorize_request_surface_rejects_remote_query_token_without_websocket_upgrade() {
+        let state = test_state();
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 8)), 3000);
+        let headers = HeaderMap::new();
+        let uri = Uri::from_static("/api/sessions?token=secret");
+
+        let result = authorize_request_surface(&state, addr, &headers, &uri).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]
@@ -362,7 +513,8 @@ mod tests {
             HeaderValue::from_static("https://evil.example"),
         );
 
-        let result = authorize_request_surface(&state, addr, &headers).await;
+        let uri = Uri::from_static("/api/sessions");
+        let result = authorize_request_surface(&state, addr, &headers, &uri).await;
         assert!(result.is_err());
     }
 
@@ -377,7 +529,8 @@ mod tests {
             HeaderValue::from_static("http://localhost:5173"),
         );
 
-        let result = authorize_request_surface(&state, addr, &headers).await;
+        let uri = Uri::from_static("/api/sessions");
+        let result = authorize_request_surface(&state, addr, &headers, &uri).await;
         assert!(result.is_ok());
     }
 }

--- a/crates/krusty-server/src/routes/credentials.rs
+++ b/crates/krusty-server/src/routes/credentials.rs
@@ -139,8 +139,10 @@ async fn delete_credential(
                     .models
                     .iter()
                     .map(|m| {
-                        let api_format =
-                            krusty_core::ai::format_detection::detect_api_format(provider.id, &m.id);
+                        let api_format = krusty_core::ai::format_detection::detect_api_format(
+                            provider.id,
+                            &m.id,
+                        );
                         let mut model = krusty_core::ai::models::ModelMetadata::new(
                             &m.id,
                             &m.display_name,

--- a/crates/krusty-server/src/routes/credentials.rs
+++ b/crates/krusty-server/src/routes/credentials.rs
@@ -100,7 +100,7 @@ async fn set_credential(
             .map_err(|e| AppError::Internal(e.to_string()))?;
     }
 
-    if matches!(provider_id, ProviderId::OpenRouter | ProviderId::OpenAI) {
+    if krusty_core::ai::catalog::supports_dynamic_models(provider_id) {
         spawn_dynamic_model_refresh(state.model_registry.clone(), provider_id, req.api_key);
     }
 
@@ -131,8 +131,33 @@ async fn delete_credential(
             .map_err(|e| AppError::Internal(e.to_string()))?;
     }
 
-    if provider_id == ProviderId::OpenRouter {
-        state.model_registry.set_models(provider_id, vec![]).await;
+    if krusty_core::ai::catalog::supports_dynamic_models(provider_id) {
+        // Fall back to builtin static catalog for this provider when live creds go away.
+        let fallback = krusty_core::ai::providers::get_provider(provider_id)
+            .map(|provider| {
+                provider
+                    .models
+                    .iter()
+                    .map(|m| {
+                        let api_format =
+                            krusty_core::ai::format_detection::detect_api_format(provider.id, &m.id);
+                        let mut model = krusty_core::ai::models::ModelMetadata::new(
+                            &m.id,
+                            &m.display_name,
+                            provider.id,
+                        )
+                        .with_context(m.context_window, m.max_output);
+                        if let Some(reasoning) = m.reasoning {
+                            model = model.with_thinking(reasoning);
+                        }
+                        model.api_format = api_format;
+                        model.supports_tools = provider.supports_tools;
+                        model
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        state.model_registry.set_models(provider_id, fallback).await;
     }
 
     let oauth_store = load_oauth_store_or_default("deleting credential provider");
@@ -207,13 +232,7 @@ fn spawn_dynamic_model_refresh(
     credential: String,
 ) {
     tokio::spawn(async move {
-        let result = match provider_id {
-            ProviderId::OpenRouter => krusty_core::ai::openrouter::fetch_models(&credential).await,
-            ProviderId::OpenAI => krusty_core::ai::openai::fetch_models(&credential).await,
-            _ => return,
-        };
-
-        match result {
+        match krusty_core::ai::catalog::fetch_dynamic_models(provider_id, &credential).await {
             Ok(models) => registry.set_models(provider_id, models).await,
             Err(e) => tracing::warn!("Failed to refresh {} models: {}", provider_id, e),
         }

--- a/crates/krusty-server/src/routes/ports/mod.rs
+++ b/crates/krusty-server/src/routes/ports/mod.rs
@@ -17,5 +17,6 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/", get(list_ports))
         .route("/:port/proxy", any(proxy_root))
+        .route("/:port/proxy/", any(proxy_root))
         .route("/:port/proxy/*path", any(proxy_path))
 }

--- a/crates/krusty-server/src/routes/sessions/crud.rs
+++ b/crates/krusty-server/src/routes/sessions/crud.rs
@@ -87,7 +87,14 @@ pub(super) async fn create_session(
     let session_manager = open_session_manager(&state)?;
     let workspace_scope = request_workspace_scope(&state, user.as_ref());
 
-    let title = req.title.as_deref().unwrap_or("New Session");
+    // Prefer an explicit placeholder so list/search UIs never depend on every
+    // client synthesizing titles for empty strings.
+    let title = req
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("New Session");
     let requested_model = trimmed_nonempty(req.model.as_deref());
     let workspace = normalize_resolved_requested_workspace(
         req.working_dir.as_deref(),

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -127,9 +127,31 @@ export interface ChatMessage {
 	thinking?: string;
 	attachments?: ChatMessageAttachment[];
 	toolCalls?: ToolCall[];
+	renderParts?: ChatRenderPart[];
 	isQueued?: boolean;
 	kind?: "recovery_notice" | "live_partial" | "streaming";
 }
+
+export type ChatRenderPart =
+	| {
+			type: "text";
+			id: string;
+			content: string;
+	  }
+	| {
+			type: "thinking";
+			id: string;
+			content: string;
+	  }
+	| {
+			type: "tool";
+			id: string;
+			toolCallId: string;
+	  }
+	| {
+			type: "attachments";
+			id: string;
+	  };
 
 export interface ChatMessageAttachment {
 	type: "image" | "file";

--- a/packages/state/src/session/messages.ts
+++ b/packages/state/src/session/messages.ts
@@ -10,6 +10,7 @@ import type {
   Attachment,
   ChatMessage,
   ChatMessageAttachment,
+  ChatRenderPart,
   ToolCall,
 } from './types';
 
@@ -76,6 +77,77 @@ function extractTextContent(content: unknown): string {
   return '';
 }
 
+function appendRenderPart(
+  message: ChatMessage,
+  part: ChatRenderPart,
+): void {
+  message.renderParts = [...(message.renderParts || []), part];
+}
+
+/**
+ * Join adjacent text into one render part.
+ *
+ * Must match the live stream path (`streaming.ts`): raw concatenation.
+ * Stored history used to insert `\n` between consecutive text blocks, which
+ * made reloaded messages diverge from the live timeline for the same content.
+ */
+function joinAdjacentText(existing: string, next: string): string {
+  if (!existing) return next;
+  if (!next) return existing;
+  return existing + next;
+}
+
+function appendTextRenderPart(message: ChatMessage, content: string): void {
+  if (!content) return;
+
+  const parts = [...(message.renderParts || [])];
+  const lastPart = parts[parts.length - 1];
+  if (lastPart?.type === 'text') {
+    parts[parts.length - 1] = {
+      ...lastPart,
+      content: joinAdjacentText(lastPart.content, content),
+    };
+  } else {
+    parts.push({
+      type: 'text',
+      id: `text-${parts.length}`,
+      content,
+    });
+  }
+  message.renderParts = parts;
+}
+
+function appendThinkingRenderPart(message: ChatMessage, content: string): void {
+  if (!content) return;
+
+  const parts = [...(message.renderParts || [])];
+  const lastPart = parts[parts.length - 1];
+  if (lastPart?.type === 'thinking') {
+    parts[parts.length - 1] = {
+      ...lastPart,
+      content: lastPart.content ? `${lastPart.content}\n\n${content}` : content,
+    };
+  } else {
+    parts.push({
+      type: 'thinking',
+      id: `thinking-${parts.length}`,
+      content,
+    });
+  }
+  message.renderParts = parts;
+}
+
+function appendAttachmentsRenderPart(message: ChatMessage): void {
+  const parts = message.renderParts || [];
+  if (parts[parts.length - 1]?.type === 'attachments') return;
+  if (parts.some((part) => part.type === 'attachments')) return;
+
+  appendRenderPart(message, {
+    type: 'attachments',
+    id: `attachments-${parts.length}`,
+  });
+}
+
 function parseStoredMessage(
   message: { role: string; content: unknown },
   toolResults?: Map<string, { output: string; isError: boolean }>,
@@ -90,6 +162,7 @@ function parseStoredMessage(
     content: '',
     thinking: '',
     toolCalls: [],
+    renderParts: [],
   };
   const contentArray = Array.isArray(message.content) ? message.content : [];
   let imageIndex = 0;
@@ -98,18 +171,22 @@ function parseStoredMessage(
     if (!block || typeof block !== 'object') continue;
 
     if (block.type === 'text' || ('text' in block && !block.type)) {
+      const text = block.text || '';
       if (parsed.content.length < MAX_MESSAGE_CONTENT_LENGTH) {
-        parsed.content += (parsed.content ? '\n' : '') + (block.text || '');
+        parsed.content += (parsed.content ? '\n' : '') + text;
       }
+      appendTextRenderPart(parsed, text);
     } else if (block.type === 'thinking' || 'thinking' in block) {
       const thinkingContent = block.thinking || '';
       parsed.thinking = parsed.thinking
         ? `${parsed.thinking}\n\n${thinkingContent}`
         : thinkingContent;
+      appendThinkingRenderPart(parsed, thinkingContent);
     } else if (block.type === 'image') {
       const attachment = parseImageAttachment(block, imageIndex);
       if (attachment) {
         parsed.attachments = [...(parsed.attachments || []), attachment];
+        appendAttachmentsRenderPart(parsed);
         imageIndex += 1;
       }
     } else if (
@@ -145,6 +222,11 @@ function parseStoredMessage(
         delegated,
         status,
       });
+      appendRenderPart(parsed, {
+        type: 'tool',
+        id: `tool-${block.id}`,
+        toolCallId: block.id,
+      });
     }
   }
 
@@ -154,6 +236,7 @@ function parseStoredMessage(
     && (!parsed.toolCalls || parsed.toolCalls.length === 0)
   ) {
     parsed.content = extractTextContent(message.content);
+    appendTextRenderPart(parsed, parsed.content);
   }
 
   return parsed;

--- a/packages/state/src/session/store.ts
+++ b/packages/state/src/session/store.ts
@@ -71,6 +71,14 @@ function normalizeTargetBranch(targetBranch: string | null | undefined): string 
   return trimmed ? trimmed : null;
 }
 
+function normalizeDisplayTitle(title: string | null | undefined): string {
+  const trimmed = title?.trim() ?? "";
+  const placeholder = trimmed.toLowerCase();
+  return placeholder === "new chat" || placeholder === "new session"
+    ? ""
+    : trimmed;
+}
+
 function buildDisplayAttachments(
   attachments: Attachment[],
 ): ChatMessageAttachment[] {
@@ -173,7 +181,7 @@ export function createSessionStore(
     | "cleanup"
   > = {
     sessionId: null,
-    title: "New Chat",
+    title: "",
     mode: "build",
     permissionMode: loadPermissionMode(),
     messages: [],
@@ -348,6 +356,7 @@ export function createSessionStore(
           content: "",
           thinking: "",
           toolCalls: [],
+          renderParts: [],
           kind: "streaming",
         },
       };
@@ -522,7 +531,7 @@ export function createSessionStore(
           return {
             ...s,
             sessionId: data.session.id,
-            title: data.session.title || "Untitled",
+            title: normalizeDisplayTitle(data.session.title),
             mode,
             permissionMode,
             model: sessionModel ?? s.model,
@@ -616,7 +625,7 @@ export function createSessionStore(
         thinkingEnabled: current.thinkingEnabled,
         fastModeEnabled: current.fastModeEnabled,
         sessionId,
-        title,
+        title: normalizeDisplayTitle(title),
       });
       get().startPresenceHeartbeat(sessionId);
     },
@@ -754,6 +763,7 @@ export function createSessionStore(
           content: "",
           thinking: "",
           toolCalls: [],
+          renderParts: [],
           kind: "streaming",
         },
       };

--- a/packages/state/src/session/streaming.ts
+++ b/packages/state/src/session/streaming.ts
@@ -20,6 +20,7 @@ import {
 } from "./transient";
 import type {
 	AssistantMessageRef,
+	ChatRenderPart,
 	SessionMode,
 	SessionStoreState,
 	ToolCall,
@@ -38,6 +39,69 @@ interface StreamCallbackDependencies {
 		getState: () => SessionStoreState,
 		mode: SessionMode,
 	) => Promise<void>;
+}
+
+function appendRenderPart(ref: AssistantMessageRef, part: ChatRenderPart) {
+	ref.current.renderParts = [...(ref.current.renderParts || []), part];
+}
+
+function appendTextRenderPart(ref: AssistantMessageRef, content: string) {
+	if (!content) return;
+
+	const parts = [...(ref.current.renderParts || [])];
+	const lastPart = parts[parts.length - 1];
+	if (lastPart?.type === "text") {
+		parts[parts.length - 1] = {
+			...lastPart,
+			content: lastPart.content + content,
+		};
+	} else {
+		parts.push({
+			type: "text",
+			id: `text-${parts.length}`,
+			content,
+		});
+	}
+	ref.current.renderParts = parts;
+}
+
+function appendThinkingRenderPart(ref: AssistantMessageRef, content: string) {
+	if (!content) return;
+
+	const parts = [...(ref.current.renderParts || [])];
+	const lastPart = parts[parts.length - 1];
+	if (lastPart?.type === "thinking") {
+		parts[parts.length - 1] = {
+			...lastPart,
+			content: lastPart.content + content,
+		};
+	} else {
+		parts.push({
+			type: "thinking",
+			id: `thinking-${parts.length}`,
+			content,
+		});
+	}
+	ref.current.renderParts = parts;
+}
+
+function appendToolRenderPart(ref: AssistantMessageRef, toolCallId: string) {
+	if (!toolCallId) return;
+
+	const parts = ref.current.renderParts || [];
+	if (
+		parts.some(
+			(part) => part.type === "tool" && part.toolCallId === toolCallId,
+		)
+	) {
+		return;
+	}
+
+	appendRenderPart(ref, {
+		type: "tool",
+		id: `tool-${toolCallId}`,
+		toolCallId,
+	});
 }
 
 export function createStreamCallbacks(
@@ -65,6 +129,7 @@ export function createStreamCallbacks(
 	function flushPendingTextDelta() {
 		if (!pendingTextDelta) return;
 		ref.current.content += pendingTextDelta;
+		appendTextRenderPart(ref, pendingTextDelta);
 		pendingTextDelta = "";
 		updateLastAssistantMessage(() => ({
 			isLoading: false,
@@ -107,6 +172,7 @@ export function createStreamCallbacks(
 		onThinkingDelta: (thinking) => {
 			flushPendingTextDelta();
 			ref.current.thinking = (ref.current.thinking || "") + thinking;
+			appendThinkingRenderPart(ref, thinking);
 			const delegatedIndex = (ref.current.toolCalls || []).findIndex(
 				(toolCall) =>
 					resolveDelegatedKind(
@@ -164,6 +230,7 @@ export function createStreamCallbacks(
 					status: "running",
 				},
 			];
+			appendToolRenderPart(ref, id);
 			updateLastAssistantMessage();
 		},
 
@@ -269,6 +336,7 @@ export function createStreamCallbacks(
 				...(ref.current.toolCalls || []),
 				planConfirmCall,
 			];
+			appendToolRenderPart(ref, toolCallId);
 			updateLastAssistantMessage();
 		},
 
@@ -442,6 +510,8 @@ export function createStreamCallbacks(
 		},
 
 		onError: (error) => {
+			// Flush rAF-batched text so the last frame is not dropped on failure.
+			flushPendingTextDelta();
 			set((state) => ({
 				isLoading: false,
 				isStreaming: false,

--- a/packages/state/src/session/types.ts
+++ b/packages/state/src/session/types.ts
@@ -87,9 +87,31 @@ export interface ChatMessage {
   thinking?: string;
   attachments?: ChatMessageAttachment[];
   toolCalls?: ToolCall[];
+  renderParts?: ChatRenderPart[];
   isQueued?: boolean;
   kind?: 'recovery_notice' | 'live_partial' | 'streaming';
 }
+
+export type ChatRenderPart =
+  | {
+      type: 'text';
+      id: string;
+      content: string;
+    }
+  | {
+      type: 'thinking';
+      id: string;
+      content: string;
+    }
+  | {
+      type: 'tool';
+      id: string;
+      toolCallId: string;
+    }
+  | {
+      type: 'attachments';
+      id: string;
+    };
 
 export type SessionMode = 'build' | 'plan';
 export type PermissionMode = 'supervised' | 'autonomous';

--- a/packages/state/test/assistant-smoothing.test.ts
+++ b/packages/state/test/assistant-smoothing.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Deno tests for assistant visual text-smoothing heuristics.
+ *
+ * Mirrors the pure helpers in apps/mobile/components/chat/assistantRenderPlan.ts
+ * so mid-stream tool interruptions rejoin prose without gluing real boundaries.
+ *
+ * Run: deno test packages/state/test/assistant-smoothing.test.ts
+ */
+
+declare const Deno: {
+  test(name: string, fn: () => void | Promise<void>): void;
+};
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertEquals(actual: unknown, expected: unknown, message: string) {
+  if (actual !== expected) {
+    throw new Error(
+      `${message}\nexpected: ${String(expected)}\nactual: ${String(actual)}`,
+    );
+  }
+}
+
+type Segment =
+  | { type: "text"; id: string; content: string }
+  | { type: "thinking"; id: string; content: string }
+  | { type: "tool"; id: string }
+  | { type: "exploration"; id: string };
+
+function startsLikeNewBlock(content: string): boolean {
+  return /^(#{1,6}\s|[-*+]\s|\d+[.)]\s|```|>|<\w)/.test(content);
+}
+
+function isSoftInterruption(segment: Segment): boolean {
+  return (
+    segment.type === "exploration" ||
+    segment.type === "thinking" ||
+    segment.type === "tool"
+  );
+}
+
+function shouldMergeContinuationText(
+  previousContent: string,
+  nextContent: string,
+  interveningSegments: Segment[],
+): boolean {
+  if (interveningSegments.length === 0) return false;
+  if (!interveningSegments.every(isSoftInterruption)) return false;
+
+  const previous = previousContent.trimEnd();
+  const next = nextContent.trimStart();
+  if (!previous || !next || startsLikeNewBlock(next)) return false;
+  if (/```\s*$/.test(previous) || /^```/.test(next)) return false;
+
+  const previousLooksUnfinished = /[A-Za-z0-9_'")\]]$/.test(previous);
+  const nextLooksContinued = /^[a-z,.;:!?'"()\]}]/.test(next);
+  return previousLooksUnfinished && nextLooksContinued;
+}
+
+function appendContinuationText(previous: string, next: string): string {
+  if (!previous) return next;
+  if (!next) return previous;
+  if (/\s$/.test(previous) || /^\s/.test(next)) return previous + next;
+  return previous + next.trimStart();
+}
+
+function smoothInterruptedText(segments: Segment[]): Segment[] {
+  const smoothed: Segment[] = [];
+  for (const segment of segments) {
+    if (segment.type !== "text") {
+      smoothed.push(segment);
+      continue;
+    }
+    let previousTextIndex = -1;
+    for (let index = smoothed.length - 1; index >= 0; index -= 1) {
+      if (smoothed[index]?.type === "text") {
+        previousTextIndex = index;
+        break;
+      }
+    }
+    const previousText = smoothed[previousTextIndex];
+    const intervening =
+      previousTextIndex >= 0 ? smoothed.slice(previousTextIndex + 1) : [];
+    if (
+      previousText?.type === "text" &&
+      shouldMergeContinuationText(
+        previousText.content,
+        segment.content,
+        intervening,
+      )
+    ) {
+      smoothed[previousTextIndex] = {
+        ...previousText,
+        content: appendContinuationText(previousText.content, segment.content),
+      };
+      continue;
+    }
+    smoothed.push(segment);
+  }
+  return smoothed;
+}
+
+Deno.test("merges mid-sentence tool interruption", () => {
+  const segments: Segment[] = [
+    { type: "text", id: "t1", content: "Looking at the " },
+    { type: "tool", id: "tool-1" },
+    { type: "text", id: "t2", content: "registry next." },
+  ];
+  const smoothed = smoothInterruptedText(segments);
+  // previous text + intervening tool remain; second text merges into first.
+  assertEquals(smoothed.length, 2, "text+tool after merge");
+  assert(smoothed[0]?.type === "text", "merged text first");
+  assert(smoothed[1]?.type === "tool", "tool stays after merged text");
+  if (smoothed[0]?.type === "text") {
+    assertEquals(
+      smoothed[0].content,
+      "Looking at the registry next.",
+      "prose rejoined",
+    );
+  }
+});
+
+Deno.test("does not merge when next starts a list/code block", () => {
+  assert(
+    !shouldMergeContinuationText(
+      "See the following:",
+      "- item one",
+      [{ type: "tool", id: "t" }],
+    ),
+    "list boundary",
+  );
+  assert(
+    !shouldMergeContinuationText(
+      "Example:",
+      "```ts\nconst x = 1\n```",
+      [{ type: "thinking", id: "th", content: "..." }],
+    ),
+    "code fence start",
+  );
+});
+
+Deno.test("does not merge across closed code fences", () => {
+  assert(
+    !shouldMergeContinuationText(
+      "```\ncode\n```",
+      "more prose here",
+      [{ type: "tool", id: "t" }],
+    ),
+    "closed fence should not continue",
+  );
+});
+
+Deno.test("merges legitimate lowercase continuation after tool", () => {
+  assert(
+    shouldMergeContinuationText(
+      "The helper returns",
+      "null when missing.",
+      [{ type: "exploration", id: "e" }],
+    ),
+    "lowercase continuation after unfinished phrase",
+  );
+});
+
+Deno.test("does not merge when previous looks finished", () => {
+  assert(
+    !shouldMergeContinuationText(
+      "All done.",
+      "Next we restart.",
+      [{ type: "tool", id: "t" }],
+    ),
+    "sentence end should not glue next capital start — capital fails continued check",
+  );
+});

--- a/packages/state/test/render-parts.test.ts
+++ b/packages/state/test/render-parts.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Deno tests for render-part text join parity (live stream vs stored reload).
+ *
+ * Run: deno test packages/state/test/render-parts.test.ts
+ */
+
+declare const Deno: {
+  test(name: string, fn: () => void | Promise<void>): void;
+};
+
+function assertEquals(actual: unknown, expected: unknown, message: string) {
+  if (actual !== expected) {
+    throw new Error(
+      `${message}\nexpected: ${String(expected)}\nactual: ${String(actual)}`,
+    );
+  }
+}
+
+/** Must match streaming.ts and messages.ts joinAdjacentText policy. */
+function joinAdjacentText(existing: string, next: string): string {
+  if (!existing) return next;
+  if (!next) return existing;
+  return existing + next;
+}
+
+Deno.test("live and stored text joins use raw concatenation", () => {
+  // Stream deltas: "Hel" + "lo" + " world"
+  const live = ["Hel", "lo", " world"].reduce(
+    (acc, chunk) => joinAdjacentText(acc, chunk),
+    "",
+  );
+  // Stored consecutive text blocks for the same continuous prose
+  const stored = ["Hello", " world"].reduce(
+    (acc, chunk) => joinAdjacentText(acc, chunk),
+    "",
+  );
+  assertEquals(live, "Hello world", "live stream should concat");
+  assertEquals(stored, "Hello world", "stored blocks should match live");
+  assertEquals(live, stored, "parity between live and stored join");
+});
+
+Deno.test("joinAdjacentText does not invent separators", () => {
+  assertEquals(joinAdjacentText("code", "base"), "codebase", "no glue space");
+  assertEquals(joinAdjacentText("a\n", "b"), "a\nb", "preserve existing newline");
+  assertEquals(joinAdjacentText("", "only"), "only", "empty existing");
+  assertEquals(joinAdjacentText("only", ""), "only", "empty next");
+});


### PR DESCRIPTION
## Summary

Addresses the full review checklist so product behavior stays consistent across CLI, server, and Expo:

- **Stream correctness:** flush rAF-batched text on `onError` so the last frame is not dropped mid-stream.
- **WebSocket remote auth:** percent-decode `?token=` query values (tokens with `+/=` work after `encodeURIComponent`); document query-token leakage tradeoffs.
- **Dynamic model catalogs:** CLI and server share `dynamic_model_providers()`; restore Grok cache on TUI boot; concurrent refresh without `block_on` on the poll path; OAuth forces catalog refresh.
- **Chat timeline:** ordered `renderParts` for tools/thinking/text; live vs stored text join parity; smoothing heuristics with unit tests; internal plan-tool filtering kept in sync with core.
- **Sessions:** default new-session title restored to `"New Session"`.
- **Toolbox / terminal / ports:** existing WIP polish included (trailing-slash port route, terminal URL helper, workspace preview cleanup).

## Test plan

- [x] `cargo test -p krusty-server auth` (includes encoded websocket token test)
- [x] `cargo check/clippy -p krusty-core -p krusty -p krusty-server -- -D warnings`
- [x] `deno test packages/state/test/render-parts.test.ts packages/state/test/assistant-smoothing.test.ts`
- [ ] Smoke: remote terminal with a token containing `+/=`
- [ ] Smoke: OAuth/Grok → CLI `/model` shows same live catalog as server
- [ ] Smoke: kill stream mid-response and confirm last text remains
- [ ] Reload a session with interleaved tool/text/thinking and compare layout to live stream