### PR TITLE
Release Krusty 0.7.3 with hardened provider streaming

### DIFF
--- a/.github/homebrew/krusty.rb
+++ b/.github/homebrew/krusty.rb
@@ -6,26 +6,26 @@
 
 class Krusty < Formula
   desc "Terminal-based AI coding assistant powered by Claude"
-  homepage "https://github.com/BurgessTG/Krusty"
+  homepage "https://github.com/honeycomb-Technologies/Krusty"
   version "VERSION_PLACEHOLDER"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/BurgessTG/Krusty/releases/download/vVERSION_PLACEHOLDER/krusty-aarch64-apple-darwin.tar.gz"
+      url "https://github.com/honeycomb-Technologies/Krusty/releases/download/vVERSION_PLACEHOLDER/krusty-aarch64-apple-darwin.tar.gz"
       sha256 "SHA256_MACOS_ARM64"
     else
-      url "https://github.com/BurgessTG/Krusty/releases/download/vVERSION_PLACEHOLDER/krusty-x86_64-apple-darwin.tar.gz"
+      url "https://github.com/honeycomb-Technologies/Krusty/releases/download/vVERSION_PLACEHOLDER/krusty-x86_64-apple-darwin.tar.gz"
       sha256 "SHA256_MACOS_X64"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/BurgessTG/Krusty/releases/download/vVERSION_PLACEHOLDER/krusty-aarch64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/honeycomb-Technologies/Krusty/releases/download/vVERSION_PLACEHOLDER/krusty-aarch64-unknown-linux-gnu.tar.gz"
       sha256 "SHA256_LINUX_ARM64"
     else
-      url "https://github.com/BurgessTG/Krusty/releases/download/vVERSION_PLACEHOLDER/krusty-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/honeycomb-Technologies/Krusty/releases/download/vVERSION_PLACEHOLDER/krusty-x86_64-unknown-linux-gnu.tar.gz"
       sha256 "SHA256_LINUX_X64"
     end
   end

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libudev-dev \
+            libxcb1-dev \
+            libxkbcommon-dev \
+            libxkbcommon-x11-dev
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,5 +1,11 @@
 # Krusty Platform Unification Audit
 
+> Historical record (superseded). The unified `AgenticOrchestrator`, canonical
+> `LoopEvent` protocol, thin server bridge, shared context injection, durable
+> recovery, MCP/tool registration, and in-place compaction described as targets
+> below are implemented. Use `AGENTS.md` and `docs/operations/` for current
+> architecture and release guidance.
+
 ## Executive Summary
 
 The TUI and Server/PWA have **diverged significantly**. While they share the same `krusty-core` crate for tools, AI client, and storage, the **orchestration layer** (how the agentic loop runs, what context gets injected, what capabilities are available) is duplicated and inconsistent. The server has a 2,328-line monolithic `chat.rs` that reimplements core logic instead of reusing it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "krusty"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4824,7 +4824,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client-state"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "krusty-client",
  "serde",
@@ -4848,7 +4848,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -4911,7 +4911,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-desktop"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -4925,7 +4925,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-mobile"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-mobile-ui"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "gpui",
  "krusty-client-state",
@@ -4948,7 +4948,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,5 +1,10 @@
 # Krusty Platform Unification Plan
 
+> Historical implementation plan (completed). The canonical implementation now
+> lives in `crates/krusty-core/src/agent/`, and server/TUI surfaces consume its
+> shared event protocol. Use `AGENTS.md` for current invariants and verification
+> commands.
+
 ## Vision
 
 One brain, many faces. The agentic loop — streaming, tool execution, context injection,

--- a/apps/desktop/shell/README.md
+++ b/apps/desktop/shell/README.md
@@ -25,11 +25,11 @@ Build outputs:
 
 ## Linux Install + Run
 - Debian/Ubuntu:
-  - `sudo apt install "./src-tauri/target/release/bundle/deb/Krusty Desktop_0.7.0_amd64.deb"`
+  - `sudo apt install "./src-tauri/target/release/bundle/deb/Krusty Desktop_0.7.3_amd64.deb"`
 - Fedora/RHEL:
-  - `sudo dnf install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.7.0-1.x86_64.rpm"`
+  - `sudo dnf install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.7.3-1.x86_64.rpm"`
 - openSUSE:
-  - `sudo zypper install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.7.0-1.x86_64.rpm"`
+  - `sudo zypper install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.7.3-1.x86_64.rpm"`
 
 After install, launch with:
 - `krusty-desktop`

--- a/apps/desktop/shell/bun.lock
+++ b/apps/desktop/shell/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@krusty/desktop-shell",

--- a/apps/desktop/shell/package.json
+++ b/apps/desktop/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krusty/desktop-shell",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "packageManager": "bun@1.3.0",
   "type": "module",

--- a/apps/desktop/shell/src-tauri/Cargo.lock
+++ b/apps/desktop/shell/src-tauri/Cargo.lock
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-desktop"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "krusty-core",
  "krusty-server",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/desktop/shell/src-tauri/Cargo.lock
