### PR TITLE
Polish Live Activity layout and status treatment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "krusty"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client-state"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "krusty-client",
  "serde",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/desktop/shell/README.md
+++ b/apps/desktop/shell/README.md
@@ -25,11 +25,11 @@ Build outputs:
 
 ## Linux Install + Run
 - Debian/Ubuntu:
-  - `sudo apt install "./src-tauri/target/release/bundle/deb/Krusty Desktop_0.8.1_amd64.deb"`
+  - `sudo apt install "./src-tauri/target/release/bundle/deb/Krusty Desktop_0.8.2_amd64.deb"`
 - Fedora/RHEL:
-  - `sudo dnf install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.8.1-1.x86_64.rpm"`
+  - `sudo dnf install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.8.2-1.x86_64.rpm"`
 - openSUSE:
-  - `sudo zypper install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.8.1-1.x86_64.rpm"`
+  - `sudo zypper install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.8.2-1.x86_64.rpm"`
 
 After install, launch with:
 - `krusty-desktop`

--- a/apps/desktop/shell/package.json
+++ b/apps/desktop/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krusty/desktop-shell",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "packageManager": "bun@1.3.0",
   "type": "module",

--- a/apps/desktop/shell/src-tauri/Cargo.lock
+++ b/apps/desktop/shell/src-tauri/Cargo.lock
@@ -2348,6 +2348,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,6 +2557,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -3028,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -3095,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-desktop"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "krusty-core",
  "krusty-server",
@@ -3125,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -5024,6 +5044,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/apps/desktop/shell/src-tauri/Cargo.toml
+++ b/apps/desktop/shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-desktop"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 
 [build-dependencies]

