### PR TITLE
Fix Windows Mako subscription contract for v0.8.0

### DIFF
--- a/crates/krusty-mako-protocol/src/client.rs
+++ b/crates/krusty-mako-protocol/src/client.rs
@@ -294,7 +294,16 @@ impl EventSubscription {
 }
 
 #[cfg(not(unix))]
-pub struct EventSubscription;
+pub struct EventSubscription {
+    pub accepted: crate::SubscriptionAccepted,
+}
+
+#[cfg(not(unix))]
+impl EventSubscription {
+    pub async fn next_event(&mut self) -> Result<Option<EventEnvelope>, ClientError> {
+        Err(ClientError::UnsupportedPlatform)
+    }
+}
 
 fn request_timeout(
     config: &MakoIpcClientConfig,


### PR DESCRIPTION
## Summary
- preserve the `EventSubscription` API shape on non-Unix targets
- keep runtime behavior fail-closed with `UnsupportedPlatform`
- unblock the Windows release build for v0.8.0

## Validation
- `cargo check --workspace`
- `cargo test -p krusty-mako-protocol -p krusty-server` (24 + 268 passed)
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The earlier v0.8.0 release workflow failed before publishing a GitHub Release; after this merges, the unpublished tag will be moved to the corrected main commit and the release workflow rerun.