+++ b/apps/desktop/shell/src-tauri/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -842,6 +842,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -863,7 +873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -876,7 +886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1335,6 +1345,15 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
@@ -1351,6 +1370,18 @@ dependencies = [
  "libc",
  "redox_users 0.4.6",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1794,6 +1825,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2208,6 +2249,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "grok-auth"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "base64 0.22.1",
+ "chrono",
+ "dirs 5.0.1",
+ "fs2",
+ "hyper",
+ "rand 0.8.5",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "tokio",
+ "toml 0.8.2",
+ "tower 0.4.13",
+ "tracing",
+ "url",
+ "webbrowser",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,6 +2434,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "019ece39bbefc17f13f677a690328cb978dbf6790e141a3c24e66372cb38588b"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2942,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.6.2"
+version = "0.7.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2957,6 +3032,7 @@ dependencies = [
  "futures",
  "git2",
  "glob",
+ "grok-auth",
  "hmac",
  "http",
  "httpdate",
@@ -3003,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-desktop"
-version = "0.6.2"
+version = "0.7.2"
 dependencies = [
  "krusty-core",
  "krusty-server",
@@ -3018,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.6.2"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3272,6 +3348,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3458,7 +3543,7 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "thiserror 1.0.69",
 ]
 
@@ -3713,6 +3798,15 @@ dependencies = [
  "sha2",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -4729,6 +4823,12 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
+name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
@@ -4887,7 +4987,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -4922,7 +5022,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -5669,7 +5769,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "objc2-quartz-core",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
@@ -5913,7 +6013,7 @@ checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -5934,7 +6034,7 @@ dependencies = [
  "objc2-foundation",
  "once_cell",
  "parking_lot",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "scopeguard",
  "tao-macros",
  "unicode-segmentation",
@@ -6008,7 +6108,7 @@ dependencies = [
  "objc2-web-kit",
  "percent-encoding",
  "plist",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -6107,7 +6207,7 @@ dependencies = [
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "serde",
  "serde_json",
  "tauri-utils",
@@ -6133,7 +6233,7 @@ dependencies = [
  "objc2-foundation",
  "once_cell",
  "percent-encoding",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "softbuffer",
  "tao",
  "tauri-runtime",
@@ -6517,6 +6617,17 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -6553,7 +6664,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7399,6 +7510,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db67ae75a9405634f5882791678772c94ff5f16a66535aae186e26aa0841fc8b"
+dependencies = [
+ "core-foundation 0.9.4",
+ "home",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc",
+ "raw-window-handle 0.5.2",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7609,7 +7737,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "windows-sys 0.59.0",
  "windows-version",
 ]
@@ -7806,6 +7934,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7853,6 +7990,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -7923,6 +8075,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7941,6 +8099,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7956,6 +8120,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7989,6 +8159,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -8004,6 +8180,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8025,6 +8207,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -8040,6 +8228,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8260,7 +8454,7 @@ dependencies = [
  "objc2-web-kit",
  "once_cell",
  "percent-encoding",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "sha2",
  "soup3",
  "tao-macros",

--- a/apps/desktop/shell/src-tauri/Cargo.toml
+++ b/apps/desktop/shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-desktop"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 
 [build-dependencies]

--- a/apps/desktop/shell/src-tauri/tauri.conf.json
+++ b/apps/desktop/shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Krusty Desktop",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "identifier": "io.krusty.desktop",
   "build": {
     "beforeDevCommand": "cd ../../mobile && npx expo start --web --port 5173",

--- a/apps/mobile/app/(tabs)/chat-screen/styles.ts
+++ b/apps/mobile/app/(tabs)/chat-screen/styles.ts
@@ -1,5 +1,39 @@
 import { StyleSheet } from "react-native";
 
+/**
+ * Desktop chat band: fills available pane width with light side breathing
+ * room, soft-capped only on ultra-wide monitors so messages + composer stay
+ * one aligned column (no full-bleed ultrawide void).
+ */
+export const DESKTOP_CHAT_MIN_WIDTH = 360;
+export const DESKTOP_CHAT_MAX_WIDTH = 960;
+/** Side inset as a fraction of available pane width (clamped). */
+export const DESKTOP_CHAT_SIDE_PAD_MIN = 16;
+export const DESKTOP_CHAT_SIDE_PAD_MAX = 48;
+/** Fixed toolbox side rail — never flex-share with chat. */
+export const TOOLBOX_DOCK_WIDTH = 360;
+
+/** Side pad for a measured pane width. */
+export function resolveDesktopChatSidePad(paneWidth: number): number {
+  if (paneWidth <= 0) return DESKTOP_CHAT_SIDE_PAD_MIN;
+  return Math.min(
+    DESKTOP_CHAT_SIDE_PAD_MAX,
+    Math.max(DESKTOP_CHAT_SIDE_PAD_MIN, Math.round(paneWidth * 0.03)),
+  );
+}
+
+/**
+ * Resolve column max width for a pane width.
+ * Always returns a positive width so the band never full-bleeds while waiting
+ * on layout measure (pass window width as fallback).
+ */
+export function resolveDesktopChatMaxWidth(paneWidth: number): number {
+  if (paneWidth <= 0) return DESKTOP_CHAT_MAX_WIDTH;
+  const pad = resolveDesktopChatSidePad(paneWidth);
+  const usable = Math.max(DESKTOP_CHAT_MIN_WIDTH, paneWidth - pad * 2);
+  return Math.min(DESKTOP_CHAT_MAX_WIDTH, usable);
+}
+
 export const styles = StyleSheet.create({
   bootScreen: { flex: 1 },
   bootInner: {
@@ -51,6 +85,41 @@ export const styles = StyleSheet.create({
   },
   container: { flex: 1 },
   flex: { flex: 1 },
+  /** Desktop: chat column + toolbox column side by side. */
+  desktopSplit: {
+    flex: 1,
+    flexDirection: "row",
+    minWidth: 0,
+    overflow: "hidden",
+  },
+  /** Flex child that holds the chat band; must shrink when toolbox docks. */
+  desktopSplitChat: {
+    flex: 1,
+    minWidth: 0,
+    overflow: "hidden",
+  },
+  /**
+   * Fluid band for messages + composer only. maxWidth set inline from pane.
+   * Title chrome stays full-pane so the toolbox button can sit in the corner.
+   */
+  desktopChatColumn: {
+    flex: 1,
+    width: "100%",
+    maxWidth: DESKTOP_CHAT_MAX_WIDTH,
+    alignSelf: "center",
+    minWidth: 0,
+    // Anchor absolute ChatBar/FABs inside this band (not the full window).
+    position: "relative",
+    overflow: "visible",
+  },
+  /** Outer measure host — full split-pane width; chrome + centered band stack. */
+  desktopChatColumnHost: {
+    flex: 1,
+    width: "100%",
+    minWidth: 0,
+    flexDirection: "column",
+    alignItems: "stretch",
+  },
   topBar: {
     flexDirection: "row",
     alignItems: "center",
@@ -58,16 +127,37 @@ export const styles = StyleSheet.create({
     paddingVertical: 10,
     gap: 12,
   },
+  /** Desktop chrome: full pane width so corner controls stay on the window edge. */
+  topBarDesktop: {
+    width: "100%",
+    paddingLeft: 56, // room for shell sidebar-open control
+    paddingRight: 12,
+    paddingVertical: 10,
+    zIndex: 20,
+  },
   menuBtn: {
     padding: 4,
   },
+  /** Flush top-right toolbox control (true corner hit target). */
+  toolboxCornerBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
   titleBtn: {
     flex: 1,
+    minWidth: 0,
   },
   title: {
     fontSize: 17,
     fontWeight: "600",
     textAlign: "center",
+  },
+  titlePlaceholder: {
+    fontWeight: "500",
   },
   statusDot: {
     width: 8,
@@ -79,7 +169,7 @@ export const styles = StyleSheet.create({
     paddingTop: 8,
   },
   listDesktop: {
-    maxWidth: 800,
+    maxWidth: DESKTOP_CHAT_MAX_WIDTH,
     alignSelf: "center",
     width: "100%",
   },

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   Pressable,
   Alert,
+  useWindowDimensions,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { router } from "expo-router";
@@ -61,7 +62,12 @@ import {
   sessionTypeForTab,
   tabForSessionType,
 } from "./chat-screen/helpers";
-import { styles } from "./chat-screen/styles";
+import {
+  DESKTOP_CHAT_MAX_WIDTH,
+  TOOLBOX_DOCK_WIDTH,
+  resolveDesktopChatMaxWidth,
+  styles,
+} from "./chat-screen/styles";
 import { useSessionActions } from "./chat-screen/useSessionActions";
 
 type LoadedStores = NonNullable<ReturnType<typeof useStores>>;
@@ -100,6 +106,7 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
   const { theme } = useThemeContext();
   const { client, isConnected } = useConnection();
   const { isDesktop } = useBreakpoint();
+  const { width: windowWidth } = useWindowDimensions();
   const { splashDone } = useSplashState();
   const entrance = useEntranceAnimation(splashDone);
 
@@ -142,6 +149,8 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
   const [bottomControlsOpen, setBottomControlsOpen] = useState(false);
   const [composerReserveHeight, setComposerReserveHeight] =
     useState(CHAT_BAR_ZONE);
+  /** Measured desktop chat pane width (split host, before soft-cap). */
+  const [desktopPaneWidth, setDesktopPaneWidth] = useState(0);
   const selectedModelInfo = useMemo(
     () => models.find((candidate) => candidate.id === model) ?? null,
     [model, models],
@@ -607,8 +616,50 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
     setToolboxOpen(false);
   }, []);
 
+  // Prefer measured host; fall back to window so the band never full-bleeds.
+  const effectivePaneWidth = useMemo(() => {
+    if (desktopPaneWidth > 0) return desktopPaneWidth;
+    if (!isDesktop) return windowWidth;
+    const toolboxSlice = toolboxOpen ? TOOLBOX_DOCK_WIDTH : 0;
+    return Math.max(0, windowWidth - toolboxSlice);
+  }, [desktopPaneWidth, isDesktop, toolboxOpen, windowWidth]);
+
+  const desktopChatMaxWidth = resolveDesktopChatMaxWidth(effectivePaneWidth);
+
+  // Title slot: real title → first user message snippet → "New chat".
+  // Store strips "New Session" placeholders, so empty string is common mid-turn.
+  const displayTitle = useMemo(() => {
+    const real = sessionTitle?.trim();
+    if (real) return { text: real, isPlaceholder: false };
+
+    const firstUser = messages.find(
+      (message) =>
+        message.role === "user" &&
+        typeof message.content === "string" &&
+        message.content.trim().length > 0,
+    );
+    if (firstUser && typeof firstUser.content === "string") {
+      const snippet = firstUser.content.trim().replace(/\s+/g, " ");
+      const text =
+        snippet.length > 56 ? `${snippet.slice(0, 56).trimEnd()}…` : snippet;
+      return { text, isPlaceholder: true };
+    }
+
+    if (sessionId) {
+      return { text: "New chat", isPlaceholder: true };
+    }
+
+    return { text: "", isPlaceholder: true };
+  }, [messages, sessionId, sessionTitle]);
+
   const topBar = (
-    <Animated.View style={[styles.topBar, entrance.topBarStyle]}>
+    <Animated.View
+      style={[
+        styles.topBar,
+        isDesktop && styles.topBarDesktop,
+        entrance.topBarStyle,
+      ]}
+    >
       {!isDesktop && (
         <Pressable
           onPress={() => {
@@ -624,29 +675,159 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
       <Pressable
         onPress={handleRenameSession}
         style={styles.titleBtn}
-        disabled={!sessionTitle}
+        disabled={!sessionId}
       >
         <Text
           style={[
             styles.title,
-            { color: sessionTitle ? t.foreground : "transparent" },
+            displayTitle.isPlaceholder && styles.titlePlaceholder,
+            {
+              color: displayTitle.text
+                ? displayTitle.isPlaceholder
+                  ? t.mutedForeground
+                  : t.foreground
+                : "transparent",
+            },
           ]}
           numberOfLines={1}
         >
-          {sessionTitle || " "}
+          {displayTitle.text || " "}
         </Text>
       </Pressable>
 
       <Pressable
         onPress={() => {
           void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-          setToolboxOpen(true);
+          setToolboxOpen((open) => !open);
         }}
-        style={styles.menuBtn}
+        style={[
+          isDesktop ? styles.toolboxCornerBtn : styles.menuBtn,
+          isDesktop && toolboxOpen
+            ? { backgroundColor: `${t.thinking}22` }
+            : null,
+        ]}
+        accessibilityLabel={toolboxOpen ? "Close toolbox" : "Open toolbox"}
       >
-        <Toolbox size={20} color={t.mutedForeground} strokeWidth={1.8} />
+        <Toolbox
+          size={isDesktop ? 20 : 20}
+          color={toolboxOpen ? t.thinking : t.mutedForeground}
+          strokeWidth={1.8}
+        />
       </Pressable>
     </Animated.View>
+  );
+
+  const transcriptAndComposer = (
+    <View style={styles.flex}>
+      <Animated.View style={[styles.flex, entrance.contentStyle]}>
+        <ChatTranscript
+          messages={messages}
+          sessionId={sessionId}
+          isStreaming={isStreaming}
+          isThinking={isThinking}
+          activeToolCallId={activeToolCallId}
+          onApproveTool={(targetSessionId, toolCallId) =>
+            handleSessionToolApproval(targetSessionId, toolCallId, true)
+          }
+          onDenyTool={(targetSessionId, toolCallId) =>
+            handleSessionToolApproval(targetSessionId, toolCallId, false)
+          }
+          onSubmitToolResult={(toolCallId, result) =>
+            void handleInteractiveToolResult(toolCallId, result)
+          }
+          onPlanConfirm={(toolCallId, choice) =>
+            void handlePlanConfirm(toolCallId, choice)
+          }
+          emptyState={
+            <View style={styles.empty}>
+              <KrustyLogo />
+              {error ? (
+                <Text style={[styles.emptyHint, { color: t.error }]}>
+                  {error}
+                </Text>
+              ) : null}
+            </View>
+          }
+          bottomPadding={composerReserveHeight}
+          hideJumpToLatest={bottomControlsOpen}
+        />
+      </Animated.View>
+
+      <Animated.View
+        style={[
+          entrance.bottomBarStyle,
+          { overflow: "visible", zIndex: 300 },
+        ]}
+      >
+        <ChatBar
+          onSend={handleChatBarSend}
+          onStop={handleStop}
+          onHeightChange={setComposerReserveHeight}
+          isStreaming={isStreaming}
+          disabled={!isConnected}
+          thinkingLevel={thinkingLevel as ThinkingLevel}
+          onThinkingChange={(level) =>
+            sessionStore.getState().setThinkingLevel(level)
+          }
+          permissionMode={permissionMode as PermissionMode}
+          onPermissionModeToggle={() =>
+            sessionStore.getState().togglePermissionMode()
+          }
+          fastModeEnabled={fastModeEnabled}
+          fastModeSupported={fastModeSupported}
+          onFastModeToggle={handleFastModeToggle}
+          mode={mode}
+          onModeToggle={() =>
+            sessionStore
+              .getState()
+              .setMode(mode === "build" ? "plan" : "build")
+          }
+          onModelSelect={handleModelSelect}
+          model={model}
+          models={models}
+          sessionType={sessionTypeForTab(activeTab)}
+          researchEnabled={researchEnabled}
+          onResearchToggle={() => setResearchEnabled((current) => !current)}
+          tokenCount={tokenCount}
+          onOverlayOpenChange={setBottomControlsOpen}
+          contentMaxWidth={isDesktop ? desktopChatMaxWidth : undefined}
+        />
+      </Animated.View>
+    </View>
+  );
+
+  const chatMain = (
+    <View style={styles.flex}>
+      {isDesktop ? (
+        <View
+          style={styles.desktopChatColumnHost}
+          onLayout={(event) => {
+            const next = Math.round(event.nativeEvent.layout.width);
+            setDesktopPaneWidth((prev) => (prev === next ? prev : next));
+          }}
+        >
+          {/* Full-pane chrome: title + toolbox button in the true top-right. */}
+          {topBar}
+          {/* Messages + composer share a centered soft-capped band. */}
+          <View
+            style={[
+              styles.desktopChatColumn,
+              {
+                maxWidth: desktopChatMaxWidth || DESKTOP_CHAT_MAX_WIDTH,
+                width: "100%",
+              },
+            ]}
+          >
+            {transcriptAndComposer}
+          </View>
+        </View>
+      ) : (
+        <>
+          {topBar}
+          {transcriptAndComposer}
+        </>
+      )}
+    </View>
   );
 
   const chatContent = (
@@ -654,86 +835,32 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
       style={[styles.container, { backgroundColor: t.background }]}
       edges={isDesktop ? [] : ["top"]}
     >
-      {!toolboxOpen ? topBar : null}
-
-      <View style={styles.flex}>
-        <Animated.View style={[styles.flex, entrance.contentStyle]}>
-          <ChatTranscript
-            messages={messages}
-            sessionId={sessionId}
-            isStreaming={isStreaming}
-            isThinking={isThinking}
-            activeToolCallId={activeToolCallId}
-            onApproveTool={(targetSessionId, toolCallId) =>
-              handleSessionToolApproval(targetSessionId, toolCallId, true)
-            }
-            onDenyTool={(targetSessionId, toolCallId) =>
-              handleSessionToolApproval(targetSessionId, toolCallId, false)
-            }
-            onSubmitToolResult={(toolCallId, result) =>
-              void handleInteractiveToolResult(toolCallId, result)
-            }
-            onPlanConfirm={(toolCallId, choice) =>
-              void handlePlanConfirm(toolCallId, choice)
-            }
-            emptyState={
-              <View style={styles.empty}>
-                <KrustyLogo />
-                {error ? (
-                  <Text style={[styles.emptyHint, { color: t.error }]}>
-                    {error}
-                  </Text>
-                ) : null}
-              </View>
-            }
-            bottomPadding={composerReserveHeight}
-            hideJumpToLatest={bottomControlsOpen}
-          />
-        </Animated.View>
-
-        {!toolboxOpen && (
-          <Animated.View style={[entrance.bottomBarStyle, { overflow: "visible", zIndex: 300 }]}>
-            <ChatBar
-              onSend={handleChatBarSend}
-              onStop={handleStop}
-              onHeightChange={setComposerReserveHeight}
-              isStreaming={isStreaming}
-              disabled={!isConnected}
-              thinkingLevel={thinkingLevel as ThinkingLevel}
-              onThinkingChange={(level) =>
-                sessionStore.getState().setThinkingLevel(level)
-              }
-              permissionMode={permissionMode as PermissionMode}
-              onPermissionModeToggle={() =>
-                sessionStore.getState().togglePermissionMode()
-              }
-              fastModeEnabled={fastModeEnabled}
-              fastModeSupported={fastModeSupported}
-              onFastModeToggle={handleFastModeToggle}
-              mode={mode}
-              onModeToggle={() =>
-                sessionStore.getState().setMode(mode === "build" ? "plan" : "build")
-              }
-              onModelSelect={handleModelSelect}
-              model={model}
-              models={models}
-              sessionType={sessionTypeForTab(activeTab)}
-              researchEnabled={researchEnabled}
-              onResearchToggle={() => setResearchEnabled((current) => !current)}
-              tokenCount={tokenCount}
-              onOverlayOpenChange={setBottomControlsOpen}
+      {isDesktop ? (
+        // Desktop: chat fills remaining width; toolbox is a fixed-width rail.
+        <View style={styles.desktopSplit}>
+          <View style={styles.desktopSplitChat}>{chatMain}</View>
+          {toolboxOpen ? (
+            <ToolboxPanel
+              variant="dock"
+              visible={toolboxOpen}
+              onClose={handleToolboxClose}
+              activeTab={toolboxTab}
+              onTabChange={setToolboxTab}
             />
-          </Animated.View>
-        )}
-
-      </View>
-
-      <ToolboxPanel
-        visible={toolboxOpen}
-        onClose={handleToolboxClose}
-        activeTab={toolboxTab}
-        onTabChange={setToolboxTab}
-      />
+          ) : null}
+        </View>
+      ) : (
+        <>
+          {chatMain}
+          <ToolboxPanel
+            variant="overlay"
+            visible={toolboxOpen}
+            onClose={handleToolboxClose}
+            activeTab={toolboxTab}
+            onTabChange={setToolboxTab}
+          />
+        </>
+      )}
     </SafeAreaView>
   );
 

--- a/apps/mobile/components/ToolboxPanel.tsx
+++ b/apps/mobile/components/ToolboxPanel.tsx
@@ -17,9 +17,10 @@ import Animated, {
   Easing,
   runOnJS,
 } from 'react-native-reanimated';
-import { FileText, Search, TerminalSquare } from 'lucide-react-native';
+import { FileText, Search, TerminalSquare, X } from 'lucide-react-native';
 import * as Haptics from '../platform/haptics';
 import { useThemeContext } from '../hooks/useTheme';
+import { useBreakpoint } from '../hooks/useBreakpoint';
 import { ToolboxTerminal } from './toolbox/ToolboxTerminal';
 import { ToolboxBrowser } from './toolbox/ToolboxBrowser';
 import { ReportsContent } from './ReportsViewer';
@@ -36,6 +37,12 @@ interface ToolboxPanelProps {
   onClose: () => void;
   activeTab: number;
   onTabChange: (tab: number) => void;
+  /**
+   * `dock` — desktop side panel (sibling of chat, no overlay/handle).
+   * `overlay` — mobile top sheet with backdrop + drag handle.
+   * Default: desktop → dock, mobile → overlay.
+   */
+  variant?: 'dock' | 'overlay';
 }
 
 export function ToolboxPanel({
@@ -43,42 +50,56 @@ export function ToolboxPanel({
   onClose,
   activeTab,
   onTabChange,
+  variant,
 }: ToolboxPanelProps) {
   const { theme } = useThemeContext();
+  const { isDesktop } = useBreakpoint();
   const t = theme.colors;
   const isDark = theme.scheme === 'dark';
   const { height: windowHeight } = useWindowDimensions();
-  const panelHeight = Math.max(windowHeight, 1);
+  const mode = variant ?? (isDesktop ? 'dock' : 'overlay');
+  const isDock = mode === 'dock';
 
+  const panelHeight = Math.max(windowHeight, 1);
   const progress = useSharedValue(0);
-  const dragY = useSharedValue(0);
+  const dragOffset = useSharedValue(0);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
+    if (isDock) {
+      // Dock is layout-driven by the parent; mount when visible.
+      setMounted(visible);
+      progress.value = visible ? 1 : 0;
+      dragOffset.value = 0;
+      return;
+    }
+
     if (visible) {
       setMounted(true);
-      dragY.value = 0;
+      dragOffset.value = 0;
       progress.value = withSpring(1, SPRING);
     } else {
-      progress.value = withTiming(0, { duration: 200, easing: Easing.out(Easing.cubic) });
+      progress.value = withTiming(0, {
+        duration: 220,
+        easing: Easing.out(Easing.cubic),
+      });
       const timer = setTimeout(() => {
-        dragY.value = 0;
+        dragOffset.value = 0;
         setMounted(false);
-      }, 220);
+      }, 240);
       return () => clearTimeout(timer);
     }
-  }, [visible, progress, dragY]);
+  }, [visible, progress, dragOffset, isDock]);
 
-  const panelStyle = useAnimatedStyle(() => {
-    const upwardDrag = Math.max(-panelHeight, Math.min(dragY.value, 0));
-    const translateY = interpolate(progress.value, [0, 1], [-panelHeight, 0]) + upwardDrag;
+  const overlayPanelStyle = useAnimatedStyle(() => {
+    const upwardDrag = Math.max(-panelHeight, Math.min(dragOffset.value, 0));
+    const translateY =
+      interpolate(progress.value, [0, 1], [-panelHeight, 0]) + upwardDrag;
     return {
       height: panelHeight,
       borderBottomLeftRadius: 20,
       borderBottomRightRadius: 20,
-      transform: [
-        { translateY },
-      ],
+      transform: [{ translateY }],
       opacity: progress.value,
     };
   });
@@ -96,107 +117,148 @@ export function ToolboxPanel({
     onClose();
   }, [onClose]);
 
-  const handleTabChange = useCallback((index: number) => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    onTabChange(index);
-  }, [onTabChange]);
+  const handleTabChange = useCallback(
+    (index: number) => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      onTabChange(index);
+    },
+    [onTabChange],
+  );
 
   const closeHandleGesture = Gesture.Pan()
     .activeOffsetY([-8, 8])
     .failOffsetX([-24, 24])
     .onUpdate((event) => {
-      dragY.value = Math.min(event.translationY, 0);
+      dragOffset.value = Math.min(event.translationY, 0);
     })
     .onEnd((event) => {
       if (event.translationY < -44 || event.velocityY < -500) {
         runOnJS(handleClose)();
         return;
       }
-
-      dragY.value = withSpring(0, SPRING);
+      dragOffset.value = withSpring(0, SPRING);
     });
 
-  if (!mounted) return null;
+  if (isDock && !visible) return null;
+  if (!isDock && !mounted) return null;
 
-  return (
+  const header = (
+    <View style={[styles.header, { borderBottomColor: t.border }]}>
+      <View
+        style={[
+          styles.tabRail,
+          {
+            backgroundColor: t.glass.background,
+            borderColor: t.glass.border,
+          },
+        ]}
+      >
+        {TOOL_TABS.map((tab, index) => {
+          const Icon = tab.icon;
+          const active = index === activeTab;
+          return (
+            <Pressable
+              key={tab.label}
+              accessibilityRole="tab"
+              accessibilityLabel={tab.label}
+              accessibilityState={{ selected: active }}
+              onPress={() => handleTabChange(index)}
+              style={[
+                styles.tabButton,
+                active && { backgroundColor: t.glass.backgroundElevated },
+              ]}
+            >
+              <Icon
+                size={18}
+                color={active ? t.foreground : t.mutedForeground}
+                strokeWidth={active ? 2.1 : 1.8}
+              />
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {isDock ? (
+        <Pressable
+          onPress={handleClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close toolbox"
+          style={styles.closeBtn}
+        >
+          <X size={18} color={t.mutedForeground} strokeWidth={1.8} />
+        </Pressable>
+      ) : null}
+    </View>
+  );
+
+  const body = (
+    <View style={styles.body}>
+      <View style={[styles.tabContent, activeTab !== 0 && styles.hidden]}>
+        <ToolboxTerminal visible={activeTab === 0 && visible} />
+      </View>
+      <View style={[styles.tabContent, activeTab !== 1 && styles.hidden]}>
+        <ToolboxBrowser visible={activeTab === 1 && visible} />
+      </View>
+      <View style={[styles.tabContent, activeTab !== 2 && styles.hidden]}>
+        <ReportsContent visible={activeTab === 2 && visible} />
+      </View>
+    </View>
+  );
+
+  const surface = (
     <>
+      <BlurView
+        intensity={50}
+        tint={isDark ? 'systemChromeMaterialDark' : 'systemChromeMaterialLight'}
+        style={StyleSheet.absoluteFill}
+      />
+      <View
+        style={[
+          StyleSheet.absoluteFill,
+          {
+            backgroundColor: isDark
+              ? 'rgba(11,17,25,0.94)'
+              : 'rgba(255,255,255,0.94)',
+          },
+        ]}
+      />
+      {header}
+      {body}
+    </>
+  );
+
+  // Desktop dock: fixed-width side rail — no overlay, no half-screen flex share.
+  if (isDock) {
+    return (
+      <View
+        style={[
+          styles.dockPanel,
+          { borderLeftColor: t.border, backgroundColor: t.background },
+        ]}
+      >
+        {surface}
+      </View>
+    );
+  }
+
+  // Mobile overlay sheet.
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
       <Animated.View style={[styles.backdrop, backdropStyle]}>
         <Pressable style={StyleSheet.absoluteFill} onPress={handleClose} />
       </Animated.View>
 
-      <Animated.View style={[styles.panel, panelStyle]}>
-        <BlurView
-          intensity={50}
-          tint={isDark ? 'systemChromeMaterialDark' : 'systemChromeMaterialLight'}
-          style={StyleSheet.absoluteFill}
-        />
-        <View
-          style={[
-            StyleSheet.absoluteFill,
-            { backgroundColor: isDark ? 'rgba(11,17,25,0.92)' : 'rgba(255,255,255,0.92)' },
-          ]}
-        />
-
-        <View style={[styles.header, { borderBottomColor: t.border }]}>
-          <View
-            style={[
-              styles.tabRail,
-              {
-                backgroundColor: t.glass.background,
-                borderColor: t.glass.border,
-              },
-            ]}
-          >
-            {TOOL_TABS.map((tab, index) => {
-              const Icon = tab.icon;
-              const active = index === activeTab;
-              return (
-                <Pressable
-                  key={tab.label}
-                  accessibilityRole="tab"
-                  accessibilityLabel={tab.label}
-                  accessibilityState={{ selected: active }}
-                  onPress={() => handleTabChange(index)}
-                  style={[
-                    styles.tabButton,
-                    active && { backgroundColor: t.glass.backgroundElevated },
-                  ]}
-                >
-                  <Icon
-                    size={18}
-                    color={active ? t.foreground : t.mutedForeground}
-                    strokeWidth={active ? 2.1 : 1.8}
-                  />
-                </Pressable>
-              );
-            })}
-          </View>
-        </View>
-
-        <View style={styles.body}>
-          <View style={[styles.tabContent, activeTab !== 0 && styles.hidden]}>
-            <ToolboxTerminal visible={activeTab === 0 && visible} />
-          </View>
-          <View style={[styles.tabContent, activeTab !== 1 && styles.hidden]}>
-            <ToolboxBrowser visible={activeTab === 1 && visible} />
-          </View>
-          <View style={[styles.tabContent, activeTab !== 2 && styles.hidden]}>
-            <ReportsContent visible={activeTab === 2 && visible} />
-          </View>
-        </View>
-
+      <Animated.View style={[styles.panelMobile, overlayPanelStyle]}>
+        {surface}
         <GestureDetector gesture={closeHandleGesture}>
-          <Animated.View style={styles.handleZone}>
+          <Animated.View style={styles.handleZoneMobile}>
             <View
-              style={[
-                styles.handle,
-                { backgroundColor: t.mutedForeground },
-              ]}
+              style={[styles.handleMobile, { backgroundColor: t.mutedForeground }]}
             />
           </Animated.View>
         </GestureDetector>
       </Animated.View>
-    </>
+    </View>
   );
 }
 
@@ -206,13 +268,27 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0,0,0,0.5)',
     zIndex: 200,
   },
-  panel: {
+  panelMobile: {
     position: 'absolute',
     left: 0,
     right: 0,
     top: 0,
     zIndex: 201,
     overflow: 'hidden',
+  },
+  /**
+   * Fixed side rail — never flex-share with chat (no % / flex:1 half-screen).
+   * Width must match TOOLBOX_DOCK_WIDTH in chat-screen/styles.
+   */
+  dockPanel: {
+    width: 360,
+    flexGrow: 0,
+    flexShrink: 0,
+    flexBasis: 360,
+    alignSelf: 'stretch',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    borderLeftWidth: StyleSheet.hairlineWidth,
   },
   header: {
     flexDirection: 'row',
@@ -221,6 +297,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 8,
     borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 10,
   },
   tabRail: {
     flexDirection: 'row',
@@ -237,10 +314,18 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  closeBtn: {
+    position: 'absolute',
+    right: 10,
+    width: 32,
+    height: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   body: {
     flex: 1,
   },
-  handleZone: {
+  handleZoneMobile: {
     position: 'absolute',
     left: 0,
     right: 0,
@@ -250,7 +335,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     zIndex: 6,
   },
-  handle: {
+  handleMobile: {
     width: 44,
     height: 5,
     borderRadius: 999,

--- a/apps/mobile/components/chat/AccordionControls.tsx
+++ b/apps/mobile/components/chat/AccordionControls.tsx
@@ -40,6 +40,7 @@ import {
   FileText,
 } from 'lucide-react-native';
 import { useThemeContext } from '../../hooks/useTheme';
+import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { cycleThinkingLevel, type ThinkingLevel } from '@krusty/api';
 import type { PermissionMode } from '@krusty/state';
 
@@ -106,6 +107,82 @@ const PROVIDER_AUTO_SCROLL_MAX_STEP = 18;
 const PROVIDER_REORDER_SPRING_CONFIG = { damping: 24, stiffness: 420, mass: 0.55 };
 const PROVIDER_REORDER_LONG_PRESS_MS = 460;
 
+/** Desktop provider filter — keeps staggered spring entrance without scale-to-zero. */
+function DesktopFilterPill({
+  index,
+  active,
+  label,
+  onPress,
+  children,
+}: {
+  index: number;
+  active: boolean;
+  label: string;
+  onPress: () => void;
+  children: React.ReactNode;
+}) {
+  const { theme } = useThemeContext();
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = withDelay(
+      index * OPEN_STAGGER_MS,
+      withSpring(1, SPRING_CONFIG),
+    );
+  }, [index, progress]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: progress.value,
+    transform: [
+      { translateX: interpolate(progress.value, [0, 1], [16, 0]) },
+      { scale: interpolate(progress.value, [0, 1], [0.88, 1]) },
+    ],
+  }));
+
+  const g = theme.colors.glass;
+
+  return (
+    <Animated.View style={[styles.desktopFilterHit, animatedStyle]}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Filter models by ${label}`}
+        onPress={() => {
+          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+          onPress();
+        }}
+        style={styles.desktopFilterHit}
+      >
+        <BlurView
+          intensity={theme.colors.glassBlur}
+          tint={
+            theme.scheme === 'dark' ? 'systemMaterialDark' : 'systemMaterialLight'
+          }
+          style={styles.providerDockBlur}
+        >
+          <View
+            style={[
+              styles.providerDockPill,
+              {
+                backgroundColor: active
+                  ? theme.colors.thinking + '18'
+                  : g.background,
+                borderColor: active
+                  ? theme.colors.thinking + '80'
+                  : g.border,
+                borderWidth: StyleSheet.hairlineWidth,
+                alignItems: 'center',
+                justifyContent: 'center',
+              },
+            ]}
+          >
+            {children}
+          </View>
+        </BlurView>
+      </Pressable>
+    </Animated.View>
+  );
+}
+
 function AccordionPill({
   children,
   index,
@@ -114,6 +191,7 @@ function AccordionPill({
   active = false,
   sideContent,
   disabled = false,
+  compact = false,
 }: {
   children: React.ReactNode;
   index: number;
@@ -122,6 +200,8 @@ function AccordionPill({
   active?: boolean;
   sideContent?: React.ReactNode;
   disabled?: boolean;
+  /** When true, only as wide as the pill (no full-width row stretch). */
+  compact?: boolean;
 }) {
   const { theme } = useThemeContext();
   const progress = useSharedValue(0);
@@ -156,7 +236,10 @@ function AccordionPill({
   return (
     <Animated.View
       pointerEvents="box-none"
-      style={[styles.pillOuter, animatedStyle]}
+      style={[
+        compact ? styles.pillOuterCompact : styles.pillOuter,
+        animatedStyle,
+      ]}
     >
       {sideContent}
       <Pressable disabled={!isOpen || disabled} onPress={onPress}>
@@ -584,6 +667,9 @@ export function AccordionControls({
   onResearchToggle,
 }: AccordionControlsProps) {
   const { theme } = useThemeContext();
+  const { isDesktop } = useBreakpoint();
+  // Desktop has room — no edge-fade “scroll chrome” or long-press reorder.
+  const enableProviderReorder = !isDesktop && providerFilters.length > 1;
   const providerScrollRef = useRef<ScrollView>(null);
   const providerDockOpenRef = useRef(false);
   const providerEditExitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -884,11 +970,52 @@ export function AccordionControls({
       }
     });
 
+  const g = theme.colors.glass;
+  const showDesktopFilters = isDesktop && modelPickerOpen && isOpen;
+  const desktopFilterCount = providerFilters.length;
+
   return (
     <View style={styles.container} pointerEvents="box-none">
       {/* Floating accordion pills */}
       <GestureDetector gesture={swipeDown}>
         <Animated.View style={styles.pillColumn}>
+          {/* Desktop: filters + bot as a flex row. Filters keep a light stagger
+              animation but avoid nested sideContent/scale-to-zero (which hid them). */}
+          {isDesktop ? (
+            <View style={styles.desktopModelRow} pointerEvents="box-none">
+              {showDesktopFilters
+                ? providerFilters.map((provider, visualIndex) => {
+                    const active = selectedProviderFilter === provider.id;
+                    // Stagger from the bot outward (right → left).
+                    const staggerIndex = desktopFilterCount - visualIndex - 1;
+                    return (
+                      <DesktopFilterPill
+                        key={provider.id}
+                        index={staggerIndex}
+                        active={active}
+                        label={provider.label}
+                        onPress={() => onProviderFilterToggle(provider.id)}
+                      >
+                        {provider.icon}
+                      </DesktopFilterPill>
+                    );
+                  })
+                : null}
+              <AccordionPill
+                index={5}
+                isOpen={isOpen}
+                onPress={handleModel}
+                active={modelPickerOpen}
+                compact
+              >
+                <Bot
+                  size={24}
+                  color={modelPickerOpen ? fabAccent : t.mutedForeground}
+                  strokeWidth={1.6}
+                />
+              </AccordionPill>
+            </View>
+          ) : (
           <AccordionPill
             index={5}
             isOpen={isOpen}
@@ -925,8 +1052,8 @@ export function AccordionControls({
                       itemCount={providerFilters.length}
                       isOpen={modelPickerOpen && isOpen}
                       active={selectedProviderFilter === provider.id}
-                      editMode={providerEditMode}
-                      canReorder={providerFilters.length > 1}
+                      editMode={enableProviderReorder && providerEditMode}
+                      canReorder={enableProviderReorder}
                       dragIndex={providerDragIndex}
                       dropIndex={providerDropIndex}
                       sharedDragX={providerDragX}
@@ -941,7 +1068,10 @@ export function AccordionControls({
                     </ProviderDockPill>
                   ))}
                 </ScrollView>
-                <Animated.View pointerEvents="none" style={[styles.modelFilterFadeLeft, providerDockFadeAnimatedStyle]}>
+                <Animated.View
+                  pointerEvents="none"
+                  style={[styles.modelFilterFadeLeft, providerDockFadeAnimatedStyle]}
+                >
                   <LinearGradient
                     colors={[dockFadeColor, 'transparent']}
                     start={{ x: 0, y: 0.5 }}
@@ -949,7 +1079,10 @@ export function AccordionControls({
                     style={StyleSheet.absoluteFill}
                   />
                 </Animated.View>
-                <Animated.View pointerEvents="none" style={[styles.modelFilterFadeRight, providerDockFadeAnimatedStyle]}>
+                <Animated.View
+                  pointerEvents="none"
+                  style={[styles.modelFilterFadeRight, providerDockFadeAnimatedStyle]}
+                >
                   <LinearGradient
                     colors={['transparent', dockFadeColor]}
                     start={{ x: 0, y: 0.5 }}
@@ -966,6 +1099,7 @@ export function AccordionControls({
               strokeWidth={1.6}
             />
           </AccordionPill>
+          )}
 
           <AccordionPill
             index={4}
@@ -1083,6 +1217,31 @@ const styles = StyleSheet.create({
     width: '100%',
     overflow: 'visible',
   },
+  pillOuterCompact: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    height: 56,
+    width: PROVIDER_PILL_SIZE,
+    flexShrink: 0,
+    overflow: 'visible',
+  },
+  desktopModelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    width: '100%',
+    height: 56,
+    gap: PROVIDER_PILL_GAP,
+    overflow: 'visible',
+  },
+  desktopFilterHit: {
+    width: PROVIDER_PILL_SIZE,
+    height: PROVIDER_PILL_SIZE,
+    flexShrink: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   modelFilterDock: {
     flex: 1,
     minWidth: 0,
@@ -1091,6 +1250,21 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     position: 'relative',
     justifyContent: 'center',
+  },
+  modelFilterDockDesktop: {
+    flex: 0,
+    flexGrow: 0,
+    flexShrink: 0,
+    overflow: 'visible',
+    // Same gap ChatBar uses between model list and crab FAB column.
+    marginRight: MODEL_BUTTON_GAP,
+  },
+  modelFilterRowDesktop: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    height: PROVIDER_DOCK_HEIGHT,
+    width: '100%',
   },
   modelFilterScroll: {
     flex: 1,

--- a/apps/mobile/components/chat/ChatBar.tsx
+++ b/apps/mobile/components/chat/ChatBar.tsx
@@ -31,6 +31,7 @@ import Animated, {
   Easing,
 } from 'react-native-reanimated';
 import { useThemeContext } from '../../hooks/useTheme';
+import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { AccordionControls } from './AccordionControls';
 import { Waveform } from './Waveform';
 import { CrabIcon } from '../ui/CrabIcon';
@@ -72,19 +73,28 @@ interface ChatBarProps {
   onResearchToggle?: () => void;
   tokenCount?: number;
   onOverlayOpenChange?: (open: boolean) => void;
+  /**
+   * Desktop: shared chat content band width. Composer + FABs size against this
+   * (or measured root width) instead of the full window, so toolbox / resize
+   * never clip controls off-screen.
+   */
+  contentMaxWidth?: number;
 }
 
 const PILL = 56;
+/** Same rounded-square corner as accordion FABs (not a full circle). */
 const RADIUS = 18;
 const GAP = 10;
 const ROOT_HORIZONTAL_PADDING = 10;
 const COMPOSER_MAX_HEIGHT = 112;
-const INPUT_SIDE_PADDING = 8;
+const INPUT_SIDE_PADDING = 10;
 const INPUT_GROWTH_CHROME = 8;
 const INPUT_LINE_HEIGHT = 22;
 const INPUT_COLLAPSED_MAX_HEIGHT = PILL - 18;
 const INPUT_EXPANDED_VERTICAL_PADDING = 8;
 const CLOSED_COMPOSER_BOTTOM_GAP = 16;
+/** Extra lift on desktop so the bar doesn't hug the window chrome. */
+const CLOSED_COMPOSER_BOTTOM_GAP_DESKTOP = 28;
 const GAUGE_SIZE = 28;
 const GAUGE_TOP_GAP = 4;
 const META_ROW_HEIGHT = 24;
@@ -92,6 +102,10 @@ const RUN_LINE_HEIGHT = 3;
 const RUN_LINE_META_GAP = 3;
 const RUN_LINE_BEAM_WIDTH = 156;
 const MODEL_POPOVER_MAX_HEIGHT = PILL * 5 + GAP * 4;
+/** Matches AccordionControls PROVIDER_PILL_STEP (56 + 8 gap). */
+const PROVIDER_PILL_STEP = 64;
+/** Gap between provider dock / model list and the bot+crab FAB column. */
+const DOCK_TO_FAB_GAP = 10;
 const PROVIDER_FILTER_ORDER_KEY = 'krusty-provider-filter-order-v1';
 const WEB_INPUT_STYLE = Platform.OS === 'web'
   ? ({
@@ -455,9 +469,11 @@ export function ChatBar(props: ChatBarProps) {
     fastModeEnabled, fastModeSupported, onFastModeToggle,
     mode, onModeToggle, onModelSelect, model, models,
     sessionType, researchEnabled, onResearchToggle, tokenCount, onOverlayOpenChange,
+    contentMaxWidth,
   } = props;
 
   const { theme } = useThemeContext();
+  const { isDesktop } = useBreakpoint();
   const insets = useSafeAreaInsets();
   const { width: viewportWidth, height: viewportHeight } = useWindowDimensions();
   const [text, setText] = useState('');
@@ -485,6 +501,8 @@ export function ChatBar(props: ChatBarProps) {
   const accordionOpenRef = useRef(false);
   const measuredRootHeightRef = useRef(0);
   const reportedComposerHeightRef = useRef(0);
+  /** Actual laid-out band width (after parent maxWidth / split). */
+  const [measuredRootWidth, setMeasuredRootWidth] = useState(0);
   const modelCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clearModelCloseTimer = () => {
@@ -578,10 +596,14 @@ export function ChatBar(props: ChatBarProps) {
   const t = theme.colors;
   const isDark = theme.scheme === 'dark';
   const isMako = sessionType === 'mako';
-  const borderColor = 'rgba(255,255,255,0.08)';
-  const bgOverlay = isDark ? 'rgba(11,17,25,0.6)' : 'rgba(255,255,255,0.6)';
+  // Match FAB glass so the composer isn't a flat grey strip against the shell.
+  const borderColor = t.glass.border;
+  const bgOverlay = isDark
+    ? 'rgba(14, 20, 30, 0.88)'
+    : 'rgba(255, 255, 255, 0.88)';
   const blurTint = isDark ? 'systemChromeMaterialDark' as const : 'systemChromeMaterialLight' as const;
   const pillTint = isDark ? 'systemMaterialDark' as const : 'systemMaterialLight' as const;
+  const composerBlur = Math.max(theme.colors.glassBlur ?? 20, isDesktop ? 48 : 40);
   const providerFilters = useMemo<ProviderFilter[]>(() => {
     const seen = new Set<string>();
     const filters: ProviderFilter[] = [];
@@ -882,10 +904,16 @@ export function ChatBar(props: ChatBarProps) {
   const kColor = kActive ? t.thinking : t.mutedForeground;
   const kBorder = kActive ? t.thinking + '40' : borderColor;
 
-  // Bottom offset: keyboard height, or a compact safe-area gap when keyboard is closed.
-  const closedBottomOffset = Platform.OS === 'web'
-    ? insets.bottom
-    : Math.max(10, Math.min(insets.bottom, CLOSED_COMPOSER_BOTTOM_GAP));
+  // Bottom offset: keyboard height, or a safe-area gap when keyboard is closed.
+  // Desktop gets extra padding so the bar sits above the window edge cleanly.
+  const closedGap = isDesktop
+    ? CLOSED_COMPOSER_BOTTOM_GAP_DESKTOP
+    : CLOSED_COMPOSER_BOTTOM_GAP;
+  const closedBottomOffset = isDesktop
+    ? Math.max(closedGap, insets.bottom + 12)
+    : Platform.OS === 'web'
+      ? Math.max(closedGap, insets.bottom)
+      : Math.max(10, Math.min(insets.bottom, closedGap));
   const bottomOffset = keyboardHeight > 0 ? keyboardHeight : closedBottomOffset;
   const gaugeTokens = tokenCount ?? 0;
   const gaugePct = Math.min(100, (gaugeTokens / 200000) * 100);
@@ -903,14 +931,65 @@ export function ChatBar(props: ChatBarProps) {
     Math.min(inputContentHeight || INPUT_LINE_HEIGHT, INPUT_COLLAPSED_MAX_HEIGHT),
   );
   const metaReserveHeight = META_ROW_HEIGHT + GAUGE_TOP_GAP;
-  const overlayBottom = bottomOffset + metaReserveHeight + composerBarHeight + GAP;
+  // Distance from root bottom to the top of the input/crab row.
+  const inputRowBottom = bottomOffset + metaReserveHeight;
+  // Accordion sits just above the crab FAB.
+  const controlsLayerBottom = inputRowBottom + PILL + GAP;
+  // Space above the input row where the model list may sit.
+  const overlayBottom = inputRowBottom + composerBarHeight + GAP;
   const runLineBottom = Math.max(0, bottomOffset - RUN_LINE_HEIGHT - RUN_LINE_META_GAP);
-  const controlsLayerWidth = Math.max(PILL, viewportWidth - ROOT_HORIZONTAL_PADDING * 2);
-  const modelPopoverTopInset = Math.max(insets.top, 0) + 12;
-  const modelPopoverHeight = Math.min(
-    MODEL_POPOVER_MAX_HEIGHT,
-    Math.max(0, viewportHeight - overlayBottom - modelPopoverTopInset),
+  // Prefer measured column width over viewport so split/toolbox/resize stay in-bounds.
+  const bandWidth =
+    measuredRootWidth > 0
+      ? measuredRootWidth
+      : contentMaxWidth != null && contentMaxWidth > 0
+        ? contentMaxWidth
+        : viewportWidth;
+  const controlsLayerWidth = Math.max(
+    PILL,
+    bandWidth - ROOT_HORIZONTAL_PADDING * 2,
   );
+  const modelPopoverTopInset = Math.max(insets.top, 0) + 12;
+
+  // Accordion stack above the crab: thinking → … → bot+filters (top).
+  const ACCORDION_PILL_COUNT = 6;
+  const pillsBelowBot = ACCORDION_PILL_COUNT - 1;
+  // Bottom edge of the bot/filter row, from the root bottom.
+  const botRowBottom =
+    controlsLayerBottom + pillsBelowBot * (PILL + GAP);
+  // Pin the *top* of the model list snug under the filter row (10px gap),
+  // then grow downward toward the input — no floating mid-gap.
+  const listTopGap = 10;
+  const desktopModelListMaxHeight = Math.max(
+    0,
+    botRowBottom - listTopGap - overlayBottom,
+  );
+  const desktopModelListHeight = Math.min(
+    MODEL_POPOVER_MAX_HEIGHT,
+    Math.max(PILL * 2, desktopModelListMaxHeight),
+  );
+  // top = botRowBottom - listTopGap  ⇒  bottom = top - height
+  const desktopModelListBottom =
+    botRowBottom - listTopGap - desktopModelListHeight;
+
+  const modelPopoverHeight = isDesktop
+    ? desktopModelListHeight
+    : Math.min(
+        MODEL_POPOVER_MAX_HEIGHT,
+        Math.max(0, viewportHeight - overlayBottom - modelPopoverTopInset),
+      );
+  // Match desktop filter row: n×56px pills with 8px gaps (no trailing gap).
+  const providerCount = Math.max(1, visualProviderFilters.length);
+  const providerDockWidth =
+    providerCount * 56 + Math.max(0, providerCount - 1) * 8;
+  const modelPopoverWidth = isDesktop ? providerDockWidth : undefined;
+  // Align under the filter strip (same right edge as filters).
+  // controlsLayer is already right-aligned at ROOT_HORIZONTAL_PADDING; bot is the
+  // rightmost control, filters sit 8px left of bot — do NOT also add crab width.
+  const FILTER_TO_BOT_GAP = 8;
+  const dockRightInset = isDesktop
+    ? ROOT_HORIZONTAL_PADDING + PILL + FILTER_TO_BOT_GAP
+    : ROOT_HORIZONTAL_PADDING + PILL + DOCK_TO_FAB_GAP;
 
   useEffect(() => {
     const measuredRootHeight = measuredRootHeightRef.current;
@@ -927,15 +1006,32 @@ export function ChatBar(props: ChatBarProps) {
   return (
     <View
       pointerEvents="box-none"
-      style={[styles.root, { paddingBottom: bottomOffset }]}
+      style={[
+        styles.root,
+        {
+          paddingBottom: bottomOffset,
+          // Parent desktop column already caps width; fill that band only.
+          // Avoid left+right+maxWidth fights on web that ignore the soft-cap.
+          ...(contentMaxWidth != null
+            ? {
+                width: '100%',
+                maxWidth: contentMaxWidth,
+                alignSelf: 'center' as const,
+                left: 0,
+                right: undefined,
+              }
+            : null),
+        },
+      ]}
       onLayout={(event) => {
-        measuredRootHeightRef.current = event.nativeEvent.layout.height;
+        const { height, width } = event.nativeEvent.layout;
+        measuredRootHeightRef.current = height;
+        const nextWidth = Math.round(width);
+        setMeasuredRootWidth((prev) => (prev === nextWidth ? prev : nextWidth));
         if (!onHeightChange) return;
         const reservedHeight = Math.max(
           PILL,
-          Math.ceil(
-            event.nativeEvent.layout.height - (keyboardHeight > 0 ? keyboardHeight : 0),
-          ),
+          Math.ceil(height - (keyboardHeight > 0 ? keyboardHeight : 0)),
         );
         if (reportedComposerHeightRef.current === reservedHeight) return;
         reportedComposerHeightRef.current = reservedHeight;
@@ -1009,8 +1105,18 @@ export function ChatBar(props: ChatBarProps) {
       {/* L-shape: [input bar] + [K column] */}
       <View style={styles.lRow}>
         {/* Input bar */}
-        <View style={[styles.bar, { borderColor, height: composerBarHeight }]}>
-          <BlurView intensity={40} tint={blurTint} style={StyleSheet.absoluteFill} />
+        <View
+          style={[
+            styles.bar,
+            {
+              borderColor,
+              height: composerBarHeight,
+              // Always rounded-square like FABs — not a full capsule/circle.
+              borderRadius: RADIUS,
+            },
+          ]}
+        >
+          <BlurView intensity={composerBlur} tint={blurTint} style={StyleSheet.absoluteFill} />
           <View style={[StyleSheet.absoluteFill, { backgroundColor: bgOverlay }]} />
           <View style={styles.barInner}>
             {isRecording
@@ -1071,63 +1177,115 @@ export function ChatBar(props: ChatBarProps) {
           </View>
         </View>
 
-        {/* K column */}
+        {/* Crab FAB only — accordion lives at root so filter dock is not clipped */}
         <View style={styles.kCol}>
-          {accordionVisible ? (
-            <View
-              pointerEvents="box-none"
-              style={[styles.controlsLayer, { width: controlsLayerWidth }]}
-            >
-              <AccordionControls
-                thinkingLevel={thinkingLevel}
-                onThinkingChange={onThinkingChange}
-                permissionMode={permissionMode}
-                onPermissionModeToggle={onPermissionModeToggle}
-                fastModeEnabled={fastModeEnabled}
-                fastModeSupported={fastModeSupported}
-                onFastModeToggle={onFastModeToggle}
-                mode={mode}
-                onModeToggle={onModeToggle}
-                onAttach={handleAttach}
-                attachPickerOpen={attachPickerOpen}
-                onPickPhoto={pickPhoto}
-                onPickCamera={pickCamera}
-                onPickFile={pickFile}
-                onModelSelect={() => modelPickerOpen ? closeModelPicker() : openModelPicker()}
-                modelPickerOpen={modelRailOpen}
-                providerFilters={providerFilterActions}
-                selectedProviderFilter={selectedProviderFilter}
-                onProviderFiltersReorder={handleProviderFiltersReorder}
-                onProviderFilterToggle={(providerId) => {
-                  setSelectedProviderFilter(current =>
-                    current === providerId ? null : providerId,
-                  );
-                }}
-                model={model}
-                isOpen={accordionOpen}
-                onToggle={toggleAccordion}
-                sessionType={sessionType}
-                researchEnabled={researchEnabled}
-                onResearchToggle={onResearchToggle}
-              />
-            </View>
-          ) : null}
-          <Pressable onPress={toggleAccordion} style={styles.kWrap}>
-            <BlurView intensity={20} tint={pillTint} style={StyleSheet.absoluteFill} />
+          <Pressable
+            onPress={toggleAccordion}
+            style={[
+              styles.kWrap,
+              {
+                borderColor: kBorder,
+                borderRadius: RADIUS,
+                backgroundColor: kActive ? t.thinking + '14' : undefined,
+              },
+            ]}
+          >
+            <BlurView intensity={composerBlur} tint={pillTint} style={StyleSheet.absoluteFill} />
             <View style={[StyleSheet.absoluteFill, { backgroundColor: bgOverlay }]} />
-            <View style={[styles.kInner, { borderColor: kBorder }]}>
+            <View style={styles.kInner}>
               <CrabIcon size={26} color={kColor} />
             </View>
           </Pressable>
         </View>
       </View>
 
-      {/* Model popover — slides out from behind accordion */}
+      {/* Accordion FABs + provider filters: positioned on the root, NOT inside the
+          56px crab column (WebKit clips overflow from that narrow column). */}
+      {accordionVisible ? (
+        <View
+          pointerEvents="box-none"
+          style={[
+            styles.controlsLayer,
+            {
+              bottom: controlsLayerBottom,
+              width: controlsLayerWidth,
+              right: ROOT_HORIZONTAL_PADDING,
+              zIndex: modelPickerOpen || modelRailOpen ? 40 : 20,
+            },
+          ]}
+        >
+          <AccordionControls
+            thinkingLevel={thinkingLevel}
+            onThinkingChange={onThinkingChange}
+            permissionMode={permissionMode}
+            onPermissionModeToggle={onPermissionModeToggle}
+            fastModeEnabled={fastModeEnabled}
+            fastModeSupported={fastModeSupported}
+            onFastModeToggle={onFastModeToggle}
+            mode={mode}
+            onModeToggle={onModeToggle}
+            onAttach={handleAttach}
+            attachPickerOpen={attachPickerOpen}
+            onPickPhoto={pickPhoto}
+            onPickCamera={pickCamera}
+            onPickFile={pickFile}
+            onModelSelect={() =>
+              modelPickerOpen ? closeModelPicker() : openModelPicker()
+            }
+            modelPickerOpen={modelRailOpen}
+            providerFilters={providerFilterActions}
+            selectedProviderFilter={selectedProviderFilter}
+            onProviderFiltersReorder={handleProviderFiltersReorder}
+            onProviderFilterToggle={(providerId) => {
+              setSelectedProviderFilter((current) =>
+                current === providerId ? null : providerId,
+              );
+            }}
+            model={model}
+            isOpen={accordionOpen}
+            onToggle={toggleAccordion}
+            sessionType={sessionType}
+            researchEnabled={researchEnabled}
+            onResearchToggle={onResearchToggle}
+          />
+        </View>
+      ) : null}
+
+      {/* Model popover — under the filter row, same width + right edge */}
       {modelPickerOpen && modelPopoverHeight > 0 && (
-        <View style={[styles.modelClip, { bottom: overlayBottom, height: modelPopoverHeight }]}>
-          <Animated.View style={[styles.modelPopover, modelPopoverStyle]}>
+        <View
+          style={
+            isDesktop && modelPopoverWidth != null
+              ? {
+                  position: 'absolute' as const,
+                  // Stay below the bot + provider filter row so filters stay visible.
+                  bottom: desktopModelListBottom,
+                  height: modelPopoverHeight,
+                  right: dockRightInset,
+                  width: modelPopoverWidth,
+                  overflow: 'hidden' as const,
+                  // Below the accordion/filter dock (zIndex 40 when open).
+                  zIndex: 25,
+                  elevation: 25,
+                }
+              : [
+                  styles.modelClip,
+                  {
+                    bottom: overlayBottom,
+                    height: modelPopoverHeight,
+                  },
+                ]
+          }
+        >
+          <Animated.View
+            style={[
+              styles.modelPopover,
+              modelPopoverStyle,
+              { borderColor: t.glass.border },
+            ]}
+          >
             <BlurView
-              intensity={theme.colors.glassBlur}
+              intensity={composerBlur}
               tint={pillTint}
               style={StyleSheet.absoluteFill}
             />
@@ -1135,7 +1293,9 @@ export function ChatBar(props: ChatBarProps) {
               style={[
                 StyleSheet.absoluteFill,
                 {
-                  backgroundColor: t.glass.background,
+                  backgroundColor: isDark
+                    ? 'rgba(14, 20, 30, 0.92)'
+                    : 'rgba(255, 255, 255, 0.92)',
                   borderRadius: RADIUS,
                 },
               ]}
@@ -1215,7 +1375,7 @@ export function ChatBar(props: ChatBarProps) {
       </View>
       <RunningGradientLine
         active={isStreaming}
-        width={viewportWidth}
+        width={bandWidth}
         color={t.thinking}
         style={[styles.runLineEdge, { bottom: runLineBottom }]}
       />
@@ -1274,6 +1434,12 @@ const styles = StyleSheet.create({
     borderRadius: RADIUS,
     overflow: 'hidden',
     borderWidth: StyleSheet.hairlineWidth,
+    // Subtle depth so the composer reads as a FAB dock, not a grey slab.
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.22,
+    shadowRadius: 18,
+    elevation: 8,
   },
   barInner: {
     flexDirection: 'row',
@@ -1316,18 +1482,31 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     overflow: 'visible',
     position: 'relative',
+    zIndex: 15,
   },
   controlsLayer: {
     position: 'absolute',
-    right: 0,
-    bottom: PILL + GAP,
+    // bottom/right/width set inline from layout metrics
     alignItems: 'flex-end',
-    zIndex: 20,
+    overflow: 'visible',
   },
-  kWrap: { width: PILL, height: PILL, borderRadius: RADIUS, overflow: 'hidden', borderWidth: StyleSheet.hairlineWidth, borderColor: 'rgba(255,255,255,0.08)' },
+  kWrap: {
+    width: PILL,
+    height: PILL,
+    // Rounded square — matches accordion FAB pills (not a circle).
+    borderRadius: RADIUS,
+    overflow: 'hidden',
+    borderWidth: StyleSheet.hairlineWidth,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.2,
+    shadowRadius: 14,
+    elevation: 8,
+  },
   kInner: { flex: 1, justifyContent: 'center', alignItems: 'center' },
 
-  // Clip container — hides the popover as it slides from behind accordion
+  // Clip container — hides the popover as it slides from behind accordion.
+  // Mobile: full width under the bar. Desktop: right-aligned dock width.
   modelClip: {
     position: 'absolute',
     left: ROOT_HORIZONTAL_PADDING,
@@ -1344,7 +1523,11 @@ const styles = StyleSheet.create({
     borderRadius: RADIUS,
     overflow: 'hidden',
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: 'rgba(255,255,255,0.1)',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 10 },
+    shadowOpacity: 0.28,
+    shadowRadius: 20,
+    elevation: 12,
   },
   providerInitials: {
     fontSize: 11,

--- a/apps/mobile/components/chat/ChatTranscript.tsx
+++ b/apps/mobile/components/chat/ChatTranscript.tsx
@@ -642,9 +642,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
   },
   listDesktop: {
-    maxWidth: 800,
-    alignSelf: "center",
+    // Parent desktopChatColumn already caps width; fill the fluid band.
     width: "100%",
+    maxWidth: "100%",
+    // Slightly tighter side pad so messages expand with the window.
+    paddingHorizontal: 12,
   },
   turn: {
     marginBottom: 12,

--- a/apps/mobile/components/chat/MarkdownContent.tsx
+++ b/apps/mobile/components/chat/MarkdownContent.tsx
@@ -16,6 +16,7 @@ export function MarkdownContent({ content, isUser }: MarkdownContentProps) {
   const { theme } = useThemeContext();
   const t = theme.colors;
   const [previewImage, setPreviewImage] = useState<{ uri: string; title?: string } | null>(null);
+  const [hoveredImageKey, setHoveredImageKey] = useState<unknown>(null);
 
   const handleLink = useCallback((url: string) => {
     Linking.openURL(url);
@@ -42,10 +43,13 @@ export function MarkdownContent({ content, isUser }: MarkdownContentProps) {
                 Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                 setPreviewImage({ uri, title });
               }}
-              style={({ pressed, hovered }) => [
+              onHoverIn={() => setHoveredImageKey(node.key)}
+              onHoverOut={() => setHoveredImageKey(null)}
+              style={({ pressed }) => [
                 markdownImageStyles.frame,
                 {
-                  borderColor: hovered ? t.userMessage : t.border,
+                  borderColor:
+                    hoveredImageKey === node.key ? t.userMessage : t.border,
                   opacity: pressed ? 0.88 : 1,
                 },
               ]}

--- a/apps/mobile/components/chat/MessageBubble.tsx
+++ b/apps/mobile/components/chat/MessageBubble.tsx
@@ -327,6 +327,8 @@ function MessageAttachments({
   const t = theme.colors;
   const [previewAttachment, setPreviewAttachment] =
     useState<ChatMessageAttachment | null>(null);
+  const [hoveredAttachmentIndex, setHoveredAttachmentIndex] =
+    useState<number | null>(null);
   const previewUri = imagePreviewUri(previewAttachment);
 
   return (
@@ -344,10 +346,17 @@ function MessageAttachments({
                 void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                 setPreviewAttachment(attachment);
               }}
-              style={({ pressed, hovered }) => [
+              onHoverIn={() => setHoveredAttachmentIndex(index)}
+              onHoverOut={() =>
+                setHoveredAttachmentIndex((current) =>
+                  current === index ? null : current,
+                )
+              }
+              style={({ pressed }) => [
                 styles.messageImageThumb,
                 {
-                  borderColor: hovered ? t.userMessage : t.border,
+                  borderColor:
+                    hoveredAttachmentIndex === index ? t.userMessage : t.border,
                   opacity: pressed ? 0.86 : 1,
                 },
               ]}

--- a/apps/mobile/components/chat/MessageBubble.tsx
+++ b/apps/mobile/components/chat/MessageBubble.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Image, View, Text, Pressable, StyleSheet } from "react-native";
 import { Brain, ChevronDown, ChevronRight, Clock } from "lucide-react-native";
 import { useThemeContext } from "../../hooks/useTheme";
+import { useBreakpoint } from "../../hooks/useBreakpoint";
 import { AssistantSegmentedContent } from "./AssistantSegmentedContent";
 import { MarkdownContent } from "./MarkdownContent";
 import { ToolCallCard } from "./ToolCallCard";
@@ -50,6 +51,7 @@ export function MessageBubble({
   onPlanConfirm,
 }: MessageBubbleProps) {
   const { theme } = useThemeContext();
+  const { isDesktop } = useBreakpoint();
   const t = theme.colors;
   const isUser = message.role === "user";
   const [copied, setCopied] = useState(false);
@@ -217,7 +219,12 @@ export function MessageBubble({
         )}
 
       {!isUser && (
-        <View style={styles.assistantWrap}>
+        <View
+          style={[
+            styles.assistantWrap,
+            isDesktop ? styles.assistantWrapDesktop : null,
+          ]}
+        >
           {assistantSegments.map(renderAssistantSegment)}
 
           {copied ? (
@@ -433,8 +440,13 @@ const styles = StyleSheet.create({
     maxWidth: "92%",
     gap: 10,
   },
+  assistantWrapDesktop: {
+    // Use the full fluid chat band on desktop.
+    maxWidth: "100%",
+    width: "100%",
+  },
   userWrap: {
-    maxWidth: "84%",
+    maxWidth: "88%",
     gap: 6,
   },
   userQueuedWrap: {

--- a/apps/mobile/components/layout/DesktopShell.tsx
+++ b/apps/mobile/components/layout/DesktopShell.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
 import {
   Settings, SquarePlus, FolderPlus, Wifi, WifiOff,
-  PanelLeftClose, PanelLeftOpen, TerminalSquare, Globe,
+  PanelLeftClose, PanelLeftOpen,
 } from 'lucide-react-native';
 import * as Haptics from '../../platform/haptics';
 import { BlurView } from '../../platform/blur';
@@ -12,8 +12,6 @@ import { useConnection } from '../../hooks/useConnection';
 import { SessionList, type SessionListProps } from '../chat/SessionList';
 import { PlanTracker } from '../chat/PlanTracker';
 import { SettingsModal } from '../SettingsModal';
-import { Terminal } from '../desktop/Terminal';
-import { WorkspacePreview } from '../desktop/WorkspacePreview';
 
 const SIDEBAR_WIDTH = 280;
 
@@ -37,11 +35,10 @@ export function DesktopShell({
   const t = theme.colors;
   const isDark = theme.scheme === 'dark';
 
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  // Default closed — open chat canvas first; user expands the menu when needed.
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   const [pickerVisible, setPickerVisible] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [terminalVisible, setTerminalVisible] = useState(false);
-  const [previewVisible, setPreviewVisible] = useState(false);
 
   // Match the mobile drawer's blur/overlay values
   const blurIntensity = 40;
@@ -114,21 +111,7 @@ export function DesktopShell({
 
               <View style={{ flex: 1 }} />
 
-              {/* Terminal toggle */}
-              <Pressable
-                onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); setTerminalVisible(v => !v); }}
-                style={styles.iconBtn}
-              >
-                <TerminalSquare size={18} color={terminalVisible ? t.userMessage : t.mutedForeground} strokeWidth={1.8} />
-              </Pressable>
-
-              {/* Preview toggle */}
-              <Pressable
-                onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); setPreviewVisible(v => !v); }}
-                style={styles.iconBtn}
-              >
-                <Globe size={18} color={previewVisible ? t.userMessage : t.mutedForeground} strokeWidth={1.8} />
-              </Pressable>
+              {/* Terminal / browser live in Toolbox — do not duplicate them here. */}
 
               <Pressable onPress={handleNew} style={styles.iconBtn}>
                 {activeTab === 0
@@ -152,14 +135,10 @@ export function DesktopShell({
           </Pressable>
         )}
 
-        {/* Chat content */}
+        {/* Chat content — terminal/browser are Toolbox-only on desktop */}
         <View style={styles.flex}>
           {children}
         </View>
-
-        {/* Bottom panels — terminal and preview */}
-        <Terminal visible={terminalVisible} />
-        <WorkspacePreview visible={previewVisible} />
       </View>
 
       <SettingsModal visible={settingsOpen} onClose={() => setSettingsOpen(false)} />

--- a/apps/mobile/types/xterm-css.d.ts
+++ b/apps/mobile/types/xterm-css.d.ts
@@ -1,0 +1,1 @@
+declare module "xterm/css/xterm.css";

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Burgess <burgess@example.com>
 pkgname=krusty
-pkgver=0.3.0
+pkgver=0.7.3
 pkgrel=1
 pkgdesc="The fun coding assistant"
 arch=('x86_64' 'aarch64')
-url="https://github.com/BurgessTG/Krusty"
+url="https://github.com/honeycomb-Technologies/Krusty"
 license=('MIT')
 depends=('gcc-libs' 'openssl')
 makedepends=('cargo')
-source=("$pkgname-$pkgver.tar.gz::https://github.com/BurgessTG/Krusty/archive/refs/tags/v$pkgver.tar.gz")
+source=("$pkgname-$pkgver.tar.gz::https://github.com/honeycomb-Technologies/Krusty/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('SKIP')
 
 prepare() {

--- a/crates/krusty-cli/Cargo.toml
+++ b/crates/krusty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "The most elegant coding CLI to ever exist"
 default-run = "krusty"

--- a/crates/krusty-cli/src/tui/handlers/stream_events/mod.rs
+++ b/crates/krusty-cli/src/tui/handlers/stream_events/mod.rs
@@ -182,6 +182,7 @@ impl App {
             LoopEvent::Usage {
                 prompt_tokens,
                 completion_tokens,
+                ..
             } => self.handle_usage(prompt_tokens, completion_tokens),
             LoopEvent::SessionPinched {
                 reason,

--- a/crates/krusty-cli/src/tui/utils/clipboard.rs
+++ b/crates/krusty-cli/src/tui/utils/clipboard.rs
@@ -65,6 +65,7 @@ fn read_clipboard_image_platform() -> Option<ClipboardImage> {
     None
 }
 
+#[cfg(target_os = "linux")]
 fn decode_clipboard_image(bytes: &[u8]) -> Option<ClipboardImage> {
     let image = image::load_from_memory(bytes).ok()?.to_rgba8();
     let (width, height) = image.dimensions();

--- a/crates/krusty-client-state/Cargo.toml
+++ b/crates/krusty-client-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client-state"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Headless Rust state machine for Krusty chat clients"
 

--- a/crates/krusty-client-state/src/chat.rs
+++ b/crates/krusty-client-state/src/chat.rs
@@ -551,7 +551,19 @@ impl ChatStore {
             ChatStreamEvent::Usage {
                 prompt_tokens,
                 completion_tokens,
-            } => self.state.token_count = Some(prompt_tokens + completion_tokens),
+                cache_creation_input_tokens,
+                cache_read_input_tokens,
+                total_tokens,
+            } => {
+                self.state.token_count = Some(if total_tokens > 0 {
+                    total_tokens
+                } else {
+                    prompt_tokens
+                        + completion_tokens
+                        + cache_creation_input_tokens
+                        + cache_read_input_tokens
+                });
+            }
             ChatStreamEvent::Lagged { skipped } => {
                 self.push_system(format!("Stream skipped {skipped} non-critical events."));
             }

--- a/crates/krusty-client/Cargo.toml
+++ b/crates/krusty-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Async Rust client for the Krusty server API"
 

--- a/crates/krusty-client/src/types.rs
+++ b/crates/krusty-client/src/types.rs
@@ -626,6 +626,9 @@ pub enum ChatStreamEvent {
     Usage {
         prompt_tokens: usize,
         completion_tokens: usize,
+        cache_creation_input_tokens: usize,
+        cache_read_input_tokens: usize,
+        total_tokens: usize,
     },
     SessionPinched {
         reason: String,
@@ -801,6 +804,9 @@ impl ChatStreamEvent {
             "usage" => Self::Usage {
                 prompt_tokens: usize_field(&value, "prompt_tokens"),
                 completion_tokens: usize_field(&value, "completion_tokens"),
+                cache_creation_input_tokens: usize_field(&value, "cache_creation_input_tokens"),
+                cache_read_input_tokens: usize_field(&value, "cache_read_input_tokens"),
+                total_tokens: usize_field(&value, "total_tokens"),
             },
             "session_pinched" => Self::SessionPinched {
                 reason: string_field(&value, "reason"),

--- a/crates/krusty-core/Cargo.toml
+++ b/crates/krusty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-core"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Core library for Krusty - AI, storage, tools, and extensions"
 

--- a/crates/krusty-core/src/agent/loop_events.rs
+++ b/crates/krusty-core/src/agent/loop_events.rs
@@ -148,8 +148,15 @@ pub enum LoopEvent {
 
     /// Token usage for this turn.
     Usage {
+        /// Uncached input tokens billed at the normal input rate.
         prompt_tokens: usize,
         completion_tokens: usize,
+        /// Input tokens written to a provider prompt cache.
+        cache_creation_input_tokens: usize,
+        /// Input tokens served from a provider prompt cache.
+        cache_read_input_tokens: usize,
+        /// Total input and output tokens represented by this turn snapshot.
+        total_tokens: usize,
     },
 
     /// Active work was handed off into a linked continuation session.

--- a/crates/krusty-core/src/agent/orchestrator.rs
+++ b/crates/krusty-core/src/agent/orchestrator.rs
@@ -90,14 +90,16 @@ fn terminal_agent_state_after_interruption(stop_reason: &LoopStopReason) -> &'st
     }
 }
 
-fn should_retry_empty_stream_idle(
+fn should_retry_empty_stream_interruption(
     stop_reason: Option<&LoopStopReason>,
     text: &str,
     has_pending_or_complete_tool_calls: bool,
     retry_attempted: bool,
 ) -> bool {
-    matches!(stop_reason, Some(LoopStopReason::StreamIdleTimeout))
-        && !retry_attempted
+    matches!(
+        stop_reason,
+        Some(LoopStopReason::StreamIdleTimeout | LoopStopReason::ProviderError)
+    ) && !retry_attempted
         && text.trim().is_empty()
         && !has_pending_or_complete_tool_calls
 }
@@ -341,7 +343,7 @@ impl AgenticOrchestrator {
             model_context_window,
         );
         let mut context_ledger = ContextLedger::from_conversation(&conversation);
-        let mut empty_stream_idle_retry_attempted = false;
+        let mut empty_stream_retry_attempted = false;
         let mut overflow_compact_retry_attempted = false;
         let project_dir_key = project_dir
             .as_ref()
@@ -577,24 +579,24 @@ impl AgenticOrchestrator {
                 messages_at_last_usage = conversation.len();
             }
 
-            if should_retry_empty_stream_idle(
+            if should_retry_empty_stream_interruption(
                 result.stop_reason.as_ref(),
                 &result.recovery_checkpoint.text,
                 !result.tool_calls.is_empty() || !result.recovery_checkpoint.tool_calls.is_empty(),
-                empty_stream_idle_retry_attempted,
+                empty_stream_retry_attempted,
             ) {
-                empty_stream_idle_retry_attempted = true;
+                empty_stream_retry_attempted = true;
                 tracing::warn!(
                     session_id = %session_id,
-                    "Provider stream went idle before text or tool calls; retrying once"
+                    "Provider stream ended before text or tool calls; retrying once"
                 );
                 let _ = event_tx.send(LoopEvent::Error {
-                    error: "Provider stream went idle before producing text or tool calls; retrying once automatically.".to_string(),
+                    error: "Provider stream ended before producing text or tool calls; retrying once automatically.".to_string(),
                 });
                 conversation.push(ModelMessage {
                     role: Role::System,
                     content: vec![Content::Text {
-                        text: "The previous provider stream went idle before producing text or tool calls. Continue from the last completed tool results; either call the next required tool or provide a concise final answer. Do not repeat completed work.".to_string(),
+                        text: "The previous provider stream ended before producing text or tool calls. Continue from the last completed tool results; either call the next required tool or provide a concise final answer. Do not repeat completed work.".to_string(),
                     }],
                 });
                 clear_recovery_state(&db_path, &session_id);
@@ -1119,7 +1121,7 @@ mod tests {
     use super::inject_runtime_context;
     use super::message_builder::finalize_explore_only_turn;
     use super::resolve_project_permission_mode;
-    use super::should_retry_empty_stream_idle;
+    use super::should_retry_empty_stream_interruption;
     use super::terminal_agent_state_after_interruption;
     use crate::agent::loop_events::LoopStopReason;
     use crate::ai::types::{AiToolCall, Content, ModelMessage, Role};
@@ -1142,29 +1144,35 @@ mod tests {
 
     #[test]
     fn empty_stream_idle_retries_once_before_recovery() {
-        assert!(should_retry_empty_stream_idle(
+        assert!(should_retry_empty_stream_interruption(
             Some(&LoopStopReason::StreamIdleTimeout),
             "",
             false,
             false
         ));
-        assert!(!should_retry_empty_stream_idle(
+        assert!(!should_retry_empty_stream_interruption(
             Some(&LoopStopReason::StreamIdleTimeout),
             "partial text",
             false,
             false
         ));
-        assert!(!should_retry_empty_stream_idle(
+        assert!(!should_retry_empty_stream_interruption(
             Some(&LoopStopReason::StreamIdleTimeout),
             "",
             true,
             false
         ));
-        assert!(!should_retry_empty_stream_idle(
+        assert!(!should_retry_empty_stream_interruption(
             Some(&LoopStopReason::StreamIdleTimeout),
             "",
             false,
             true
+        ));
+        assert!(should_retry_empty_stream_interruption(
+            Some(&LoopStopReason::ProviderError),
+            "",
+            false,
+            false
         ));
     }
 

--- a/crates/krusty-core/src/agent/stream.rs
+++ b/crates/krusty-core/src/agent/stream.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 
 use crate::ai::streaming::StreamPart;
-use crate::ai::types::AiToolCall;
+use crate::ai::types::{AiToolCall, FinishReason, Usage};
 use serde_json::Value;
 
 use super::loop_events::{LoopEvent, LoopStopReason};
@@ -64,15 +64,33 @@ pub(crate) async fn process_stream(
     let mut tool_calls = Vec::new();
     let mut recovery_tool_calls = Vec::new();
     let mut last_error = None;
-    let mut total_tokens = 0usize;
-    let mut prompt_tokens = 0usize;
+    let mut usage = Usage::default();
     let mut stop_reason = None;
+    let mut received_finish = false;
     let mut last_checkpoint_text_len = 0usize;
 
     loop {
-        let part = match tokio::time::timeout(idle_timeout, api_rx.recv()).await {
+        let receive_timeout = if received_finish {
+            // OpenAI-compatible streams can emit their usage-only frame after
+            // the finish reason. Drain already queued telemetry without making
+            // every provider keep the turn open for the full idle timeout.
+            Duration::from_millis(250)
+        } else {
+            idle_timeout
+        };
+        let part = match tokio::time::timeout(receive_timeout, api_rx.recv()).await {
             Ok(Some(part)) => part,
-            Ok(None) => break,
+            Ok(None) if received_finish => break,
+            Ok(None) => {
+                let error = "AI stream ended without a finish signal".to_string();
+                let _ = event_tx.send(LoopEvent::Error {
+                    error: error.clone(),
+                });
+                last_error = Some(error);
+                stop_reason = Some(LoopStopReason::ProviderError);
+                break;
+            }
+            Err(_) if received_finish => break,
             Err(_) => {
                 let _ = event_tx.send(LoopEvent::Error {
                     error: format!(
@@ -88,6 +106,17 @@ pub(crate) async fn process_stream(
                 break;
             }
         };
+
+        if received_finish && !matches!(&part, StreamPart::Usage { .. } | StreamPart::Finish { .. })
+        {
+            let error = "AI provider emitted content after its finish signal".to_string();
+            let _ = event_tx.send(LoopEvent::Error {
+                error: error.clone(),
+            });
+            last_error = Some(error);
+            stop_reason = Some(LoopStopReason::ProviderError);
+            break;
+        }
 
         match &part {
             StreamPart::TextDelta { delta } => {
@@ -185,16 +214,73 @@ pub(crate) async fn process_stream(
                     true,
                 );
             }
-            StreamPart::Usage { usage } => {
-                prompt_tokens = usage.prompt_tokens;
-                total_tokens = if usage.total_tokens > 0 {
-                    usage.total_tokens
-                } else {
-                    usage.prompt_tokens + usage.completion_tokens
-                };
+            StreamPart::Finish { reason } => {
+                let incomplete_tool_calls = recovery_tool_calls
+                    .iter()
+                    .filter(|pending| !tool_calls.iter().any(|call| call.id == pending.id))
+                    .count();
+                match reason {
+                    FinishReason::Stop | FinishReason::ToolCalls if incomplete_tool_calls > 0 => {
+                        let error = format!(
+                            "AI response ended with {incomplete_tool_calls} incomplete tool call(s); none were executed"
+                        );
+                        let _ = event_tx.send(LoopEvent::Error {
+                            error: error.clone(),
+                        });
+                        last_error = Some(error);
+                        stop_reason = Some(LoopStopReason::ProviderError);
+                    }
+                    FinishReason::ToolCalls if tool_calls.is_empty() => {
+                        let error = "AI provider reported tool calls but supplied no complete calls; none were executed".to_string();
+                        let _ = event_tx.send(LoopEvent::Error {
+                            error: error.clone(),
+                        });
+                        last_error = Some(error);
+                        stop_reason = Some(LoopStopReason::ProviderError);
+                    }
+                    FinishReason::Stop | FinishReason::ToolCalls => {}
+                    FinishReason::Length => {
+                        let error = "AI response reached its output-token limit; incomplete tool calls were not executed".to_string();
+                        let _ = event_tx.send(LoopEvent::Error {
+                            error: error.clone(),
+                        });
+                        last_error = Some(error);
+                        stop_reason = Some(LoopStopReason::ProviderError);
+                    }
+                    FinishReason::ContentFilter => {
+                        let error =
+                            "AI response was blocked by the provider content filter".to_string();
+                        let _ = event_tx.send(LoopEvent::Error {
+                            error: error.clone(),
+                        });
+                        last_error = Some(error);
+                        stop_reason = Some(LoopStopReason::ProviderError);
+                    }
+                    FinishReason::Other(reason) => {
+                        let error = format!("AI response ended unexpectedly: {reason}");
+                        let _ = event_tx.send(LoopEvent::Error {
+                            error: error.clone(),
+                        });
+                        last_error = Some(error);
+                        stop_reason = Some(LoopStopReason::ProviderError);
+                    }
+                }
+                if stop_reason.is_some() {
+                    break;
+                }
+                received_finish = true;
+            }
+            StreamPart::Usage { usage: snapshot } => {
+                // Usage snapshots can split input and output across events.
+                // Merge them before publishing so downstream cache telemetry and
+                // context budgeting always see the complete turn so far.
+                usage.merge_snapshot(snapshot);
                 let _ = event_tx.send(LoopEvent::Usage {
                     prompt_tokens: usage.prompt_tokens,
                     completion_tokens: usage.completion_tokens,
+                    cache_creation_input_tokens: usage.cache_creation_input_tokens,
+                    cache_read_input_tokens: usage.cache_read_input_tokens,
+                    total_tokens: usage.total_tokens,
                 });
             }
             StreamPart::TextDeltaWithCitations { delta, citations } => {
@@ -276,8 +362,8 @@ pub(crate) async fn process_stream(
         tool_calls,
         recovery_checkpoint,
         last_error,
-        total_tokens,
-        prompt_tokens,
+        total_tokens: usage.total_tokens,
+        prompt_tokens: usage.input_tokens(),
         stop_reason,
     }
 }
@@ -311,7 +397,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::process_stream;
-    use crate::agent::loop_events::LoopEvent;
+    use crate::agent::loop_events::{LoopEvent, LoopStopReason};
     use crate::ai::streaming::StreamPart;
     use crate::ai::types::Usage;
 
@@ -331,6 +417,11 @@ mod tests {
                 },
             })
             .expect("usage send should succeed");
+        api_tx
+            .send(StreamPart::Finish {
+                reason: crate::ai::types::FinishReason::Stop,
+            })
+            .expect("finish should send");
         drop(api_tx);
 
         let result = process_stream(api_rx, &event_tx, Duration::from_secs(1), |_| {}).await;
@@ -344,6 +435,9 @@ mod tests {
             LoopEvent::Usage {
                 prompt_tokens: 120,
                 completion_tokens: 45,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                total_tokens: 165,
             } => {}
             other => panic!("unexpected event: {other:?}"),
         }
@@ -361,9 +455,156 @@ mod tests {
                 thinking: "step one".to_string(),
             })
             .expect("thinking delta should send");
+        api_tx
+            .send(StreamPart::Finish {
+                reason: crate::ai::types::FinishReason::Stop,
+            })
+            .expect("finish should send");
         drop(api_tx);
 
         let result = process_stream(api_rx, &event_tx, Duration::from_secs(1), |_| {}).await;
         assert_eq!(result.recovery_checkpoint.thinking, "step one");
+    }
+
+    #[tokio::test]
+    async fn usage_snapshots_merge_input_cache_and_output() {
+        let (api_tx, api_rx) = mpsc::unbounded_channel();
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+
+        api_tx
+            .send(StreamPart::Usage {
+                usage: Usage {
+                    prompt_tokens: 100,
+                    completion_tokens: 0,
+                    total_tokens: 1_000,
+                    cache_creation_input_tokens: 200,
+                    cache_read_input_tokens: 700,
+                },
+            })
+            .expect("start usage should send");
+        api_tx
+            .send(StreamPart::Usage {
+                usage: Usage {
+                    prompt_tokens: 0,
+                    completion_tokens: 50,
+                    total_tokens: 50,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 0,
+                },
+            })
+            .expect("delta usage should send");
+        api_tx
+            .send(StreamPart::Finish {
+                reason: crate::ai::types::FinishReason::Stop,
+            })
+            .expect("finish should send");
+        drop(api_tx);
+
+        let result = process_stream(api_rx, &event_tx, Duration::from_secs(1), |_| {}).await;
+        assert_eq!(result.prompt_tokens, 1_000);
+        assert_eq!(result.total_tokens, 1_050);
+    }
+
+    #[tokio::test]
+    async fn usage_frame_after_finish_is_drained() {
+        let (api_tx, api_rx) = mpsc::unbounded_channel();
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+
+        api_tx
+            .send(StreamPart::Finish {
+                reason: crate::ai::types::FinishReason::Stop,
+            })
+            .expect("finish should send");
+        api_tx
+            .send(StreamPart::Usage {
+                usage: Usage {
+                    prompt_tokens: 25,
+                    completion_tokens: 10,
+                    total_tokens: 100,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 65,
+                },
+            })
+            .expect("trailing usage should send");
+        drop(api_tx);
+
+        let result = process_stream(api_rx, &event_tx, Duration::from_secs(1), |_| {}).await;
+        assert_eq!(result.prompt_tokens, 90);
+        assert_eq!(result.total_tokens, 100);
+        assert!(result.stop_reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn length_finish_is_terminal_and_never_executes_partial_tools() {
+        let (api_tx, api_rx) = mpsc::unbounded_channel();
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+
+        api_tx
+            .send(StreamPart::ToolCallStart {
+                id: "partial".to_string(),
+                name: "bash".to_string(),
+            })
+            .expect("tool start should send");
+        api_tx
+            .send(StreamPart::Finish {
+                reason: crate::ai::types::FinishReason::Length,
+            })
+            .expect("finish should send");
+        drop(api_tx);
+
+        let result = process_stream(api_rx, &event_tx, Duration::from_secs(1), |_| {}).await;
+        assert!(result.tool_calls.is_empty());
+        assert_eq!(result.stop_reason, Some(LoopStopReason::ProviderError));
+        assert!(result
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("output-token limit")));
+    }
+
+    #[tokio::test]
+    async fn nominal_finish_rejects_incomplete_tool_calls() {
+        let (api_tx, api_rx) = mpsc::unbounded_channel();
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+
+        api_tx
+            .send(StreamPart::ToolCallStart {
+                id: "partial".to_string(),
+                name: "edit".to_string(),
+            })
+            .expect("tool start should send");
+        api_tx
+            .send(StreamPart::Finish {
+                reason: crate::ai::types::FinishReason::Stop,
+            })
+            .expect("finish should send");
+        drop(api_tx);
+
+        let result = process_stream(api_rx, &event_tx, Duration::from_secs(1), |_| {}).await;
+        assert!(result.tool_calls.is_empty());
+        assert_eq!(result.stop_reason, Some(LoopStopReason::ProviderError));
+        assert!(result
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("incomplete tool call")));
+    }
+
+    #[tokio::test]
+    async fn channel_close_without_finish_is_provider_error() {
+        let (api_tx, api_rx) = mpsc::unbounded_channel();
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+
+        api_tx
+            .send(StreamPart::TextDelta {
+                delta: "partial".to_string(),
+            })
+            .expect("text should send");
+        drop(api_tx);
+
+        let result = process_stream(api_rx, &event_tx, Duration::from_secs(1), |_| {}).await;
+        assert_eq!(result.stop_reason, Some(LoopStopReason::ProviderError));
+        assert_eq!(
+            result.last_error.as_deref(),
+            Some("AI stream ended without a finish signal")
+        );
     }
 }

--- a/crates/krusty-core/src/ai/client/streaming/openai.rs
+++ b/crates/krusty-core/src/ai/client/streaming/openai.rs
@@ -11,6 +11,7 @@ use crate::ai::format::openai::OpenAIFormat;
 use crate::ai::format::FormatHandler;
 use crate::ai::models::ApiFormat;
 use crate::ai::parsers::OpenAIParser;
+use crate::ai::providers::ProviderId;
 use crate::ai::streaming::StreamPart;
 use crate::ai::transform::apply_request_body_transform;
 use crate::ai::types::ModelMessage;
@@ -54,6 +55,12 @@ fn remove_openai_function_tool_named(tools: &mut Vec<Value>, name: &str) {
             .and_then(Value::as_str);
         !matches!(direct_name.or(nested_name), Some(tool_name) if tool_name == name)
     });
+}
+
+fn append_stream_usage_options(body: &mut Value, provider_id: ProviderId, api_format: ApiFormat) {
+    if provider_id == ProviderId::OpenAI && matches!(api_format, ApiFormat::OpenAI) {
+        body["stream_options"] = serde_json::json!({"include_usage": true});
+    }
 }
 
 impl AiClient {
@@ -159,6 +166,8 @@ impl AiClient {
             body["service_tier"] = serde_json::json!(service_tier);
         }
 
+        append_stream_usage_options(&mut body, self.provider_id(), self.config().api_format);
+
         if matches!(self.config().api_format, ApiFormat::OpenAIResponses) {
             if let Some(cache_key) = options.session_id.as_deref().filter(|key| !key.is_empty()) {
                 body["prompt_cache_key"] = serde_json::json!(cache_key);
@@ -245,5 +254,21 @@ mod tests {
         append_openai_hosted_web_search_tool(&mut body, &options, ApiFormat::OpenAI);
 
         assert!(body.get("tools").is_none());
+    }
+
+    #[test]
+    fn official_chat_completions_requests_usage_frames() {
+        let mut body = json!({"model": "gpt-4.1", "stream": true});
+        append_stream_usage_options(&mut body, ProviderId::OpenAI, ApiFormat::OpenAI);
+
+        assert_eq!(body["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn compatible_providers_do_not_receive_openai_only_stream_options() {
+        let mut body = json!({"model": "grok", "stream": true});
+        append_stream_usage_options(&mut body, ProviderId::Grok, ApiFormat::OpenAI);
+
+        assert!(body.get("stream_options").is_none());
     }
 }

--- a/crates/krusty-core/src/ai/openrouter/api.rs
+++ b/crates/krusty-core/src/ai/openrouter/api.rs
@@ -35,7 +35,10 @@ pub async fn fetch_models_with_client(
     let response = client
         .get(OPENROUTER_MODELS_URL)
         .header("Authorization", format!("Bearer {}", api_key))
-        .header("HTTP-Referer", "https://github.com/BurgessTG/Krusty")
+        .header(
+            "HTTP-Referer",
+            "https://github.com/honeycomb-Technologies/Krusty",
+        )
         .send()
         .await?;
 

--- a/crates/krusty-core/src/ai/parsers/anthropic/messages.rs
+++ b/crates/krusty-core/src/ai/parsers/anthropic/messages.rs
@@ -7,7 +7,7 @@ use crate::ai::types::{ContextEditingMetrics, FinishReason, Usage};
 
 impl AnthropicParser {
     pub(super) fn parse_message_delta(&self, json: &Value) -> SseEvent {
-        if let Some(usage) = json.get("usage") {
+        let usage = json.get("usage").and_then(|usage| {
             let input_tokens = usage
                 .get("input_tokens")
                 .and_then(|t| t.as_u64())
@@ -17,36 +17,37 @@ impl AnthropicParser {
                 .and_then(|t| t.as_u64())
                 .unwrap_or(0) as usize;
 
-            if input_tokens > 0 || output_tokens > 0 {
-                let cache_read = usage
-                    .get("cache_read_input_tokens")
-                    .and_then(|t| t.as_u64())
-                    .unwrap_or(0) as usize;
-                let cache_creation = usage
-                    .get("cache_creation_input_tokens")
-                    .and_then(|t| t.as_u64())
-                    .unwrap_or(0) as usize;
-                return SseEvent::Usage(Usage {
+            let cache_read = usage
+                .get("cache_read_input_tokens")
+                .and_then(|t| t.as_u64())
+                .unwrap_or(0) as usize;
+            let cache_creation = usage
+                .get("cache_creation_input_tokens")
+                .and_then(|t| t.as_u64())
+                .unwrap_or(0) as usize;
+
+            (input_tokens > 0 || output_tokens > 0 || cache_read > 0 || cache_creation > 0).then(
+                || Usage {
                     prompt_tokens: input_tokens,
                     completion_tokens: output_tokens,
-                    total_tokens: input_tokens + output_tokens,
+                    total_tokens: input_tokens
+                        .saturating_add(cache_creation)
+                        .saturating_add(cache_read)
+                        .saturating_add(output_tokens),
                     cache_creation_input_tokens: cache_creation,
                     cache_read_input_tokens: cache_read,
-                });
-            }
-        }
+                },
+            )
+        });
 
         if let Some(delta) = json.get("delta") {
             if let Some(stop_reason) = delta.get("stop_reason").and_then(|s| s.as_str()) {
                 let reason = parse_finish_reason(stop_reason);
-                return SseEvent::Finish {
-                    reason,
-                    usage: None,
-                };
+                return SseEvent::Finish { reason, usage };
             }
         }
 
-        SseEvent::Skip
+        usage.map(SseEvent::Usage).unwrap_or(SseEvent::Skip)
     }
 
     pub(super) fn parse_message_start(&self, json: &Value) -> SseEvent {
@@ -98,11 +99,12 @@ impl AnthropicParser {
                     );
                 }
 
-                let total_input = input_tokens + cache_creation + cache_read;
                 return SseEvent::Usage(Usage {
-                    prompt_tokens: total_input,
+                    prompt_tokens: input_tokens,
                     completion_tokens: 0,
-                    total_tokens: total_input,
+                    total_tokens: input_tokens
+                        .saturating_add(cache_creation)
+                        .saturating_add(cache_read),
                     cache_creation_input_tokens: cache_creation,
                     cache_read_input_tokens: cache_read,
                 });
@@ -125,5 +127,54 @@ impl AnthropicParser {
             .and_then(|m| m.as_str())
             .unwrap_or("Unknown error");
         Err(anyhow::anyhow!("API error: {}", error_msg))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn message_delta_preserves_usage_and_max_tokens_finish() {
+        let event = AnthropicParser::new().parse_message_delta(&json!({
+            "type": "message_delta",
+            "delta": {"stop_reason": "max_tokens"},
+            "usage": {"output_tokens": 321}
+        }));
+
+        match event {
+            SseEvent::Finish {
+                reason: FinishReason::Length,
+                usage: Some(usage),
+            } => assert_eq!(usage.completion_tokens, 321),
+            _ => panic!("unexpected Anthropic message-delta event"),
+        }
+    }
+
+    #[test]
+    fn message_start_keeps_cache_buckets_separate() {
+        let event = AnthropicParser::new().parse_message_start(&json!({
+            "type": "message_start",
+            "message": {
+                "usage": {
+                    "input_tokens": 100,
+                    "cache_creation_input_tokens": 200,
+                    "cache_read_input_tokens": 700
+                }
+            }
+        }));
+
+        match event {
+            SseEvent::Usage(usage) => {
+                assert_eq!(usage.prompt_tokens, 100);
+                assert_eq!(usage.cache_creation_input_tokens, 200);
+                assert_eq!(usage.cache_read_input_tokens, 700);
+                assert_eq!(usage.input_tokens(), 1_000);
+                assert_eq!(usage.total_tokens, 1_000);
+            }
+            _ => panic!("unexpected Anthropic message-start event"),
+        }
     }
 }

--- a/crates/krusty-core/src/ai/parsers/google.rs
+++ b/crates/krusty-core/src/ai/parsers/google.rs
@@ -3,8 +3,8 @@
 use anyhow::Result;
 use serde_json::Value;
 
-use crate::ai::sse::{SseEvent, SseParser, ToolCallAccumulator};
-use crate::ai::types::FinishReason;
+use crate::ai::sse::{SseEvent, SseParser};
+use crate::ai::types::{AiToolCall, FinishReason, Usage};
 
 /// Google Gemini SSE parser
 ///
@@ -12,27 +12,11 @@ use crate::ai::types::FinishReason;
 /// ```json
 /// {"candidates": [{"content": {"parts": [{"text": "..."}], "role": "model"}, "finishReason": "STOP"}]}
 /// ```
-pub struct GoogleParser {
-    /// Track tool calls being accumulated
-    tool_accumulators: std::sync::Mutex<std::collections::HashMap<usize, ToolCallAccumulator>>,
-}
+pub struct GoogleParser;
 
 impl GoogleParser {
     pub fn new() -> Self {
-        Self {
-            tool_accumulators: std::sync::Mutex::new(std::collections::HashMap::new()),
-        }
-    }
-
-    /// Lock tool accumulators with proper error handling
-    fn lock_tool_accumulators(
-        &self,
-    ) -> anyhow::Result<
-        std::sync::MutexGuard<'_, std::collections::HashMap<usize, ToolCallAccumulator>>,
-    > {
-        self.tool_accumulators
-            .lock()
-            .map_err(|e| anyhow::anyhow!("Tool accumulators lock poisoned: {}", e))
+        Self
     }
 
     /// Parse Google finish reason to our FinishReason enum
@@ -40,9 +24,118 @@ impl GoogleParser {
         match reason {
             "STOP" => FinishReason::Stop,
             "MAX_TOKENS" => FinishReason::Length,
-            "SAFETY" | "RECITATION" | "OTHER" => FinishReason::Stop,
+            "SAFETY" | "RECITATION" | "PROHIBITED_CONTENT" | "SPII" | "IMAGE_SAFETY" => {
+                FinishReason::ContentFilter
+            }
             _ => FinishReason::Other(reason.to_string()),
         }
+    }
+
+    fn parse_usage(json: &Value) -> Option<Usage> {
+        let usage = json.get("usageMetadata")?;
+        let prompt = usage
+            .get("promptTokenCount")
+            .and_then(|tokens| tokens.as_u64())
+            .unwrap_or(0) as usize;
+        let completion = usage
+            .get("candidatesTokenCount")
+            .and_then(|tokens| tokens.as_u64())
+            .unwrap_or(0) as usize;
+        let total = usage
+            .get("totalTokenCount")
+            .and_then(|tokens| tokens.as_u64())
+            .unwrap_or((prompt + completion) as u64) as usize;
+        // Google includes cached content in promptTokenCount.
+        let cached = usage
+            .get("cachedContentTokenCount")
+            .and_then(|tokens| tokens.as_u64())
+            .unwrap_or(0) as usize;
+
+        (prompt > 0 || completion > 0 || cached > 0).then_some(Usage {
+            prompt_tokens: prompt.saturating_sub(cached),
+            completion_tokens: completion,
+            total_tokens: total,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: cached,
+        })
+    }
+
+    fn parse_frame(&self, json: &Value) -> Vec<SseEvent> {
+        let mut events = Vec::new();
+        let mut usage = Self::parse_usage(json);
+        let mut has_tool_calls = false;
+
+        if let Some(candidate) = json
+            .get("candidates")
+            .and_then(|candidates| candidates.as_array())
+            .and_then(|candidates| candidates.first())
+        {
+            if let Some(parts) = candidate
+                .get("content")
+                .and_then(|content| content.get("parts"))
+                .and_then(|parts| parts.as_array())
+            {
+                for part in parts {
+                    if let Some(text) = part.get("text").and_then(|text| text.as_str()) {
+                        if !text.is_empty() {
+                            events.push(SseEvent::TextDelta(text.to_string()));
+                        }
+                    }
+
+                    if let Some(function_call) = part.get("functionCall") {
+                        let name = function_call
+                            .get("name")
+                            .and_then(|name| name.as_str())
+                            .unwrap_or("");
+                        if name.is_empty() {
+                            continue;
+                        }
+
+                        has_tool_calls = true;
+                        let id = function_call
+                            .get("id")
+                            .and_then(|id| id.as_str())
+                            .map(ToString::to_string)
+                            .unwrap_or_else(|| format!("google_{}", uuid::Uuid::new_v4()));
+                        let arguments = function_call
+                            .get("args")
+                            .cloned()
+                            .unwrap_or_else(|| serde_json::json!({}));
+                        events.push(SseEvent::ToolCallStart {
+                            id: id.clone(),
+                            name: name.to_string(),
+                        });
+                        events.push(SseEvent::ToolCallComplete(AiToolCall {
+                            id,
+                            name: name.to_string(),
+                            arguments,
+                        }));
+                    }
+                }
+            }
+
+            if let Some(reason) = candidate
+                .get("finishReason")
+                .and_then(|reason| reason.as_str())
+            {
+                let mut reason = Self::parse_finish_reason(reason);
+                if has_tool_calls && reason == FinishReason::Stop {
+                    reason = FinishReason::ToolCalls;
+                }
+                events.push(SseEvent::Finish {
+                    reason,
+                    usage: usage.take(),
+                });
+            }
+        }
+
+        if let Some(usage) = usage {
+            events.push(SseEvent::Usage(usage));
+        }
+        if events.is_empty() {
+            events.push(SseEvent::Skip);
+        }
+        events
     }
 }
 
@@ -55,103 +148,132 @@ impl Default for GoogleParser {
 #[async_trait::async_trait]
 impl SseParser for GoogleParser {
     async fn parse_event(&self, json: &Value) -> Result<SseEvent> {
-        // Google Gemini format: {"candidates": [{...}]}
-        if let Some(candidates) = json.get("candidates").and_then(|c| c.as_array()) {
-            if let Some(candidate) = candidates.first() {
-                // Check for finish reason
-                if let Some(finish_reason) = candidate.get("finishReason").and_then(|f| f.as_str())
-                {
-                    // If there's content with finish, extract it first
-                    if let Some(content) = candidate.get("content") {
-                        if let Some(parts) = content.get("parts").and_then(|p| p.as_array()) {
-                            for part in parts {
-                                // Text content
-                                if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
-                                    if !text.is_empty() {
-                                        // Return text delta, finish will be next chunk
-                                        return Ok(SseEvent::TextDelta(text.to_string()));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    // Return finish event
-                    return Ok(SseEvent::Finish {
-                        reason: Self::parse_finish_reason(finish_reason),
-                        usage: None,
-                    });
+        Ok(self
+            .parse_frame(json)
+            .into_iter()
+            .next()
+            .unwrap_or(SseEvent::Skip))
+    }
+
+    async fn parse_events(&self, json: &Value) -> Result<Vec<SseEvent>> {
+        Ok(self.parse_frame(json))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::types::Usage;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn cached_prompt_tokens_are_not_counted_twice() {
+        let event = GoogleParser::new()
+            .parse_event(&json!({
+                "usageMetadata": {
+                    "promptTokenCount": 1_000,
+                    "cachedContentTokenCount": 700,
+                    "candidatesTokenCount": 50,
+                    "totalTokenCount": 1_070
                 }
+            }))
+            .await
+            .expect("usage event should parse");
 
-                // Extract content parts
-                if let Some(content) = candidate.get("content") {
-                    if let Some(parts) = content.get("parts").and_then(|p| p.as_array()) {
-                        for part in parts {
-                            // Text content
-                            if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
-                                if !text.is_empty() {
-                                    return Ok(SseEvent::TextDelta(text.to_string()));
-                                }
-                            }
+        let SseEvent::Usage(usage) = event else {
+            panic!("expected usage event");
+        };
+        assert_eq!(
+            usage,
+            Usage {
+                prompt_tokens: 300,
+                completion_tokens: 50,
+                total_tokens: 1_070,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 700,
+            }
+        );
+        assert_eq!(usage.input_tokens(), 1_000);
+    }
 
-                            // Function call (tool use)
-                            if let Some(function_call) = part.get("functionCall") {
-                                let name = function_call
-                                    .get("name")
-                                    .and_then(|n| n.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
-                                let args = function_call
-                                    .get("args")
-                                    .map(|a| serde_json::to_string(a).unwrap_or_default())
-                                    .unwrap_or_default();
-
-                                if !name.is_empty() {
-                                    // Generate a unique ID for the tool call
-                                    let id = format!("google_{}", uuid::Uuid::new_v4());
-
-                                    // Store accumulator
-                                    let mut accumulators = self.lock_tool_accumulators()?;
-                                    let index = accumulators.len();
-                                    let mut acc =
-                                        ToolCallAccumulator::new(id.clone(), name.clone());
-                                    acc.add_arguments(&args);
-                                    accumulators.insert(index, acc);
-
-                                    return Ok(SseEvent::ToolCallStart { id, name });
-                                }
-                            }
-                        }
-                    }
+    #[tokio::test]
+    async fn final_frame_preserves_text_usage_and_finish() {
+        let events = GoogleParser::new()
+            .parse_events(&json!({
+                "candidates": [{
+                    "content": {"parts": [{"text": "done"}]},
+                    "finishReason": "STOP"
+                }],
+                "usageMetadata": {
+                    "promptTokenCount": 100,
+                    "candidatesTokenCount": 4,
+                    "totalTokenCount": 104
                 }
-            }
-        }
+            }))
+            .await
+            .expect("final frame should parse");
 
-        // Check for usage metadata
-        if let Some(usage) = json.get("usageMetadata") {
-            let prompt = usage
-                .get("promptTokenCount")
-                .and_then(|t| t.as_u64())
-                .unwrap_or(0) as usize;
-            let completion = usage
-                .get("candidatesTokenCount")
-                .and_then(|t| t.as_u64())
-                .unwrap_or(0) as usize;
-            // Gemini 2.5+ reports implicit cache hits via cachedContentTokenCount
-            let cached = usage
-                .get("cachedContentTokenCount")
-                .and_then(|t| t.as_u64())
-                .unwrap_or(0) as usize;
-            if prompt > 0 || completion > 0 {
-                return Ok(SseEvent::Usage(crate::ai::types::Usage {
-                    prompt_tokens: prompt,
-                    completion_tokens: completion,
-                    total_tokens: prompt + completion,
-                    cache_creation_input_tokens: 0,
-                    cache_read_input_tokens: cached,
-                }));
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], SseEvent::TextDelta(text) if text == "done"));
+        assert!(matches!(
+            &events[1],
+            SseEvent::Finish {
+                reason: FinishReason::Stop,
+                usage: Some(Usage {
+                    total_tokens: 104,
+                    ..
+                })
             }
-        }
+        ));
+    }
 
-        Ok(SseEvent::Skip)
+    #[tokio::test]
+    async fn function_call_is_completed_before_tool_finish() {
+        let events = GoogleParser::new()
+            .parse_events(&json!({
+                "candidates": [{
+                    "content": {"parts": [{
+                        "functionCall": {
+                            "name": "read",
+                            "args": {"path": "README.md"}
+                        }
+                    }]},
+                    "finishReason": "STOP"
+                }]
+            }))
+            .await
+            .expect("tool frame should parse");
+
+        assert_eq!(events.len(), 3);
+        let SseEvent::ToolCallStart { id, name } = &events[0] else {
+            panic!("expected tool start");
+        };
+        assert_eq!(name, "read");
+        assert!(matches!(
+            &events[1],
+            SseEvent::ToolCallComplete(call)
+                if call.id == *id
+                    && call.name == "read"
+                    && call.arguments == json!({"path": "README.md"})
+        ));
+        assert!(matches!(
+            &events[2],
+            SseEvent::Finish {
+                reason: FinishReason::ToolCalls,
+                usage: None
+            }
+        ));
+    }
+
+    #[test]
+    fn safety_finishes_are_not_treated_as_success() {
+        assert_eq!(
+            GoogleParser::parse_finish_reason("SAFETY"),
+            FinishReason::ContentFilter
+        );
+        assert!(matches!(
+            GoogleParser::parse_finish_reason("OTHER"),
+            FinishReason::Other(reason) if reason == "OTHER"
+        ));
     }
 }

--- a/crates/krusty-core/src/ai/parsers/openai/chat.rs
+++ b/crates/krusty-core/src/ai/parsers/openai/chat.rs
@@ -4,39 +4,66 @@ use super::OpenAIParser;
 use crate::ai::sse::SseEvent;
 use crate::ai::types::{FinishReason, Usage};
 
+fn parse_chat_usage(json: &Value) -> Option<Usage> {
+    let usage = json.get("usage")?;
+    let prompt_tokens = usage
+        .get("prompt_tokens")
+        .and_then(|tokens| tokens.as_u64())
+        .unwrap_or(0) as usize;
+    let completion_tokens = usage
+        .get("completion_tokens")
+        .and_then(|tokens| tokens.as_u64())
+        .unwrap_or(0) as usize;
+    let cached_tokens = usage
+        .get("prompt_tokens_details")
+        .and_then(|details| details.get("cached_tokens"))
+        .and_then(|tokens| tokens.as_u64())
+        .or_else(|| {
+            usage
+                .get("cache_read_input_tokens")
+                .and_then(|tokens| tokens.as_u64())
+        })
+        .unwrap_or(0) as usize;
+    let total_tokens = usage
+        .get("total_tokens")
+        .and_then(|tokens| tokens.as_u64())
+        .unwrap_or((prompt_tokens + completion_tokens) as u64) as usize;
+
+    (prompt_tokens > 0 || completion_tokens > 0 || cached_tokens > 0).then_some(Usage {
+        prompt_tokens: prompt_tokens.saturating_sub(cached_tokens),
+        completion_tokens,
+        total_tokens,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: cached_tokens,
+    })
+}
+
 impl OpenAIParser {
     pub(super) fn parse_chat_completions_event(&self, json: &Value) -> anyhow::Result<SseEvent> {
+        let usage = parse_chat_usage(json);
         let choices = json.get("choices").and_then(|c| c.as_array());
 
         if let Some(choices) = choices {
             if let Some(choice) = choices.first() {
                 if let Some(reason) = choice.get("finish_reason").and_then(|r| r.as_str()) {
-                    if reason == "stop" || reason == "end_turn" {
-                        return Ok(SseEvent::Finish {
-                            reason: FinishReason::Stop,
-                            usage: None,
-                        });
-                    }
                     if reason == "tool_calls" {
                         let tool_calls = self.drain_tool_calls()?;
 
                         if tool_calls.is_empty() {
                             return Ok(SseEvent::Finish {
                                 reason: FinishReason::ToolCalls,
-                                usage: None,
+                                usage,
                             });
                         }
-                        return Ok(SseEvent::FinishWithToolCalls {
-                            tool_calls,
-                            usage: None,
-                        });
+                        return Ok(SseEvent::FinishWithToolCalls { tool_calls, usage });
                     }
-                    if reason == "length" || reason == "max_tokens" {
-                        return Ok(SseEvent::Finish {
-                            reason: FinishReason::Length,
-                            usage: None,
-                        });
-                    }
+                    let reason = match reason {
+                        "stop" | "end_turn" => FinishReason::Stop,
+                        "length" | "max_tokens" => FinishReason::Length,
+                        "content_filter" => FinishReason::ContentFilter,
+                        other => FinishReason::Other(other.to_string()),
+                    };
+                    return Ok(SseEvent::Finish { reason, usage });
                 }
 
                 if let Some(delta) = choice.get("delta") {
@@ -105,24 +132,8 @@ impl OpenAIParser {
             }
         }
 
-        if let Some(usage) = json.get("usage") {
-            let prompt_tokens = usage
-                .get("prompt_tokens")
-                .and_then(|t| t.as_u64())
-                .unwrap_or(0) as usize;
-            let completion_tokens = usage
-                .get("completion_tokens")
-                .and_then(|t| t.as_u64())
-                .unwrap_or(0) as usize;
-            if prompt_tokens > 0 || completion_tokens > 0 {
-                return Ok(SseEvent::Usage(Usage {
-                    prompt_tokens,
-                    completion_tokens,
-                    total_tokens: prompt_tokens + completion_tokens,
-                    cache_creation_input_tokens: 0,
-                    cache_read_input_tokens: 0,
-                }));
-            }
+        if let Some(usage) = usage {
+            return Ok(SseEvent::Usage(usage));
         }
 
         Ok(SseEvent::Skip)

--- a/crates/krusty-core/src/ai/parsers/openai/mod.rs
+++ b/crates/krusty-core/src/ai/parsers/openai/mod.rs
@@ -258,6 +258,56 @@ mod tests {
     }
 
     #[test]
+    fn chat_usage_keeps_cached_tokens_separate() {
+        let parser = OpenAIParser::new();
+        let event = parser
+            .parse_chat_completions_event(&json!({
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 1000,
+                    "prompt_tokens_details": {"cached_tokens": 700},
+                    "completion_tokens": 50,
+                    "total_tokens": 1050
+                }
+            }))
+            .expect("chat usage should parse");
+
+        let SseEvent::Usage(usage) = event else {
+            panic!("expected usage event");
+        };
+        assert_eq!(usage.prompt_tokens, 300);
+        assert_eq!(usage.cache_read_input_tokens, 700);
+        assert_eq!(usage.input_tokens(), 1_000);
+        assert_eq!(usage.completion_tokens, 50);
+        assert_eq!(usage.total_tokens, 1_050);
+    }
+
+    #[test]
+    fn chat_finish_preserves_usage_and_filter_reason() {
+        let event = OpenAIParser::new()
+            .parse_chat_completions_event(&json!({
+                "choices": [{"finish_reason": "content_filter", "delta": {}}],
+                "usage": {
+                    "prompt_tokens": 20,
+                    "completion_tokens": 3,
+                    "total_tokens": 23
+                }
+            }))
+            .expect("filtered finish should parse");
+
+        assert!(matches!(
+            event,
+            SseEvent::Finish {
+                reason: crate::ai::types::FinishReason::ContentFilter,
+                usage: Some(crate::ai::types::Usage {
+                    total_tokens: 23,
+                    ..
+                })
+            }
+        ));
+    }
+
+    #[test]
     fn responses_argument_deltas_still_accumulate() {
         let parser = OpenAIParser::new();
 

--- a/crates/krusty-core/src/ai/sse/events.rs
+++ b/crates/krusty-core/src/ai/sse/events.rs
@@ -86,6 +86,16 @@ pub enum SseEvent {
 pub trait SseParser: Send + Sync {
     /// Parse a JSON event into an SSE event
     async fn parse_event(&self, json: &Value) -> anyhow::Result<SseEvent>;
+
+    /// Parse a provider frame that contains multiple logical stream events.
+    ///
+    /// Most SSE formats emit one logical event per frame. Providers such as
+    /// Gemini can combine final content, tool calls, usage, and a finish reason
+    /// in one frame, so they can override this without complicating the common
+    /// stream processor.
+    async fn parse_events(&self, json: &Value) -> anyhow::Result<Vec<SseEvent>> {
+        Ok(vec![self.parse_event(json).await?])
+    }
 }
 
 /// Common helper to parse finish reasons

--- a/crates/krusty-core/src/ai/sse/processor/dispatch.rs
+++ b/crates/krusty-core/src/ai/sse/processor/dispatch.rs
@@ -38,185 +38,187 @@ impl SseStreamProcessor {
                 self.event_count, elapsed, event_type
             );
 
-            match parser.parse_event(&json).await? {
-                SseEvent::TextDelta(text) => {
-                    debug!("  -> TextDelta: {} chars", text.len());
-                    self.stream_buffer.process_chunk(text).await;
-                }
-                SseEvent::TextDeltaWithCitations { text, citations } => {
-                    debug!(
-                        "  -> TextDeltaWithCitations: {} chars, {} citations",
-                        text.len(),
-                        citations.len()
-                    );
-                    self.dispatch_part(StreamPart::TextDeltaWithCitations {
-                        delta: text,
-                        citations,
-                    });
-                }
-                SseEvent::ToolCallStart { id, name } => {
-                    info!(
-                        "SSE ToolCallStart: id={}, name={} at {:?}",
-                        id, name, elapsed
-                    );
-                    self.dispatch_part(StreamPart::ToolCallStart { id, name });
-                }
-                SseEvent::ToolCallDelta { id, delta } => {
-                    debug!("  -> ToolCallDelta: id={}, {} chars", id, delta.len());
-                    self.dispatch_part(StreamPart::ToolCallDelta { id, delta });
-                }
-                SseEvent::ToolCallComplete(tool_call) => {
-                    info!(
-                        "SSE ToolCallComplete: id={}, name={} at {:?}",
-                        tool_call.id, tool_call.name, elapsed
-                    );
-                    self.dispatch_part(StreamPart::ToolCallComplete { tool_call });
-                }
-                SseEvent::ServerToolStart { id, name } => {
-                    info!(
-                        "SSE ServerToolStart: id={}, name={} at {:?}",
-                        id, name, elapsed
-                    );
-                    self.dispatch_part(StreamPart::ServerToolStart { id, name });
-                }
-                SseEvent::ServerToolDelta { id, delta } => {
-                    debug!("  -> ServerToolDelta: id={}, {} chars", id, delta.len());
-                    self.dispatch_part(StreamPart::ServerToolDelta { id, delta });
-                }
-                SseEvent::ServerToolComplete { id, name, input } => {
-                    info!(
-                        "SSE ServerToolComplete: id={}, name={} at {:?}",
-                        id, name, elapsed
-                    );
-                    self.dispatch_part(StreamPart::ServerToolComplete { id, name, input });
-                }
-                SseEvent::WebSearchResults {
-                    tool_use_id,
-                    results,
-                } => {
-                    info!(
-                        "SSE WebSearchResults: {} results for {} at {:?}",
-                        results.len(),
-                        tool_use_id,
-                        elapsed
-                    );
-                    self.dispatch_part(StreamPart::WebSearchResults {
+            for event in parser.parse_events(&json).await? {
+                match event {
+                    SseEvent::TextDelta(text) => {
+                        debug!("  -> TextDelta: {} chars", text.len());
+                        self.stream_buffer.process_chunk(text).await;
+                    }
+                    SseEvent::TextDeltaWithCitations { text, citations } => {
+                        debug!(
+                            "  -> TextDeltaWithCitations: {} chars, {} citations",
+                            text.len(),
+                            citations.len()
+                        );
+                        self.dispatch_part(StreamPart::TextDeltaWithCitations {
+                            delta: text,
+                            citations,
+                        });
+                    }
+                    SseEvent::ToolCallStart { id, name } => {
+                        info!(
+                            "SSE ToolCallStart: id={}, name={} at {:?}",
+                            id, name, elapsed
+                        );
+                        self.dispatch_part(StreamPart::ToolCallStart { id, name });
+                    }
+                    SseEvent::ToolCallDelta { id, delta } => {
+                        debug!("  -> ToolCallDelta: id={}, {} chars", id, delta.len());
+                        self.dispatch_part(StreamPart::ToolCallDelta { id, delta });
+                    }
+                    SseEvent::ToolCallComplete(tool_call) => {
+                        info!(
+                            "SSE ToolCallComplete: id={}, name={} at {:?}",
+                            tool_call.id, tool_call.name, elapsed
+                        );
+                        self.dispatch_part(StreamPart::ToolCallComplete { tool_call });
+                    }
+                    SseEvent::ServerToolStart { id, name } => {
+                        info!(
+                            "SSE ServerToolStart: id={}, name={} at {:?}",
+                            id, name, elapsed
+                        );
+                        self.dispatch_part(StreamPart::ServerToolStart { id, name });
+                    }
+                    SseEvent::ServerToolDelta { id, delta } => {
+                        debug!("  -> ServerToolDelta: id={}, {} chars", id, delta.len());
+                        self.dispatch_part(StreamPart::ServerToolDelta { id, delta });
+                    }
+                    SseEvent::ServerToolComplete { id, name, input } => {
+                        info!(
+                            "SSE ServerToolComplete: id={}, name={} at {:?}",
+                            id, name, elapsed
+                        );
+                        self.dispatch_part(StreamPart::ServerToolComplete { id, name, input });
+                    }
+                    SseEvent::WebSearchResults {
                         tool_use_id,
                         results,
-                    });
-                }
-                SseEvent::WebFetchResult {
-                    tool_use_id,
-                    content,
-                } => {
-                    info!(
-                        "SSE WebFetchResult: url={} for {} at {:?}",
-                        content.url, tool_use_id, elapsed
-                    );
-                    self.dispatch_part(StreamPart::WebFetchResult {
+                    } => {
+                        info!(
+                            "SSE WebSearchResults: {} results for {} at {:?}",
+                            results.len(),
+                            tool_use_id,
+                            elapsed
+                        );
+                        self.dispatch_part(StreamPart::WebSearchResults {
+                            tool_use_id,
+                            results,
+                        });
+                    }
+                    SseEvent::WebFetchResult {
                         tool_use_id,
                         content,
-                    });
-                }
-                SseEvent::ServerToolError {
-                    tool_use_id,
-                    error_code,
-                } => {
-                    warn!(
-                        "SSE ServerToolError: {} for {} at {:?}",
-                        error_code, tool_use_id, elapsed
-                    );
-                    self.dispatch_part(StreamPart::ServerToolError {
+                    } => {
+                        info!(
+                            "SSE WebFetchResult: url={} for {} at {:?}",
+                            content.url, tool_use_id, elapsed
+                        );
+                        self.dispatch_part(StreamPart::WebFetchResult {
+                            tool_use_id,
+                            content,
+                        });
+                    }
+                    SseEvent::ServerToolError {
                         tool_use_id,
                         error_code,
-                    });
-                }
-                SseEvent::ThinkingStart { index } => {
-                    info!("SSE ThinkingStart: index={} at {:?}", index, elapsed);
-                    self.dispatch_part(StreamPart::ThinkingStart { index });
-                }
-                SseEvent::ThinkingDelta { index, thinking } => {
-                    debug!(
-                        "  -> ThinkingDelta: index={}, {} chars",
+                    } => {
+                        warn!(
+                            "SSE ServerToolError: {} for {} at {:?}",
+                            error_code, tool_use_id, elapsed
+                        );
+                        self.dispatch_part(StreamPart::ServerToolError {
+                            tool_use_id,
+                            error_code,
+                        });
+                    }
+                    SseEvent::ThinkingStart { index } => {
+                        info!("SSE ThinkingStart: index={} at {:?}", index, elapsed);
+                        self.dispatch_part(StreamPart::ThinkingStart { index });
+                    }
+                    SseEvent::ThinkingDelta { index, thinking } => {
+                        debug!(
+                            "  -> ThinkingDelta: index={}, {} chars",
+                            index,
+                            thinking.len()
+                        );
+                        self.dispatch_part(StreamPart::ThinkingDelta { index, thinking });
+                    }
+                    SseEvent::SignatureDelta { index, signature } => {
+                        debug!(
+                            "  -> SignatureDelta: index={}, {} chars",
+                            index,
+                            signature.len()
+                        );
+                        self.dispatch_part(StreamPart::SignatureDelta { index, signature });
+                    }
+                    SseEvent::ThinkingComplete {
                         index,
-                        thinking.len()
-                    );
-                    self.dispatch_part(StreamPart::ThinkingDelta { index, thinking });
-                }
-                SseEvent::SignatureDelta { index, signature } => {
-                    debug!(
-                        "  -> SignatureDelta: index={}, {} chars",
-                        index,
-                        signature.len()
-                    );
-                    self.dispatch_part(StreamPart::SignatureDelta { index, signature });
-                }
-                SseEvent::ThinkingComplete {
-                    index,
-                    thinking,
-                    signature,
-                } => {
-                    info!(
+                        thinking,
+                        signature,
+                    } => {
+                        info!(
                         "SSE ThinkingComplete: index={}, thinking={} chars, sig={} chars at {:?}",
                         index,
                         thinking.len(),
                         signature.len(),
                         elapsed
                     );
-                    self.dispatch_part(StreamPart::ThinkingComplete {
-                        index,
-                        thinking,
-                        signature,
-                    });
-                }
-                SseEvent::Finish { reason, usage } => {
-                    info!(
-                        "SSE Finish: reason={:?} at {:?} ({} events, {} bytes)",
-                        reason, elapsed, self.event_count, self.bytes_received
-                    );
-                    self.stream_buffer.flush().await;
-                    if let Some(usage) = usage {
-                        self.emit_usage(usage, "from finish");
+                        self.dispatch_part(StreamPart::ThinkingComplete {
+                            index,
+                            thinking,
+                            signature,
+                        });
                     }
-                    self.dispatch_part(StreamPart::Finish { reason });
-                }
-                SseEvent::FinishWithToolCalls { tool_calls, usage } => {
-                    info!(
-                        "SSE FinishWithToolCalls: {} tool calls at {:?} ({} events, {} bytes)",
-                        tool_calls.len(),
-                        elapsed,
-                        self.event_count,
-                        self.bytes_received
-                    );
-                    self.stream_buffer.flush().await;
-                    for tool_call in tool_calls {
+                    SseEvent::Finish { reason, usage } => {
                         info!(
-                            "  -> Completing tool call: id={}, name={}",
-                            tool_call.id, tool_call.name
+                            "SSE Finish: reason={:?} at {:?} ({} events, {} bytes)",
+                            reason, elapsed, self.event_count, self.bytes_received
                         );
-                        self.dispatch_part(StreamPart::ToolCallComplete { tool_call });
+                        self.stream_buffer.flush().await;
+                        if let Some(usage) = usage {
+                            self.emit_usage(usage, "from finish");
+                        }
+                        self.dispatch_part(StreamPart::Finish { reason });
                     }
-                    if let Some(usage) = usage {
-                        self.emit_usage(usage, "from finish");
+                    SseEvent::FinishWithToolCalls { tool_calls, usage } => {
+                        info!(
+                            "SSE FinishWithToolCalls: {} tool calls at {:?} ({} events, {} bytes)",
+                            tool_calls.len(),
+                            elapsed,
+                            self.event_count,
+                            self.bytes_received
+                        );
+                        self.stream_buffer.flush().await;
+                        for tool_call in tool_calls {
+                            info!(
+                                "  -> Completing tool call: id={}, name={}",
+                                tool_call.id, tool_call.name
+                            );
+                            self.dispatch_part(StreamPart::ToolCallComplete { tool_call });
+                        }
+                        if let Some(usage) = usage {
+                            self.emit_usage(usage, "from finish");
+                        }
+                        self.dispatch_part(StreamPart::Finish {
+                            reason: FinishReason::ToolCalls,
+                        });
                     }
-                    self.dispatch_part(StreamPart::Finish {
-                        reason: FinishReason::ToolCalls,
-                    });
-                }
-                SseEvent::Usage(usage) => {
-                    self.emit_usage(usage, "event");
-                }
-                SseEvent::ContextEdited(metrics) => {
-                    info!(
+                    SseEvent::Usage(usage) => {
+                        self.emit_usage(usage, "event");
+                    }
+                    SseEvent::ContextEdited(metrics) => {
+                        info!(
                         "SSE ContextEdited: cleared {} tokens ({} tool uses, {} thinking turns)",
                         metrics.cleared_input_tokens,
                         metrics.cleared_tool_uses,
                         metrics.cleared_thinking_turns
                     );
-                    self.dispatch_part(StreamPart::ContextEdited { metrics });
-                }
-                SseEvent::Skip => {
-                    debug!("  -> Skip event");
+                        self.dispatch_part(StreamPart::ContextEdited { metrics });
+                    }
+                    SseEvent::Skip => {
+                        debug!("  -> Skip event");
+                    }
                 }
             }
         } else if !data.is_empty() && !data.trim().is_empty() {

--- a/crates/krusty-core/src/ai/types/context.rs
+++ b/crates/krusty-core/src/ai/types/context.rs
@@ -2,8 +2,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::ai::reasoning::DEFAULT_THINKING_BUDGET;
 
-/// Usage information with cache metrics
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+/// Usage information with cache metrics.
+///
+/// `prompt_tokens` is the uncached input bucket. Cache reads and writes stay
+/// separate so callers can compute both the real context size and provider
+/// cost without double-counting.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Usage {
     pub prompt_tokens: usize,
     pub completion_tokens: usize,
@@ -14,6 +18,37 @@ pub struct Usage {
     /// Tokens read from cache (10% cost vs 100%)
     #[serde(default)]
     pub cache_read_input_tokens: usize,
+}
+
+impl Usage {
+    /// Total input represented by this usage snapshot, including cached input.
+    pub fn input_tokens(&self) -> usize {
+        self.prompt_tokens
+            .saturating_add(self.cache_creation_input_tokens)
+            .saturating_add(self.cache_read_input_tokens)
+    }
+
+    /// Merge cumulative provider snapshots from a single streamed response.
+    ///
+    /// Providers such as Anthropic report input at message start and output at
+    /// message delta. Each bucket is cumulative when present, so taking the
+    /// maximum preserves the complete turn without adding repeated snapshots.
+    pub fn merge_snapshot(&mut self, snapshot: &Self) {
+        self.prompt_tokens = self.prompt_tokens.max(snapshot.prompt_tokens);
+        self.completion_tokens = self.completion_tokens.max(snapshot.completion_tokens);
+        self.cache_creation_input_tokens = self
+            .cache_creation_input_tokens
+            .max(snapshot.cache_creation_input_tokens);
+        self.cache_read_input_tokens = self
+            .cache_read_input_tokens
+            .max(snapshot.cache_read_input_tokens);
+
+        let represented_total = self.input_tokens().saturating_add(self.completion_tokens);
+        self.total_tokens = self
+            .total_tokens
+            .max(snapshot.total_tokens)
+            .max(represented_total);
+    }
 }
 
 /// Context management configuration for automatic context editing

--- a/crates/krusty-core/src/storage/runtime_traces/mapping.rs
+++ b/crates/krusty-core/src/storage/runtime_traces/mapping.rs
@@ -144,9 +144,15 @@ pub(super) fn summarize_loop_event(event: &LoopEvent) -> Value {
         LoopEvent::Usage {
             prompt_tokens,
             completion_tokens,
+            cache_creation_input_tokens,
+            cache_read_input_tokens,
+            total_tokens,
         } => json!({
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
+            "cache_creation_input_tokens": cache_creation_input_tokens,
+            "cache_read_input_tokens": cache_read_input_tokens,
+            "total_tokens": total_tokens,
         }),
         LoopEvent::SessionPinched {
             reason,

--- a/crates/krusty-core/src/tools/implementations/bash/execution.rs
+++ b/crates/krusty-core/src/tools/implementations/bash/execution.rs
@@ -1,10 +1,12 @@
 use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 
 use serde_json::json;
-use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::fs::{File, OpenOptions};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::{mpsc, Mutex};
 use tokio::time::{sleep, timeout};
@@ -85,6 +87,7 @@ async fn collect_pipe_output<R>(
     pipe: Option<R>,
     stream: Option<StreamContext>,
     buffer: Arc<Mutex<BoundedOutputBuffer>>,
+    spool: Option<Arc<Mutex<File>>>,
 ) where
     R: AsyncRead + Unpin + Send + 'static,
 {
@@ -94,6 +97,13 @@ async fn collect_pipe_output<R>(
 
     let mut reader = BufReader::new(pipe).lines();
     while let Ok(Some(line)) = reader.next_line().await {
+        if let Some(spool) = &spool {
+            let mut file = spool.lock().await;
+            if file.write_all(line.as_bytes()).await.is_ok() {
+                let _ = file.write_all(b"\n").await;
+            }
+        }
+
         if let Some(stream) = &stream {
             let _ = stream.output_tx.send(ToolOutputChunk {
                 tool_use_id: stream.tool_use_id.clone(),
@@ -105,6 +115,63 @@ async fn collect_pipe_output<R>(
 
         buffer.lock().await.push_line(&line);
     }
+}
+
+const TOOL_OUTPUT_RETENTION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+async fn cleanup_old_outputs(directory: &Path) {
+    let Ok(mut entries) = tokio::fs::read_dir(directory).await else {
+        return;
+    };
+    let cutoff = std::time::SystemTime::now()
+        .checked_sub(TOOL_OUTPUT_RETENTION)
+        .unwrap_or(std::time::UNIX_EPOCH);
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        if !path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("tool_") && name.ends_with(".log"))
+        {
+            continue;
+        }
+        let Ok(metadata) = entry.metadata().await else {
+            continue;
+        };
+        if metadata.modified().is_ok_and(|modified| modified < cutoff) {
+            let _ = tokio::fs::remove_file(path).await;
+        }
+    }
+}
+
+async fn create_output_spool(path: &Path) -> Option<Arc<Mutex<File>>> {
+    let directory = path.parent()?;
+    if let Err(error) = tokio::fs::create_dir_all(directory).await {
+        tracing::warn!(%error, path = %directory.display(), "Could not create tool-output store");
+        return None;
+    }
+    cleanup_old_outputs(directory).await;
+
+    let file = match OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)
+        .await
+    {
+        Ok(file) => file,
+        Err(error) => {
+            tracing::warn!(%error, path = %path.display(), "Could not create tool-output spool");
+            return None;
+        }
+    };
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await;
+    }
+
+    Some(Arc::new(Mutex::new(file)))
 }
 
 pub(super) async fn join_reader_with_timeout(mut handle: tokio::task::JoinHandle<()>) {
@@ -194,6 +261,7 @@ pub(super) async fn execute_foreground(
     mut cmd: Command,
     timeout_duration: Duration,
     stream: Option<StreamContext>,
+    output_spool_path: PathBuf,
 ) -> ToolResult {
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -207,16 +275,19 @@ pub(super) async fn execute_foreground(
         RAW_CAPTURE_MAX_LINES,
         RAW_CAPTURE_MAX_BYTES,
     )));
+    let spool = create_output_spool(&output_spool_path).await;
 
     let stdout_handle = tokio::spawn(collect_pipe_output(
         stdout,
         stream.clone(),
         Arc::clone(&buffer),
+        spool.clone(),
     ));
     let stderr_handle = tokio::spawn(collect_pipe_output(
         stderr,
         stream.clone(),
         Arc::clone(&buffer),
+        spool.clone(),
     ));
 
     let wait_result = timeout(timeout_duration, child.wait()).await;
@@ -255,6 +326,10 @@ pub(super) async fn execute_foreground(
 
     join_reader_with_timeout(stdout_handle).await;
     join_reader_with_timeout(stderr_handle).await;
+    if let Some(spool) = &spool {
+        let mut file = spool.lock().await;
+        let _ = file.flush().await;
+    }
 
     let combined_output = {
         let mut guard = buffer.lock().await;
@@ -274,7 +349,19 @@ pub(super) async fn execute_foreground(
         });
     }
 
-    let processed = process_output(combined_output);
+    let stripped_output = super::strip_ansi(&combined_output);
+    let truncated = crate::tools::truncation::truncate_tail(
+        &stripped_output,
+        super::MAX_OUTPUT_LINES,
+        super::MAX_OUTPUT_BYTES,
+    )
+    .was_truncated;
+    let retained_path = truncated.then_some(output_spool_path.as_path());
+    let processed = process_output(combined_output, retained_path);
+    drop(spool);
+    if !truncated {
+        let _ = tokio::fs::remove_file(&output_spool_path).await;
+    }
     let metadata = Some(json!({
         "exit_code": exit_code,
         "killed": killed,

--- a/crates/krusty-core/src/tools/implementations/bash/mod.rs
+++ b/crates/krusty-core/src/tools/implementations/bash/mod.rs
@@ -9,6 +9,7 @@ mod tests;
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::{json, Value};
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
 
@@ -33,6 +34,29 @@ pub(super) const READER_JOIN_TIMEOUT_MS: u64 = 2_000;
 pub(super) const TIMEOUT_KILL_GRACE_MS: u64 = 800;
 
 pub struct BashTool;
+
+fn output_spool_path(ctx: &ToolContext) -> PathBuf {
+    let session = ctx
+        .session_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or("local")
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+
+    ctx.working_dir
+        .join(".krusty")
+        .join("tool-output")
+        .join(session)
+        .join(format!("tool_{}.log", uuid::Uuid::new_v4()))
+}
 
 #[derive(Deserialize)]
 struct Params {
@@ -211,16 +235,19 @@ If a validation/preflight command fails with actionable file diagnostics (for ex
             _ => return ToolResult::error("Streaming context incomplete for bash tool"),
         };
 
-        execute_foreground(cmd, timeout_duration, stream).await
+        execute_foreground(cmd, timeout_duration, stream, output_spool_path(ctx)).await
     }
 }
 
 /// Apply ANSI stripping and truncation to the final output sent to the AI model.
-fn process_output(combined: String) -> String {
+fn process_output(combined: String, full_output_path: Option<&std::path::Path>) -> String {
     let stripped = strip_ansi(&combined);
     let result = truncation::truncate_tail(&stripped, MAX_OUTPUT_LINES, MAX_OUTPUT_BYTES);
     if let Some(notice) = result.notice() {
-        format!("{}{}", result.text, notice)
+        let recovery = full_output_path
+            .map(|path| format!(" Full output saved to {}.", path.display()))
+            .unwrap_or_default();
+        format!("{}{}{}", result.text, notice, recovery)
     } else {
         result.text
     }

--- a/crates/krusty-core/src/tools/implementations/bash/tests.rs
+++ b/crates/krusty-core/src/tools/implementations/bash/tests.rs
@@ -1,5 +1,9 @@
 use super::execution::{join_reader_with_timeout, BoundedOutputBuffer};
 use super::shell::strip_shell_background_suffix;
+use super::{output_spool_path, BashTool};
+use crate::tools::registry::Tool;
+use crate::tools::ToolContext;
+use serde_json::json;
 
 #[test]
 fn strip_shell_background_suffix_accepts_simple_suffix() {
@@ -56,4 +60,56 @@ fn bounded_output_buffer_clips_to_max_bytes() {
 async fn join_reader_with_timeout_does_not_double_poll_completed_handle() {
     let handle = tokio::spawn(async {});
     join_reader_with_timeout(handle).await;
+}
+
+#[test]
+fn output_spool_is_workspace_local_and_session_scoped() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let ctx = ToolContext {
+        working_dir: temp.path().to_path_buf(),
+        session_id: Some("session/with spaces".to_string()),
+        ..Default::default()
+    };
+
+    let path = output_spool_path(&ctx);
+    assert!(path.starts_with(temp.path().join(".krusty/tool-output")));
+    assert!(path.to_string_lossy().contains("session_with_spaces"));
+    assert_eq!(
+        path.extension().and_then(|value| value.to_str()),
+        Some("log")
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn truncated_output_keeps_recoverable_full_log() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let working_dir = temp.path().canonicalize().expect("canonical tempdir");
+    let ctx = ToolContext {
+        working_dir: working_dir.clone(),
+        session_id: Some("test-session".to_string()),
+        sandbox_root: Some(working_dir.clone()),
+        ..Default::default()
+    };
+    let command = "i=1; while [ $i -le 5000 ]; do printf 'line-%s\\n' \"$i\"; i=$((i+1)); done";
+
+    let result = BashTool.execute(json!({"command": command}), &ctx).await;
+    assert!(!result.is_error, "{}", result.output);
+
+    let envelope: serde_json::Value = serde_json::from_str(&result.output).expect("tool JSON");
+    let preview = envelope["data"]["output"].as_str().expect("output preview");
+    assert!(preview.contains("Output truncated"));
+    assert!(preview.contains("Full output saved to"));
+    assert!(!preview.contains("line-1\n"));
+    assert!(preview.contains("line-5000"));
+
+    let directory = working_dir.join(".krusty/tool-output/test-session");
+    let paths = std::fs::read_dir(directory)
+        .expect("output directory")
+        .map(|entry| entry.expect("output entry").path())
+        .collect::<Vec<_>>();
+    assert_eq!(paths.len(), 1);
+    let full = std::fs::read_to_string(&paths[0]).expect("full output log");
+    assert!(full.contains("line-1\n"));
+    assert!(full.contains("line-5000\n"));
 }

--- a/crates/krusty-core/src/tools/implementations/edit.rs
+++ b/crates/krusty-core/src/tools/implementations/edit.rs
@@ -148,7 +148,7 @@ Preserve exact indentation and prefer small replacements. Use replace_all:true o
                     let new_content = format!(
                         "{}{}{}",
                         &content[..m.start],
-                        &params.new_string,
+                        params.new_string,
                         &content[m.end..]
                     );
 

--- a/crates/krusty-core/src/tools/implementations/multiedit.rs
+++ b/crates/krusty-core/src/tools/implementations/multiedit.rs
@@ -121,7 +121,7 @@ Edits apply sequentially, so later edits see earlier changes. Prefer this over m
                     content = format!(
                         "{}{}{}",
                         &content[..m.start],
-                        &edit.new_string,
+                        edit.new_string,
                         &content[m.end..],
                     );
                     applied += 1;

--- a/crates/krusty-desktop/Cargo.toml
+++ b/crates/krusty-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-desktop"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Native GPUI desktop workspace for Krusty"
 default-run = "krusty-desktop"

--- a/crates/krusty-mobile-ui/Cargo.toml
+++ b/crates/krusty-mobile-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-mobile-ui"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Lightweight GPUI mobile primitives for Krusty"
 

--- a/crates/krusty-mobile/Cargo.toml
+++ b/crates/krusty-mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-mobile"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Native GPUI mobile preview client for Krusty"
 default-run = "krusty-mobile"

--- a/crates/krusty-server/Cargo.toml
+++ b/crates/krusty-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-server"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Self-hosted Krusty API server library"
 

--- a/crates/krusty-server/src/routes/files/mod.rs
+++ b/crates/krusty-server/src/routes/files/mod.rs
@@ -146,7 +146,8 @@ mod tests {
         .await
         .unwrap_or_else(|_| panic!("browse should succeed"));
 
-        assert_eq!(response.current, repo_dir.to_string_lossy());
+        let canonical_repo = repo_dir.canonicalize().expect("repo should canonicalize");
+        assert_eq!(response.current, canonical_repo.to_string_lossy());
     }
 
     #[tokio::test]

--- a/crates/krusty-server/src/routes/sessions/crud.rs
+++ b/crates/krusty-server/src/routes/sessions/crud.rs
@@ -112,13 +112,11 @@ pub(super) async fn create_session(
         trimmed_nonempty(req.project_dir.as_deref())
             .or(trimmed_nonempty(req.working_dir.as_deref())),
     )?;
-    let target_branch = req.target_branch.as_deref().map(str::trim).and_then(|b| {
-        if b.is_empty() {
-            None
-        } else {
-            Some(b)
-        }
-    });
+    let target_branch = req
+        .target_branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|branch| !branch.is_empty());
     let session_id = session_manager.create_session_for_user_with_config_and_permission(
         title,
         requested_model,

--- a/crates/krusty-server/src/types/events.rs
+++ b/crates/krusty-server/src/types/events.rs
@@ -183,6 +183,9 @@ pub enum AgenticEvent {
     Usage {
         prompt_tokens: usize,
         completion_tokens: usize,
+        cache_creation_input_tokens: usize,
+        cache_read_input_tokens: usize,
+        total_tokens: usize,
     },
     /// Active work was handed off into a linked continuation session.
     SessionPinched {
@@ -466,9 +469,15 @@ impl From<krusty_core::agent::LoopEvent> for AgenticEvent {
             LoopEvent::Usage {
                 prompt_tokens,
                 completion_tokens,
+                cache_creation_input_tokens,
+                cache_read_input_tokens,
+                total_tokens,
             } => Self::Usage {
                 prompt_tokens,
                 completion_tokens,
+                cache_creation_input_tokens,
+                cache_read_input_tokens,
+                total_tokens,
             },
             LoopEvent::SessionPinched {
                 reason,

--- a/deploy/systemd/krusty-serve.service
+++ b/deploy/systemd/krusty-serve.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Krusty self-hosted server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/Work/krusty
+ExecStart=%h/Work/krusty/target/release/krusty serve --port 3000
+Environment=RUST_LOG=info
+Restart=on-failure
+RestartSec=3
+TimeoutStopSec=30
+
+[Install]
+WantedBy=default.target

--- a/docs/operations/build-and-deploy.md
+++ b/docs/operations/build-and-deploy.md
@@ -4,15 +4,17 @@ This document explains how Krusty is built, tested, and distributed across all o
 
 ## Rust workspace
 
-The Rust side of Krusty is organized as a Cargo workspace with three crates:
+The Rust side of Krusty is organized as a Cargo workspace with eight Krusty crates plus the `grok-auth` support crate. The primary runtime boundaries are:
 
 - **krusty-cli** (`crates/krusty-cli`) -- The terminal application with the TUI. This is the default member of the workspace, so a bare `cargo build` compiles it. It depends on both `krusty-core` and `krusty-server`.
 - **krusty-core** (`crates/krusty-core`) -- The core library containing AI provider integrations, tool implementations, the ACP/MCP protocol layers, WASM extension hosting, and local storage. Everything shared between the CLI and the server lives here.
 - **krusty-server** (`crates/krusty-server`) -- The self-hosted API server built on Axum. It serves the REST/WebSocket APIs used by the mobile and desktop clients, and optionally embeds the web frontend (more on that below).
+- **krusty-client** and **krusty-client-state** -- Typed transport and shared client-state boundaries.
+- **krusty-desktop**, **krusty-mobile**, and **krusty-mobile-ui** -- Native desktop/mobile presentation crates that consume the same core contracts.
 
 The workspace root `Cargo.toml` sets a few important release profile options: link-time optimization (`lto = true`), a single codegen unit (`codegen-units = 1`), and symbol stripping (`strip = true`). These produce smaller, faster release binaries at the cost of longer compile times. The workspace also defines shared lint rules so all three crates enforce the same code quality standards through Clippy.
 
-All three crates share version `0.7.0` and edition 2021.
+The eight Krusty crates and desktop bundle share version `0.7.3` and edition 2021.
 
 ## Build commands
 
@@ -60,7 +62,7 @@ The preflight is safe for validation: it reads repository metadata, remote refs,
 
 ## Release automation
 
-Releases are triggered by pushing a Git tag that matches `v*` (for example, `v0.7.0`). The release workflow (`.github/workflows/release.yml`) has three stages:
+Releases are triggered by pushing a Git tag that matches `v*` (for example, `v0.7.3`). The release workflow (`.github/workflows/release.yml`) has three stages:
 
 **1. Build matrix.** A matrix job compiles release binaries for five targets:
 
@@ -78,7 +80,7 @@ Each job first builds the Expo web frontend from `apps/mobile` (so it can be emb
 
 **3. Create release.** Once both build stages complete, all artifacts are downloaded and a GitHub Release is created with auto-generated release notes. The release includes the CLI binaries for all five platforms plus the desktop Linux packages.
 
-**Governance TODO:** the tag-triggered release path should gain an explicit release/tag environment gate (or equivalent protected tag ruleset) before autonomous agents can request or prepare releases at scale. This card documents the gap only; do not validate releases by pushing `v*` tags or by manually dispatching a release workflow.
+The publish job fails closed unless GitHub reports the release tag as protected (`github.ref_protected == true`). The repository also maintains an active `Protect release tags` ruleset. Do not push a `v*` tag merely to test the workflow; create one only for an approved, fully verified release.
 
 ## Distribution channels
 
@@ -95,7 +97,23 @@ The script (`install.sh`) detects the host OS and architecture, fetches the late
 You can pin a specific version by setting `VERSION` before running the script:
 
 ```bash
-VERSION=v0.7.0 curl -fsSL ... | sh
+VERSION=v0.7.3 curl -fsSL ... | sh
+```
+
+## Self-hosted systemd service
+
+The checked-in user service runs the release binary from the standard
+`~/Work/krusty` checkout on port 3000. Build the embedded Expo web bundle and
+release binary before installing or restarting it:
+
+```bash
+cd apps/mobile && bun install --frozen-lockfile && bun run web:build && cd ../..
+cargo build --release -p krusty
+install -Dm644 deploy/systemd/krusty-serve.service \
+  ~/.config/systemd/user/krusty-serve.service
+systemctl --user daemon-reload
+systemctl --user enable --now krusty-serve.service
+curl --fail http://127.0.0.1:3000/health
 ```
 
 ### Homebrew tap

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -925,7 +925,16 @@ export class KrustyClient {
 				);
 				break;
 			case "usage":
-				callbacks.onUsage(event.prompt_tokens, event.completion_tokens);
+				callbacks.onUsage(event.prompt_tokens, event.completion_tokens, {
+					promptTokens: event.prompt_tokens,
+					completionTokens: event.completion_tokens,
+					cacheCreationInputTokens:
+						event.cache_creation_input_tokens ?? 0,
+					cacheReadInputTokens: event.cache_read_input_tokens ?? 0,
+					totalTokens:
+						event.total_tokens ??
+						event.prompt_tokens + event.completion_tokens,
+				});
 				break;
 			case "context_compaction_started":
 				callbacks.onContextCompactionStarted?.(event);

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -761,6 +761,14 @@ export type SessionContinuationEvent =
 	| SessionPinchedEvent
 	| ContextCompactedEvent;
 
+export interface UsageMetrics {
+	promptTokens: number;
+	completionTokens: number;
+	cacheCreationInputTokens: number;
+	cacheReadInputTokens: number;
+	totalTokens: number;
+}
+
 export type StreamEvent =
 	| { type: "text_delta"; delta: string }
 	| { type: "text_delta_with_citations"; delta: string; citations: unknown[] }
@@ -790,7 +798,14 @@ export type StreamEvent =
 			title: string;
 			task_count: number;
 	  }
-	| { type: "usage"; prompt_tokens: number; completion_tokens: number }
+	| {
+			type: "usage";
+			prompt_tokens: number;
+			completion_tokens: number;
+			cache_creation_input_tokens?: number;
+			cache_read_input_tokens?: number;
+			total_tokens?: number;
+	  }
 	| ContextCompactionStartedEvent
 	| SessionPinchedEvent
 	| ContextCompactedEvent
@@ -860,7 +875,11 @@ export interface StreamCallbacks {
 		title: string,
 		taskCount: number,
 	) => void;
-	onUsage: (promptTokens: number, completionTokens: number) => void;
+	onUsage: (
+		promptTokens: number,
+		completionTokens: number,
+		metrics?: UsageMetrics,
+	) => void;
 	onContextCompactionStarted?: (event: ContextCompactionStartedEvent) => void;
 	onSessionPinched?: (event: SessionContinuationEvent) => void;
 	onTitleUpdate: (title: string) => void;

--- a/packages/state/src/session/store.ts
+++ b/packages/state/src/session/store.ts
@@ -63,7 +63,7 @@ import {
 } from './thinking';
 
 function hasOwnProperty<T extends object>(value: T, key: PropertyKey): boolean {
-  return  Object.hasOwn(value, key);
+  return Object.hasOwn(value, key);
 }
 
 function normalizeTargetBranch(targetBranch: string | null | undefined): string | null {

--- a/packages/state/src/session/streaming.ts
+++ b/packages/state/src/session/streaming.ts
@@ -370,9 +370,12 @@ export function createStreamCallbacks(
 			}));
 		},
 
-		onUsage: (promptTokens, completionTokens) => {
+		onUsage: (promptTokens, completionTokens, metrics) => {
 			flushPendingTextDelta();
-			set({ tokenCount: promptTokens + completionTokens });
+			set({
+				tokenCount:
+					metrics?.totalTokens ?? promptTokens + completionTokens,
+			});
 		},
 
 		onSessionPinched: (event: SessionContinuationEvent) => {


### PR DESCRIPTION
## Summary
- preserve and ship the latest desktop/mobile chat workspace changes
- enforce provider finish reasons, EOF recovery, and complete Gemini tool frames
- report cache-aware token usage across Rust and TypeScript clients
- retain recoverable full bash output when model previews are truncated
- prepare v0.7.3 packaging and a reproducible Honey systemd service

## Validation
- changed core/client/server suites pass locally
- TypeScript and Expo production web export pass on macOS and Honey Linux
- full Honey Linux workspace gate and GitHub CI are in progress
- default-branch and protected-tag governance preflights pass