### PR TITLE
Release Krusty 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "krusty"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4835,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4850,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client-state"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "krusty-client",
  "serde",
@@ -4859,7 +4859,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -4927,7 +4927,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-desktop"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -4979,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-mobile"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -4993,7 +4993,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-mobile-ui"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "gpui",
  "krusty-client-state",
@@ -5002,7 +5002,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/desktop/shell/README.md
+++ b/apps/desktop/shell/README.md
@@ -25,11 +25,11 @@ Build outputs:
 
 ## Linux Install + Run
 - Debian/Ubuntu:
-  - `sudo apt install "./src-tauri/target/release/bundle/deb/Krusty Desktop_0.7.3_amd64.deb"`
+  - `sudo apt install "./src-tauri/target/release/bundle/deb/Krusty Desktop_0.8.0_amd64.deb"`
 - Fedora/RHEL:
-  - `sudo dnf install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.7.3-1.x86_64.rpm"`
+  - `sudo dnf install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.8.0-1.x86_64.rpm"`
 - openSUSE:
-  - `sudo zypper install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.7.3-1.x86_64.rpm"`
+  - `sudo zypper install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.8.0-1.x86_64.rpm"`
 
 After install, launch with:
 - `krusty-desktop`

--- a/apps/desktop/shell/package.json
+++ b/apps/desktop/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krusty/desktop-shell",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "private": true,
   "packageManager": "bun@1.3.0",
   "type": "module",

--- a/apps/desktop/shell/src-tauri/Cargo.lock
+++ b/apps/desktop/shell/src-tauri/Cargo.lock
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-desktop"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "krusty-core",
  "krusty-server",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/desktop/shell/src-tauri/Cargo.toml
+++ b/apps/desktop/shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-desktop"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 
 [build-dependencies]

--- a/apps/desktop/shell/src-tauri/tauri.conf.json
+++ b/apps/desktop/shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Krusty Desktop",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "identifier": "io.krusty.desktop",
   "build": {
     "beforeDevCommand": "cd ../../mobile && npx expo start --web --port 5173",

--- a/crates/krusty-cli/Cargo.toml
+++ b/crates/krusty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 description = "The most elegant coding CLI to ever exist"
 default-run = "krusty"

--- a/crates/krusty-client-state/Cargo.toml
+++ b/crates/krusty-client-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client-state"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 description = "Headless Rust state machine for Krusty chat clients"
 

--- a/crates/krusty-client/Cargo.toml
+++ b/crates/krusty-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 description = "Async Rust client for the Krusty server API"
 

--- a/crates/krusty-core/Cargo.toml
+++ b/crates/krusty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-core"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 description = "Core library for Krusty - AI, storage, tools, and extensions"
 

--- a/crates/krusty-core/src/agent/subagent/scheduler.rs
+++ b/crates/krusty-core/src/agent/subagent/scheduler.rs
@@ -273,7 +273,9 @@ async fn run_scheduler(
                 let Some(command) = command else { return; };
                 match command {
                     Command::Acquire { request, response } => {
-                        state.pending.push_back(Pending { request, response });
+                        state
+                            .pending
+                            .push_back(self::Pending { request, response });
                         if state.active.len() >= state.target_limit {
                             state.demand_observed = true;
                         }

--- a/crates/krusty-desktop/Cargo.toml
+++ b/crates/krusty-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-desktop"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 description = "Native GPUI desktop workspace for Krusty"
 default-run = "krusty-desktop"

--- a/crates/krusty-mobile-ui/Cargo.toml
+++ b/crates/krusty-mobile-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-mobile-ui"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 description = "Lightweight GPUI mobile primitives for Krusty"
 

--- a/crates/krusty-mobile/Cargo.toml
+++ b/crates/krusty-mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-mobile"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 description = "Native GPUI mobile preview client for Krusty"
 default-run = "krusty-mobile"

--- a/crates/krusty-server/Cargo.toml
+++ b/crates/krusty-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-server"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 description = "Self-hosted Krusty API server library"
 

--- a/docs/operations/build-and-deploy.md
+++ b/docs/operations/build-and-deploy.md
@@ -17,7 +17,7 @@ The Rust side of Krusty is organized as a Cargo workspace with ten Krusty crates
 The workspace root `Cargo.toml` sets a few important release profile options: link-time optimization (`lto = true`), a single codegen unit (`codegen-units = 1`), and symbol stripping (`strip = true`). These produce smaller, faster release binaries at the cost of longer compile times. The workspace also defines shared lint rules so all workspace crates enforce the same code quality standards through Clippy.
 
 The product-facing Krusty crates and desktop bundle currently share version
-`0.7.3` and edition 2021. The internal Mako daemon/protocol crates have their
+`0.8.0` and edition 2021. The internal Mako daemon/protocol crates have their
 own `0.1.0` package versions; release tags are validated against the `krusty`
 package version.
 
@@ -67,7 +67,7 @@ The preflight is safe for validation: it reads repository metadata, remote refs,
 
 ## Release automation
 
-Releases are triggered by pushing a Git tag that matches `v*` (for example, `v0.7.3`). Before packaging, the release workflow calls `.github/workflows/client-quality.yml`; no release build starts unless the API streaming/error contracts, shared-state type-check/tests, mobile TypeScript check, and Expo web export all pass. The remaining release workflow (`.github/workflows/release.yml`) has three artifact stages:
+Releases are triggered by pushing a Git tag that matches `v*` (for example, `v0.8.0`). Before packaging, the release workflow calls `.github/workflows/client-quality.yml`; no release build starts unless the API streaming/error contracts, shared-state type-check/tests, mobile TypeScript check, and Expo web export all pass. The remaining release workflow (`.github/workflows/release.yml`) has three artifact stages:
 
 **1. Build matrix.** A matrix job compiles release binaries for five targets:
 
@@ -110,7 +110,7 @@ sh install.sh --self-test
 You can pin a specific version by setting `VERSION` before running the script:
 
 ```bash
-curl -fsSL ... | VERSION=v0.7.3 sh
+curl -fsSL ... | VERSION=v0.8.0 sh
 ```
 
 ## Self-hosted systemd service


### PR DESCRIPTION
## Summary

- bump the Krusty product crates and desktop bundle to 0.8.0
- regenerate workspace and desktop lockfiles
- fix the standalone desktop scheduler build by disambiguating the pending request type
- update release and desktop package documentation

## Validation

- `cargo check --workspace`
- `cargo check --manifest-path apps/desktop/shell/src-tauri/Cargo.toml`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- `bun test packages/api/test` (19 passed)
- `deno task check:state`
- `deno task test:state` (29 passed)
- mobile TypeScript check
- Expo web export
- `sh install.sh --self-test`
