### PR TITLE
Enable HTTP/2 for APNs delivery

### DIFF
--- a/crates/krusty-server/Cargo.toml
+++ b/crates/krusty-server/Cargo.toml
@@ -36,7 +36,7 @@ portable-pty = "0.8"
 # Web Push notifications (pure Rust, no OpenSSL — matches rustls stack)
 web-push-native = "0.4"
 base64ct = { version = "1", features = ["alloc"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["http2", "json", "stream", "rustls-tls"] }
 
 # APNs (Apple Push Notification service) — JWT auth via ES256
 jsonwebtoken = "9"


### PR DESCRIPTION
## What changed

- Enable reqwest's HTTP/2 transport feature in `krusty-server`.

## Why

Apple's APNs provider API requires HTTP/2. The server disabled reqwest default features and selected JSON, streaming, and rustls, but omitted the separate HTTP/2 feature. APNs initialization therefore succeeded while every delivery failed at the transport layer before Apple returned an HTTP response.

## Impact

Krusty's native APNs delivery path can connect to Apple's production and sandbox provider endpoints. This makes tool approval, completion, awaiting-input, Mako, error, and test notifications deliverable through the existing APNs service.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cd apps/mobile && npx expo export --platform web`
- Direct production APNs request for `io.krusty.mobile` returned HTTP 200 using the configured Honey credential and registered device.