--- a/apps/desktop/shell/src-tauri/tauri.conf.json
+++ b/apps/desktop/shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Krusty Desktop",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "identifier": "io.krusty.desktop",
   "build": {
     "beforeDevCommand": "cd ../../mobile && npx expo start --web --port 5173",

--- a/apps/mobile/widgets/ChatStreamActivity.tsx
+++ b/apps/mobile/widgets/ChatStreamActivity.tsx
@@ -7,7 +7,9 @@ import {
   font,
   foregroundStyle,
   frame,
+  layoutPriority,
   lineLimit,
+  monospacedDigit,
   opacity,
   padding,
   resizable,
@@ -55,7 +57,8 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
     toolApprovalSessionId,
   } = props;
   const statusColor =
-    status === "needs_input" ? "#ef4444" : status === "completed" ? "#22c55e" : "#ff6b35";
+    status === "needs_input" ? "#fbbf24" : status === "completed" ? "#34c759" : "#ff7a32";
+  const timerColor = "#ff7a32";
   const statusLabel =
     status === "needs_input" ? "Needs input" : status === "completed" ? "Completed" : "Working";
   const elapsed = formatElapsed(elapsedSeconds);
@@ -70,8 +73,8 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
       modifiers={[
         resizable(),
         aspectRatio({ ratio: 1, contentMode: "fit" }),
-        frame({ width: 30, height: 30 }),
-        cornerRadius(9),
+        frame({ width: 28, height: 28 }),
+        cornerRadius(8),
         clipped(),
       ]}
     />
@@ -82,49 +85,51 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
       modifiers={[
         resizable(),
         aspectRatio({ ratio: 1, contentMode: "fit" }),
-        frame({ width: 18, height: 18 }),
+        frame({ width: 17, height: 17 }),
         cornerRadius(5),
         clipped(),
       ]}
     />
   );
   const metrics = (
-    <HStack spacing={14}>
-      <HStack spacing={5}>
-        <Image systemName="wrench" modifiers={[foregroundStyle("#60a5fa"), font({ size: 11 })]} />
-        <Text modifiers={[font({ size: 11 }), opacity(0.78)]}>{toolCount} tools</Text>
+    <HStack spacing={16}>
+      <HStack spacing={6}>
+        <Image systemName="wrench" size={12} color="#a8b0bc" />
+        <Text modifiers={[font({ size: 10, weight: "medium" }), opacity(0.76)]}>{toolCount} tools</Text>
       </HStack>
-      <HStack spacing={5}>
-        <Image systemName="doc.text.magnifyingglass" modifiers={[foregroundStyle("#60a5fa"), font({ size: 11 })]} />
-        <Text modifiers={[font({ size: 11, design: "monospaced" }), foregroundStyle("#22c55e")]}>+{filesAdded}</Text>
-        <Text modifiers={[font({ size: 11, design: "monospaced" }), foregroundStyle("#ef4444")]}>−{filesRemoved}</Text>
+      <HStack spacing={6}>
+        <Image systemName="doc.text.magnifyingglass" size={12} color="#a8b0bc" />
+        <HStack spacing={3}>
+          <Text modifiers={[font({ size: 10, weight: "medium" }), monospacedDigit(), foregroundStyle("#34c759")]}>+{filesAdded}</Text>
+          <Text modifiers={[font({ size: 10, weight: "medium" }), monospacedDigit(), foregroundStyle("#ff5b62")]}>−{filesRemoved}</Text>
+        </HStack>
       </HStack>
     </HStack>
   );
 
   return {
     banner: (
-      <VStack alignment="leading" spacing={9} modifiers={[padding({ all: 14 })]}>
-        <HStack spacing={9}>
+      <VStack alignment="leading" spacing={10} modifiers={[padding({ horizontal: 14, vertical: 13 })]}>
+        <HStack spacing={10}>
           {logo}
-          <Text modifiers={[font({ size: 14, weight: "semibold" }), lineLimit(1)]}>
+          <Text modifiers={[font({ size: 13, weight: "semibold" }), lineLimit(1), layoutPriority(1)]}>
             {chatTitle || "Krusty session"}
           </Text>
           <Spacer />
-          <VStack alignment="trailing" spacing={2}>
-            <Text modifiers={[font({ size: 17, weight: "medium", design: "monospaced" }), foregroundStyle(statusColor)]}>
+          <VStack alignment="trailing" spacing={3} modifiers={[frame({ minWidth: 58, alignment: "trailing" })]}>
+            <Text modifiers={[font({ size: 15, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
               {elapsed}
             </Text>
             <HStack spacing={4}>
-              <Image systemName="circle.fill" modifiers={[foregroundStyle(statusColor), font({ size: 6 })]} />
-              <Text modifiers={[font({ size: 9, weight: "semibold" }), foregroundStyle(statusColor)]}>{statusLabel}</Text>
+              <Image systemName="circle.fill" size={5} color={statusColor} />
+              <Text modifiers={[font({ size: 9, weight: "medium" }), foregroundStyle(statusColor)]}>{statusLabel}</Text>
             </HStack>
           </VStack>
         </HStack>
         <HStack>
           {metrics}
           <Spacer />
-          <Image systemName="chevron.right" modifiers={[foregroundStyle("#60a5fa"), font({ size: 11 })]} />
+          <Image systemName="chevron.right" size={9} color="#8b93a1" />
         </HStack>
         {status === "needs_input" && approvalTarget && (
           <VStack spacing={6}>
@@ -143,29 +148,32 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
       <HStack spacing={6}>
         {compactLogo}
         <HStack spacing={3}>
-          <Text modifiers={[font({ size: 9, design: "monospaced" }), foregroundStyle("#22c55e")]}>+{filesAdded}</Text>
-          <Text modifiers={[font({ size: 9, design: "monospaced" }), foregroundStyle("#ef4444")]}>−{filesRemoved}</Text>
+          <Text modifiers={[font({ size: 9, weight: "medium" }), monospacedDigit(), foregroundStyle("#34c759")]}>+{filesAdded}</Text>
+          <Text modifiers={[font({ size: 9, weight: "medium" }), monospacedDigit(), foregroundStyle("#ff5b62")]}>−{filesRemoved}</Text>
         </HStack>
       </HStack>
     ),
     compactTrailing: (
-      <Text modifiers={[font({ size: 11, weight: "medium", design: "monospaced" }), foregroundStyle(statusColor)]}>
+      <Text modifiers={[font({ size: 11, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
         {elapsed}
       </Text>
     ),
     minimal: compactLogo,
     expandedLeading: logo,
     expandedCenter: (
-      <Text modifiers={[font({ size: 13, weight: "semibold" }), lineLimit(1)]}>
+      <Text modifiers={[font({ size: 12, weight: "semibold" }), lineLimit(1)]}>
         {chatTitle || "Krusty session"}
       </Text>
     ),
     expandedTrailing: (
-      <VStack alignment="trailing" spacing={2}>
-        <Text modifiers={[font({ size: 12, weight: "medium", design: "monospaced" }), foregroundStyle(statusColor)]}>
+      <VStack alignment="trailing" spacing={3}>
+        <Text modifiers={[font({ size: 11, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
           {elapsed}
         </Text>
-        <Text modifiers={[font({ size: 9, weight: "semibold" }), foregroundStyle(statusColor)]}>{statusLabel}</Text>
+        <HStack spacing={3}>
+          <Image systemName="circle.fill" size={4} color={statusColor} />
+          <Text modifiers={[font({ size: 8, weight: "medium" }), foregroundStyle(statusColor)]}>{statusLabel}</Text>
+        </HStack>
       </VStack>
     ),
     expandedBottom: (

--- a/apps/mobile/widgets/ChatStreamActivity.tsx
+++ b/apps/mobile/widgets/ChatStreamActivity.tsx
@@ -65,6 +65,12 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
   const timerColor = "#ff7a32";
   const statusLabel =
     status === "needs_input" ? "Needs input" : status === "completed" ? "Completed" : "Working";
+  const compactStatusSymbol =
+    status === "needs_input"
+      ? "exclamationmark.circle.fill"
+      : status === "completed"
+        ? "checkmark.circle.fill"
+        : "circle.fill";
   const elapsed = formatElapsed(elapsedSeconds);
   const approvalTarget =
     toolApprovalId && toolApprovalSessionId
@@ -186,9 +192,12 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
       </HStack>
     ),
     compactTrailing: (
-      <Text modifiers={[font({ size: 11, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
-        {elapsed}
-      </Text>
+      <HStack spacing={4}>
+        <Image systemName={compactStatusSymbol} size={7} color={statusColor} />
+        <Text modifiers={[font({ size: 11, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
+          {elapsed}
+        </Text>
+      </HStack>
     ),
     minimal: compactLogo,
     expandedLeading: logo,

--- a/apps/mobile/widgets/ChatStreamActivity.tsx
+++ b/apps/mobile/widgets/ChatStreamActivity.tsx
@@ -38,6 +38,10 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
   // where the main React Native asset bundle is not guaranteed to be readable.
   const KRUSTY_LOGO =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAMnElEQVRYCU1YSailRxWuqn+4U7+hu/MS04lpu4kJ6QgJiGjAhQQUE4kuXLgQ9y5cBARxABEDLtxJNoIuXGQbggZECQQTEUxIInQGM5jpJa+705033+GfqsrvO6f++27de+uvOnWG75w6NfzX2mxsbDTGmlSkYa2x/CUyx0lhN3IEBBTtkZTaiYhHjEFpMUaKCBNrpbNeGk0NDFnrcuqIYowtMSyPnh9KrHEypC1BD6oWp+AEIAD3UpQhTdATDmSJDH3VJTW6SYCYACKGkLOxLGyzy+igwSp1KSED6cm2ioFDOJeqRUQsqRBqFn1QiLDkKXR2e12gS4QwkLSoUTVAoiCThkjJMNUkDvSTNrQ42OvpbVgxhx5mgSYQXnZYIiknYEQCfQEkrGRSZxVcgtiTHe3Jj5qpiNZ76OydlD4ESz5BQZOCh/KiS7VQq2YZtemU0dBJPFbbFkkio6JhyeOITxQxN+CroukfpCExpTAMqU0YRAMgikg8lCgvIeZIbBVMNSRUPR/6oRqMyggrqtNspcuGeR1j08UiN5kEkhFSM2KemiEBZSuSRAXTNlCV2BaKzUw2oGkUAuCXKAhFC2SkONf62Pnopc5h2XFIVpk9fyb++Bsb+1N39ajrugAeH02IJlOAYk+00Iz0IKpPsUtywoAIaSuR2CEiAuol2YghfvPS5j2f3chGhXH5U89/uH3YZsBkTNOa71ya/+zBxdrR+k+vxh8+dGFcZvNZu7M7/9trN1qZLlXGoIgy2JA5k1Ci6i3BTN5PZjKPoRU8S6INwX/rc90PvlqsXzhjhuP/vPTehwcID9mLPDz9crhtOv/9q81WMXnskdPrRXjnf0f/fLt75tWuNYX4zOkCO+YFYUX4bFxigg4mlhizuegkp2AXomICF0iiDKCxje4fVR/fmF8YZ/mobqqqbbPCFVlmcmfePho8+rw35eDiul8cHbs8HhwvjmeN951xBYBLKFIgiAkRUlMpZkgkFFZpY2RUZJokPAkWKcLFdDNxXvuD4+Zwvzrt7YNfuHnrjvL9q8dvfVojjQaDMhS5j3aYNYPBuuT5DDDghyhQZzUk0Insgmqa5w/gyEbnQWCESO2DIXGRsGhwdEh4F43/9KhenxSlc7985BY7KX7zxPGvrvphmRcui841Pk4QsLdubB/6V67v7VWd2hNjYpm2aBvWiKFfeRIFoKIDkkMJjYSJgiiMDYtMG/dUa2HvaOH3jrth2Zl2emYa/WwGFVDOxRRtZyOyI86m7cz/9tmd63Vsiw0IwhCdT+EQtQkV2VMqiUkwYqcGbzIvSEUgIel3RcobrPm6i4vaz+a+7MImaOoUUrTl6d35EIM33ocQq+COuzwvs9PjAiHcnzatD1wF4gDjhAOfMIlWpowmGSHBLiDQko6Eg+0EUwcNAAWk0azu5lU7ia7LosWGE93tZ8yd54c2uMXC3V1MkObYrLIsR47D2o++cururdHP/3rtoyk2PTomkyYtDEsfltjEl0ktJWHRDmqCIR5g74GRFILp8O1i50LoIgz4Jn7//ukvHqviPIsvlfbKqdk1hsih5Fwx88O9T3xWVQsTh0ktFSMsCoCrTacUkwcYlCGDVBjiSYK2sshQAkQnWIKPTRs6bImdt5wgm7W1qY5jY8wsM8iybr0DH/VyH3/8X/uY0TpfywfEkYqigX0Co9/LAY3QCibaxydV4gklIJM5LOc4zN3aoBiXpijtqVE+GYYxzrBOAootsEAadSGIBqHN7RhTm2clbeDHJS97kE4TbSUwDFWUKRN4DBfBSJEnsDNUIsDBYW5HudmZ+uHZtdGZybbtvn5/8cCF6bmNLrw3NPc5e+/RJ/ttedXnNlNFmLeiLKHDMX9Ig2amtU4F0fGjzPLkPkRjhME4c0tLCFaQYeUG4579oHrh48XFzcxg/603x211up5ttfOiauLO0NxbOn/jzSvxj89xaz5sC15ROGsnZzCxiC0YorUTKHScBfchtABH+VBrl0NERmkIEq91r+9mJizOrecF/Bdttbezzko34rRDPs0788RHNdZKNhwWObFAiW7MVCURT7ZpH4Xkvia37jRQn9homwUOJKK4RGx2MDRumGdY7hbnF2Zw4AxSY5Q7rHGX4Rg1gwx6MuMwTRb7Fjrj0p47rZnKrIDq3gRaS4JYJzuusHisBAY0uiVSMocixsrCrM9LyCAznnnt+v7hYj106zbgbL9p3sZ34/F+2N12jz98hxmsHefDqsj/9Nz22Un93fvjr/9ewBNoldWeIs8o0zpUgkI4IPT7UA9bMdMPjYwES93ijcxhs/d4WfnHu4cv7lQMhkA3L6f3rEtr8ZVHjq52zTvFeD4ZPumqyzvx9e3KDrC/QI0WCT/0KwTUgknHEiB0TvhlRNlIF2SRcLDZuxA77EMFuYFGxG3mcgDFBh0HBfbxbr9p9/J6Ee0MB7IvDC51NEn7UthBg5BkxS2HELH+giYswqgzjaHlBJMs/oDCDG2jefC+O+65y26WcTxylz88evqNuXNZ5yJePAe3bZ1tR2dDMR+V3/5ScW3hnn9zdw/omBoKRZAxTMBIR5YwAfIkQivUhH4ZHRlKbkEHjtgvX5zcPgq3xtnN6/WTtvvL6zZDikA1Us3Xoy4OfO7L8NBdww+uHb38Vr1r+pu7okr+Ew+TiLolgHwNQoPA8WVRtGpc2eAWx9ihJJIFp2xVNwe+K7tqK7Zt3YAFmS4TYP28mTbmqO1q67CB7x7M2xZPrAaqT9HQTuqv0gAohREscnEh4oQKjx6ZwCEe8nQB95BQW7vwDiesJCe3D/HL1t5hc2pwXgRT+9gGzkzAjQRHj+Ch9gRM9HGb6kt6c00AhCrhAL/g1IfEFYOJDZZwvvrawBjeeKBc9r+0y9tZY46buMAp3IaFDw1OtmSesyVpo4pQs6FEnTEw6pQxLHRUKuI62bHFmyWdPaLlttzhFI0tAOFYgTDuq8IGSh0QvOhbj/QHekroFwxSSKEmVUdYLOjLnyboc/0pCdGVTBMt4gFbGtWkDbei0HUemdR2oao8rka5jT/5nr3zM9CBKYt43ag73BwNGHBRBCRs2gIs2aYmWk9dNU4A2EiYGFKITwMDBBJHCZTKKFzwsYHMHo/LU6OybAsz9t4yWAcH+3U9nkQz73B/RZBC7v1oVG6cGt267rOunDbIPA1ij0MNs8ZSESCcMuLk9kQSOPswME4UFwIjqFpsmeEmEfdmzbkzG2UWB5PY2Hnru989NTSl29zwR01Av0Woqua+z595+IHbv3jnwQe7zR/+feONXQZA54kGk1LRzDY/kkMEIzZloSirUiiFIUwZGXg5eXGnvnxl9rWL7ZZpFm1zy1qo5y2OlGKCPda+P/ePvrBXB4P7I6ZpY+y38vnB9en164vFDMsAfx/2HtNMj02xoOartNriLGG4D0iPDDxpE2Ck6MqVWYHseCAYvGhgbVfRIWlgRu495rjLLs8GJmDjAbPfmwe8Nk2bgIsKcgmLMvKmRvuo+6hLj+hQuFOTrjnDKAgrjfeYFIkm9nrpTk8m790wmcBHnuJlDV/RhRpnWuaHg+gLeouXATC0uPNzGVInTfUflRF7bKpdsLnBpqSJOAkztER8KODRhsha2L0wbC9N/J+vxPPj+qaBz2KYOPNpm/+3WsscbheU5WuArinv79ms1gqzaPnKtj0v5mYkbBIDdZ0IBSceFMYhPuDLpeqifaDrISmyFaLp2iY0lS2HWPEGLxv0y5piUA6HODswbxICwUNkoasqgx2UxZnBMM9xu0WwNByCQwRS1MDFnZrJyhYqsgKP/NAFAfwnRGjl69+ISgsbcXWU/QFdCMu1ToWgUWKF422A6cOixDC4kD00REv67NEIAST6jlXGUTZFCZpMYxJ7AgYZSkoBreOpzgcujskNvQerOLkoKWoAAjgLxU1hfKT0qNihMcUoKFf+0uOogBDVEE2IhM6xXiUaWoSDXJisXlhsqiRjiyHKoyiNtoWyiok8JBKX3IcQRdBYU1DxSpyWgVI3OJdJH57KzpSgGPvi6KrHCYQOc7Tn4Lwp/yo75xP77kD19b70SpZeirqeqlwCJ+GQeCVTZBU7ysDeSiQAQkylLBLmlTYjwpuDFEGv8e1ZxJneeyoWBdpIncQimtIAmEAlDCx9nqeiPrksY4q4F9UZFXYh9YCok7qIUb6o9HjG/8hCESu9h4mytCNWKQ9m/Poun0kvyFJOxknoeZfxx05NiFy9/TC7XPxim0lDIUkXLCaxR8VcPlLIqysQTJChAFWIGnD0S1a5qZS2xEf8I4GeqIYWIaH/f8rzY1cH1l+6AAAAAElFTkSuQmCC";
+  const CODE_ICON =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAAAXNSR0IArs4c6QAAAGxlWElmTU0AKgAAAAgABAEaAAUAAAABAAAAPgEbAAUAAAABAAAARgEoAAMAAAABAAIAAIdpAAQAAAABAAAATgAAAAAAAADYAAAAAQAAANgAAAABAAKgAgAEAAAAAQAAAEigAwAEAAAAAQAAAEgAAAAARDxGgQAAAAlwSFlzAAAhOAAAITgBRZYxYAAABNtJREFUeAHtm71PFEEUwGfuvAO1UIxacZUJldhopYUxkqAIEdEQDUbkDxA7ba/VTjor1EhICCpGRDFaWGinhVoYEiuwUSKa+AF33o7zzgzZ3Xu7N7vzwRYzCdndtzPv43ezM/teFkJccwQcAUfAEXAEHAFHwBFwBBACFJFlTjQ5/ewAzeduMkI6ucPvGa1dOtff/dqGo5kHdPfeXHs+X/hICd0qgHBQK5XKn87hwb7PQmbqmDOlWJfefK5w0Q8H9PJfta2l0HJGl404PZkHxOH0xwVg+t4m0wZU9E/OzJf4+P2YjgpjLzC5blmmZxBluZNYwIyRTxcGuj9g93TLMg2IL8bo48XXoBndIKL0ZRbQxMRsG6X0MOa4x5gDRLcUT3A4DWskY+zLwrtXVt6B4MfJ7AzKRe5e9FG5XPawmWVClklA4+PjrYySY1jAlNlbf8B+wxTGnLIt27yt1MVtrr85C/uMsF+rP5aei2sbRyVAY2NzLTtLxWt8Gg6Ds3ze316ofrtSHhysqDjPZ08/lgPx2fN0ZGRkNUp3eWqq2FHYcd3vz/Ji5eroaM9a1Jhm8tSPGMDZVSo+yFFymb/7b4c/OAcHmxmNu8/XF+4T68P6eCR+96rDCfkDPoKvmD4ZWSpAAg6l5HjYiPj1wnLZ6459hw7y7X030v8v+115jMjXRZht8FEFUmJAcXDWPVU4yVE89+Lb+8uhod6VNKpVICUCJAMH1qE0QYgxKm/PcbbTQpIGJAOH50hPYFEUwSY93rk/v5cHsgcbx6j3EJP7ZWAbfPDL/OdpIEkBkoXzdbFySmXHKNAcmnsRRt7wCuKiP1jsHGyDDzohNQVkCw4EHFX74e8/0rmXbkixgGzCqdd+KF77qTJPGhCA1gkpEpBNOPXZo7n2owsSCsg2HACksnvBeKzpgNQAaCPgmKz9qEIKANoIOPDLm679qEAKAILEE94VsOkKMtg+VbdyTLeN2o8sJGDg9zEAiF/Us3J/B3FuCo7N2o8MpDADpXKHgKdyzFLtB4sjMINM5DKYUb8Maj/+a3HerPYj+iU5yqyxYQYBQCZymbgAVGo/cXqxezJwYBkJ55IBQDLPaJqED3MYZCq1nyidmFwWDrYBBQCBcpuQTNR+woBU4ICuBkAgtAXJxNsz+C+aKhzQgwKCG6YhqdZ+wMe4pgMO6I8EBDdNQlKt/YB/UU0XHNAfCwg6mIKko/YD/oWbTjiguykg6KQbks7aD/gnmm44oFcKEHSUhRTOZWBsuJn67sdELikNCIKUgcQVRuZzApSp3SvOdtpcMhEgWUgCBHY0WfvB7IEsLRwYmxgQDIqbSeFcBvr7m8naD2ZbBQ74nQoQDBSQPEZu8Hrpd/iDc/h4Ae5HNZO1H7Ad9gdLH6J8w+TYRxRYPy0yqP20trUvh797riv3SN/Zga5ZLYY0KrFaD8p67QfjmvoRw5Q1k9ms/TTzRfa+NUA2az+ywcv0swbIVu1HJugkfawBslH7SRK4bF9rgEy9PcsGmrafFUCmaz9pg5cZZwVQkdKjqDOS3/2gYy0JrQCKiiXJdz9ROkzLrQBaq65N8zUo+AEmIz9rXvWW6QBV9VsB9P9/S2u9PF97y5PHav1Y846cP92zpBqAG+8IOAKOgCPgCDgCjoAj4AhsCIF/S/I8n8HpBxIAAAAASUVORK5CYII=";
+  const TOOLBOX_ICON =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAAAXNSR0IArs4c6QAAAGxlWElmTU0AKgAAAAgABAEaAAUAAAABAAAAPgEbAAUAAAABAAAARgEoAAMAAAABAAIAAIdpAAQAAAABAAAATgAAAAAAAADYAAAAAQAAANgAAAABAAKgAgAEAAAAAQAAAEigAwAEAAAAAQAAAEgAAAAARDxGgQAAAAlwSFlzAAAhOAAAITgBRZYxYAAABOhJREFUeAHtnM1PFDEUwNtlWaPxIMab8abyH+hJJRERjQbWmBVC8KRnb3DlKl7krCcNAYlxMRpFxAT1pH+CejPejF6MBli2vjfjrG2n3c5Hux/QSTYz89q+tr990/a10yHEH56AJ+CQAHWoW1C9UF09Syi9Rgk9TRg5TCjZL0Qw3TDyC9J8Y4S9I4w9Gi8PvTElsRHuHND849VjhR56j1J6xkaBIx2Msbf1bXZz4urQ50jm4uwU0MLyyilCik8hkz4XhWeE/CSkNjI+OvzehX7U6QxQYDnFwgdXcCIgCKleq590ZUmFKCPb5+CxcmQ5fFnxD8C8eJnNayeAsEG23eY0qzTmFXQCzSJlDCtmTNc8GfRWygiMbRLCprZ/bz6YmLgE7UfyY37+eV/PvtJ1aBVmoTcsxVKGeVrv2ZwACrryWA1QwKbGykNzyiCD8B/QucXqKsSkd+Xo+jzlmOnunTxiwThHUQ60HIU4lUirA8dWDg43gDSDwLSPlaq+Wh2aPFU60sjcAEpTgg6P6wEZ/iDrA8Wwiy+sGfJ1EsxYfdC2j2YN0MOllaPF3p77rRz/qCijj1bb2r4xWRn+ogpPK7MCaKH6egDGJk9wVJu2AC7iBz4aY1fGy+fW8+rPDSh4pEjhGXh1e/MWxmp6Rv4wUr+c95HLBahj4USkLUDKDKjj4ViClAmQGQ7bgFm/6Sw+V1SvpOeGj0bpbXBB9ijT5bCk1ICSwamXx8rnXyoL60i4WH11gdBC1TakVIA6FU7E3AWkxIA6HY4rSIkAdQscF5CMgLoNjm1ITQF1KxybkLSAuh2OLUhKQOhbwRTmC737gOOc1nflUaXTnpP1buyiyneLAQq88lLxIwRoHM/ughPBNEFCB7e2WTshzwLEJsyCKYsdBgchBQNXsHpYONiIoPFnNAisOy/DawFQ0O5o19C703L4ChshKdbXxGUf3XoWUk/R5swsLZWO9x6cpZTAOhb8Z4w8+LT1Y2qmUoF1sfxHHv0ICR63st4toRUoYWN9TbAg7doSOJ5pfKv+0oE7BUpuodniD68RWH40oYa8+kNLYtOq8sgzogIge+tZhUk588iaZHm2+/z6k66viYA0a0vatShN7VQ9oEqmSW4Uq3SpZM0UaeskMRABNdO4S8M8IMMfD5b5/1hcXoPxkj/GRgcbXLwFGezBA/KADAQMwd6CPCADAUOw6ItpIvOtuiaKINb1hmn1CEq5G1v6dXq4rERvng/w1yEB3wYZLMEJoOD1EyljlUyKkvhWpUslS6ywSUQ3gGD+R84T54RkWdZ7lS6VLKt+Pl2iRppPkOT6+9fN6UNHSvBOlThhliRtkjiu9fNlaPgcKNS16rZ6Hz7jTrhOUl8nj1gnVN5WGTwgA0kPyAMyEDAEewtKBQh3FisOfA9QIe5qkbZOEgPRgmDbtarW4UY2VUj3yrR1khgIA0Xckw6Lh/3xatNZ3MjWirdW43nblTTeisWdi4oj2JfPyYWBYrg2356NKFyZ2nopb4gRAGHJ4N2gdXn5ta0lbmHmuBEG3hEa4LMU2yAIwa8ZuPKM+Yw77RrrjHWXyxUDFG7Qr43sJkhhXWsjqo8TxAAhQfzUA37NAE1OJrrT7oNvgEBddZ+3iLVBMgBsuGHeIvtXW2SF7b5v01dk2l1tn78n4Al4Ap7AbiTwF7tHQuje7xuFAAAAAElFTkSuQmCC";
 
   function formatElapsed(seconds: number): string {
     const minutes = Math.floor(Math.max(0, seconds) / 60);
@@ -91,14 +95,34 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
       ]}
     />
   );
+  const toolIcon = (
+    <Image
+      uiImage={TOOLBOX_ICON}
+      modifiers={[
+        resizable(),
+        aspectRatio({ ratio: 1, contentMode: "fit" }),
+        frame({ width: 12, height: 12 }),
+      ]}
+    />
+  );
+  const codeIcon = (
+    <Image
+      uiImage={CODE_ICON}
+      modifiers={[
+        resizable(),
+        aspectRatio({ ratio: 1, contentMode: "fit" }),
+        frame({ width: 12, height: 12 }),
+      ]}
+    />
+  );
   const metrics = (
     <HStack spacing={16}>
       <HStack spacing={6}>
-        <Image systemName="wrench" size={12} color="#a8b0bc" />
+        {toolIcon}
         <Text modifiers={[font({ size: 10, weight: "medium" }), opacity(0.76)]}>{toolCount} tools</Text>
       </HStack>
       <HStack spacing={6}>
-        <Image systemName="doc.text.magnifyingglass" size={12} color="#a8b0bc" />
+        {codeIcon}
         <HStack spacing={3}>
           <Text modifiers={[font({ size: 10, weight: "medium" }), monospacedDigit(), foregroundStyle("#34c759")]}>+{filesAdded}</Text>
           <Text modifiers={[font({ size: 10, weight: "medium" }), monospacedDigit(), foregroundStyle("#ff5b62")]}>−{filesRemoved}</Text>
@@ -147,6 +171,14 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
     compactLeading: (
       <HStack spacing={6}>
         {compactLogo}
+        <Image
+          uiImage={CODE_ICON}
+          modifiers={[
+            resizable(),
+            aspectRatio({ ratio: 1, contentMode: "fit" }),
+            frame({ width: 10, height: 10 }),
+          ]}
+        />
         <HStack spacing={3}>
           <Text modifiers={[font({ size: 9, weight: "medium" }), monospacedDigit(), foregroundStyle("#34c759")]}>+{filesAdded}</Text>
           <Text modifiers={[font({ size: 9, weight: "medium" }), monospacedDigit(), foregroundStyle("#ff5b62")]}>−{filesRemoved}</Text>

--- a/crates/krusty-cli/Cargo.toml
+++ b/crates/krusty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "The most elegant coding CLI to ever exist"
 default-run = "krusty"

--- a/crates/krusty-client-state/Cargo.toml
+++ b/crates/krusty-client-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client-state"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Headless Rust state machine for Krusty chat clients"
 

--- a/crates/krusty-client/Cargo.toml
+++ b/crates/krusty-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Async Rust client for the Krusty server API"
 

--- a/crates/krusty-core/Cargo.toml
+++ b/crates/krusty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-core"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Core library for Krusty - AI, storage, tools, and extensions"
 

--- a/crates/krusty-server/Cargo.toml
+++ b/crates/krusty-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-server"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Self-hosted Krusty API server library"
 

--- a/docs/operations/build-and-deploy.md
+++ b/docs/operations/build-and-deploy.md
@@ -16,7 +16,7 @@ The Rust side of Krusty is organized as a Cargo workspace with seven Krusty crat
 The workspace root `Cargo.toml` sets a few important release profile options: link-time optimization (`lto = true`), a single codegen unit (`codegen-units = 1`), and symbol stripping (`strip = true`). These produce smaller, faster release binaries at the cost of longer compile times. The workspace also defines shared lint rules so all workspace crates enforce the same code quality standards through Clippy.
 
 The product-facing Krusty crates and desktop bundle currently share version
-`0.8.1` and edition 2021. The internal Mako daemon/protocol crates have their
+`0.8.2` and edition 2021. The internal Mako daemon/protocol crates have their
 own `0.1.0` package versions; release tags are validated against the `krusty`
 package version.
 
@@ -66,7 +66,7 @@ The preflight is safe for validation: it reads repository metadata, remote refs,
 
 ## Release automation
 
-Releases are triggered by pushing a Git tag that matches `v*` (for example, `v0.8.1`). Before packaging, the release workflow calls `.github/workflows/client-quality.yml`; no release build starts unless the API streaming/error contracts, shared-state type-check/tests, mobile TypeScript check, and Expo web export all pass. The remaining release workflow (`.github/workflows/release.yml`) has three artifact stages:
+Releases are triggered by pushing a Git tag that matches `v*` (for example, `v0.8.2`). Before packaging, the release workflow calls `.github/workflows/client-quality.yml`; no release build starts unless the API streaming/error contracts, shared-state type-check/tests, mobile TypeScript check, and Expo web export all pass. The remaining release workflow (`.github/workflows/release.yml`) has three artifact stages:
 
 **1. Build matrix.** A matrix job compiles release binaries for five targets:
 
@@ -109,7 +109,7 @@ sh install.sh --self-test
 You can pin a specific version by setting `VERSION` before running the script:
 
 ```bash
-curl -fsSL ... | VERSION=v0.8.1 sh
+curl -fsSL ... | VERSION=v0.8.2 sh
 ```
 
 ## Self-hosted systemd service
@@ -185,7 +185,7 @@ GitHub does not publish the versioned source archive until its tag exists, so
 AUR metadata is updated after the protected release tag is published. Run:
 
 ```bash
-./aur/update-release.sh 0.8.1
+./aur/update-release.sh 0.8.2
 cd aur
 makepkg --verifysource -f
 makepkg --printsrcinfo | diff -u .SRCINFO -


### PR DESCRIPTION
## What changed

- Tightens spacing and balances the logo, title, timer, status, tool count, and diff count across lock-screen and expanded Live Activity layouts.
- Keeps the timer on a constant Krusty brand color while status uses a restrained dot or compact state glyph.
- Replaces oversized generic symbols with consistent Lucide-derived toolbox and code/XML emblems.
- Adds compact Working, Needs input, and Completed treatments while preserving the elapsed timer and code diff.

## Why

The prior Live Activity rendered oversized symbols, uneven spacing, and state-dependent timer colors. Compact mode also lacked enough state information to distinguish work that needed input or had completed.

## Validation

- Mobile TypeScript check
- Expo native widget bundle serialization
- Expo iOS export
- Expo web export
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- Interactive layout/state verification at 736px with no horizontal overflow
