### PR TITLE
Force HTTP/2 for APNs delivery

### DIFF
--- a/crates/krusty-server/src/apns.rs
+++ b/crates/krusty-server/src/apns.rs
@@ -115,6 +115,9 @@ impl ApnsService {
 
         let client = Client::builder()
             .timeout(Duration::from_secs(10))
+            // APNs is HTTP/2-only. Do not allow reqwest to fall back to HTTP/1.1
+            // when ALPN negotiation is unavailable or inconclusive.
+            .http2_prior_knowledge()
             .build()
             .context("Failed to build HTTP client for APNs")?;
 


### PR DESCRIPTION
## Summary
- force the APNs reqwest client to use HTTP/2 prior knowledge
- prevent HTTP/1.1 fallback against Apple's HTTP/2-only API

## Runtime proof
- the existing live Honey request failed before receiving an HTTP response
- an isolated probe using this exact reqwest setting was accepted by production APNs with HTTP 200

## Validation
- cargo fmt --all -- --check
- cargo check --workspace
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- cd apps/mobile && npx expo export --platform web