### PR TITLE
Smooth mobile streaming and Live Activity updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "krusty"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client-state"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "krusty-client",
  "serde",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/desktop/shell/README.md
+++ b/apps/desktop/shell/README.md
@@ -25,11 +25,11 @@ Build outputs:
 
 ## Linux Install + Run
 - Debian/Ubuntu:
-  - `sudo apt install "./src-tauri/target/release/bundle/deb/Krusty Desktop_0.8.1_amd64.deb"`
+  - `sudo apt install "./src-tauri/target/release/bundle/deb/Krusty Desktop_0.8.2_amd64.deb"`
 - Fedora/RHEL:
-  - `sudo dnf install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.8.1-1.x86_64.rpm"`
+  - `sudo dnf install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.8.2-1.x86_64.rpm"`
 - openSUSE:
-  - `sudo zypper install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.8.1-1.x86_64.rpm"`
+  - `sudo zypper install "./src-tauri/target/release/bundle/rpm/Krusty Desktop-0.8.2-1.x86_64.rpm"`
 
 After install, launch with:
 - `krusty-desktop`

--- a/apps/desktop/shell/package.json
+++ b/apps/desktop/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krusty/desktop-shell",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "packageManager": "bun@1.3.0",
   "type": "module",

--- a/apps/desktop/shell/src-tauri/Cargo.lock
+++ b/apps/desktop/shell/src-tauri/Cargo.lock
@@ -2348,6 +2348,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,6 +2557,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -3028,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -3095,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-desktop"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "krusty-core",
  "krusty-server",
@@ -3125,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -5024,6 +5044,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/apps/desktop/shell/src-tauri/Cargo.toml
+++ b/apps/desktop/shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-desktop"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 
 [build-dependencies]

--- a/apps/desktop/shell/src-tauri/tauri.conf.json
+++ b/apps/desktop/shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Krusty Desktop",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "identifier": "io.krusty.desktop",
   "build": {
     "beforeDevCommand": "cd ../../mobile && npx expo start --web --port 5173",

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -179,24 +179,33 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
   const notifiedApprovalIdsRef = useRef<Set<string>>(new Set());
   const suppressCompletionRef = useRef(false);
   const attemptedWorkspaceSessionHydrationRef = useRef<string | null>(null);
+  const sessionsRefreshInFlightRef = useRef(false);
+  const toolActivityRef = useRef<{
+    toolCalls: ReturnType<typeof flattenToolCalls>;
+    awaitingApprovalCalls: ReturnType<typeof flattenToolCalls>;
+    activeToolCall: ReturnType<typeof getActiveToolCall>;
+    activityDiff: { additions: number; deletions: number };
+  } | null>(null);
 
   const lastAssistantMessage = useMemo(
     () => getLastAssistantMessage(messages),
     [messages],
   );
-  const toolCalls = useMemo(() => flattenToolCalls(messages), [messages]);
-  const awaitingApprovalCalls = useMemo(
-    () =>
-      toolCalls.filter((toolCall) => toolCall.status === "awaiting_approval"),
-    [toolCalls],
-  );
-  const activeToolCall = useMemo(
-    () => getActiveToolCall(toolCalls),
-    [toolCalls],
-  );
-  const activityDiff = useMemo(
-    () =>
-      toolCalls.reduce(
+  const toolActivity = useMemo(() => {
+    const toolCalls = flattenToolCalls(messages);
+    const previous = toolActivityRef.current;
+    const unchanged =
+      previous?.toolCalls.length === toolCalls.length &&
+      toolCalls.every((toolCall, index) => previous.toolCalls[index] === toolCall);
+    if (unchanged && previous) return previous;
+
+    const next = {
+      toolCalls,
+      awaitingApprovalCalls: toolCalls.filter(
+        (toolCall) => toolCall.status === "awaiting_approval",
+      ),
+      activeToolCall: getActiveToolCall(toolCalls),
+      activityDiff: toolCalls.reduce(
         (total, toolCall) => {
           const diff = buildToolDiffPresentation(toolCall);
           if (diff) {
@@ -207,8 +216,16 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
         },
         { additions: 0, deletions: 0 },
       ),
-    [toolCalls],
-  );
+    };
+    toolActivityRef.current = next;
+    return next;
+  }, [messages]);
+  const {
+    toolCalls,
+    awaitingApprovalCalls,
+    activeToolCall,
+    activityDiff,
+  } = toolActivity;
 
   const lastAssistantSnippet =
     lastAssistantMessage?.content?.slice(0, 200) ?? "";
@@ -306,6 +323,7 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
   });
 
   useWidgetSync({
+    sessionId,
     hasActiveSession: Boolean(sessionId),
     sessionTitle: sessionTitle || "Untitled",
     lastMessage: lastAssistantSnippet,
@@ -420,13 +438,20 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
     }
 
     const refreshHandle = setInterval(() => {
-      if (AppState.currentState === "active") {
-        void sessionsStore.getState().loadSessions();
-      }
+      if (
+        AppState.currentState !== "active" ||
+        sessionStore.getState().isStreaming ||
+        sessionsRefreshInFlightRef.current
+      ) return;
+
+      sessionsRefreshInFlightRef.current = true;
+      void sessionsStore.getState().loadSessions().finally(() => {
+        sessionsRefreshInFlightRef.current = false;
+      });
     }, 5000);
 
     return () => clearInterval(refreshHandle);
-  }, [client, isConnected, sessionsStore]);
+  }, [client, isConnected, sessionStore, sessionsStore]);
 
   useEffect(() => {
     const subscription = AppState.addEventListener("change", (nextState) => {
@@ -545,14 +570,11 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
 
     previousStreamingRef.current = isStreaming;
   }, [
-    activeToolCall,
-    activityDiff,
+    activityDiff.additions,
+    activityDiff.deletions,
     awaitingApprovalCalls,
     endActivity,
     isStreaming,
-    isThinking,
-    lastAssistantMessage,
-    model,
     notifyStreamComplete,
     sessionId,
     sessionTitle,
@@ -597,6 +619,30 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
       void handleToolApprovalAction(targetSessionId, toolCallId, approved);
     },
     [handleToolApprovalAction],
+  );
+  const handleApproveTranscriptTool = useCallback(
+    (targetSessionId: string, toolCallId: string) => {
+      handleSessionToolApproval(targetSessionId, toolCallId, true);
+    },
+    [handleSessionToolApproval],
+  );
+  const handleDenyTranscriptTool = useCallback(
+    (targetSessionId: string, toolCallId: string) => {
+      handleSessionToolApproval(targetSessionId, toolCallId, false);
+    },
+    [handleSessionToolApproval],
+  );
+  const handleSubmitTranscriptTool = useCallback(
+    (toolCallId: string, result: string) => {
+      void handleInteractiveToolResult(toolCallId, result);
+    },
+    [handleInteractiveToolResult],
+  );
+  const handleTranscriptPlanConfirm = useCallback(
+    (toolCallId: string, choice: "execute" | "abandon") => {
+      void handlePlanConfirm(toolCallId, choice);
+    },
+    [handlePlanConfirm],
   );
 
   const handleStop = useCallback(() => {
@@ -770,18 +816,10 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
           isStreaming={isStreaming}
           isThinking={isThinking}
           activeToolCallId={activeToolCallId}
-          onApproveTool={(targetSessionId, toolCallId) =>
-            handleSessionToolApproval(targetSessionId, toolCallId, true)
-          }
-          onDenyTool={(targetSessionId, toolCallId) =>
-            handleSessionToolApproval(targetSessionId, toolCallId, false)
-          }
-          onSubmitToolResult={(toolCallId, result) =>
-            void handleInteractiveToolResult(toolCallId, result)
-          }
-          onPlanConfirm={(toolCallId, choice) =>
-            void handlePlanConfirm(toolCallId, choice)
-          }
+          onApproveTool={handleApproveTranscriptTool}
+          onDenyTool={handleDenyTranscriptTool}
+          onSubmitToolResult={handleSubmitTranscriptTool}
+          onPlanConfirm={handleTranscriptPlanConfirm}
           emptyState={
             <View style={styles.empty}>
               <KrustyLogo />
@@ -973,14 +1011,10 @@ function ChatScreenContent({ stores }: { stores: LoadedStores }) {
           model,
           models,
           tokenCount,
-          onApproveTool: (targetSessionId, toolCallId) =>
-            handleSessionToolApproval(targetSessionId, toolCallId, true),
-          onDenyTool: (targetSessionId, toolCallId) =>
-            handleSessionToolApproval(targetSessionId, toolCallId, false),
-          onSubmitToolResult: (toolCallId, result) =>
-            void handleInteractiveToolResult(toolCallId, result),
-          onPlanConfirm: (toolCallId, choice) =>
-            void handlePlanConfirm(toolCallId, choice),
+          onApproveTool: handleApproveTranscriptTool,
+          onDenyTool: handleDenyTranscriptTool,
+          onSubmitToolResult: handleSubmitTranscriptTool,
+          onPlanConfirm: handleTranscriptPlanConfirm,
           onSend: handleChatBarSend,
           onStop: handleStop,
           onThinkingChange: (level) =>

--- a/apps/mobile/components/chat/ChatTranscript.tsx
+++ b/apps/mobile/components/chat/ChatTranscript.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  memo,
   useMemo,
   useRef,
   useState,
@@ -139,6 +140,7 @@ export function ChatTranscript({
   const pendingAutoScrollRef = useRef(false);
   const pendingAutoScrollAnimatedRef = useRef(false);
   const bottomAnchorTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const bottomAnchorFrameRef = useRef<number | null>(null);
   const isUserDraggingRef = useRef(false);
   const programmaticScrollUntilRef = useRef(0);
   const loadedSessionIdRef = useRef<string | null>(null);
@@ -184,6 +186,10 @@ export function ChatTranscript({
   const clearBottomAnchorTimers = useCallback(() => {
     bottomAnchorTimersRef.current.forEach((timer) => clearTimeout(timer));
     bottomAnchorTimersRef.current = [];
+    if (bottomAnchorFrameRef.current !== null) {
+      cancelAnimationFrame(bottomAnchorFrameRef.current);
+      bottomAnchorFrameRef.current = null;
+    }
   }, []);
 
   const markProgrammaticScroll = useCallback((durationMs = PROGRAMMATIC_SCROLL_SETTLE_MS) => {
@@ -226,16 +232,16 @@ export function ChatTranscript({
         scrollToBottom(useAnimated);
       };
 
-      requestAnimationFrame(() => {
+      bottomAnchorFrameRef.current = requestAnimationFrame(() => {
+        bottomAnchorFrameRef.current = null;
         anchor(animated);
-        requestAnimationFrame(() => {
-          anchor(false);
-        });
       });
 
-      bottomAnchorTimersRef.current = [80, 180, 360].map((delay) =>
-        setTimeout(() => anchor(false), delay),
-      );
+      // One bounded fallback catches delayed Markdown measurement without
+      // issuing a multi-frame scroll storm for every streamed delta.
+      bottomAnchorTimersRef.current = [
+        setTimeout(() => anchor(false), 96),
+      ];
     },
     [clearBottomAnchorTimers, scrollToBottom],
   );
@@ -389,6 +395,37 @@ export function ChatTranscript({
     });
   }, [markProgrammaticScroll, onScrollTargetHandled, scrollToMessageId, turns]);
 
+  const renderTurn = useCallback(
+    ({ item, index }: { item: TranscriptTurn; index: number }) => {
+      const isLastTurn = index === turns.length - 1;
+      return (
+        <TranscriptTurnRow
+          turn={item}
+          isLastTurn={isLastTurn}
+          isStreaming={isStreaming && isLastTurn}
+          isThinking={isThinking && isLastTurn}
+          activeToolCallId={activeToolCallId}
+          sessionId={sessionId}
+          onApproveTool={onApproveTool}
+          onDenyTool={onDenyTool}
+          onSubmitToolResult={onSubmitToolResult}
+          onPlanConfirm={onPlanConfirm}
+        />
+      );
+    },
+    [
+      activeToolCallId,
+      isStreaming,
+      isThinking,
+      onApproveTool,
+      onDenyTool,
+      onPlanConfirm,
+      onSubmitToolResult,
+      sessionId,
+      turns.length,
+    ],
+  );
+
   if (messages.length === 0) {
     return (
       <Pressable style={styles.empty} onPress={Keyboard.dismiss}>
@@ -420,23 +457,7 @@ export function ChatTranscript({
         }}
         onScroll={handleListScroll}
         scrollEventThrottle={16}
-        renderItem={({ item, index }) => {
-          const isLastTurn = index === turns.length - 1;
-          return (
-            <TranscriptTurnRow
-              turn={item}
-              isLastTurn={isLastTurn}
-              isStreaming={isStreaming && isLastTurn}
-              isThinking={isThinking && isLastTurn}
-              activeToolCallId={activeToolCallId}
-              sessionId={sessionId}
-              onApproveTool={onApproveTool}
-              onDenyTool={onDenyTool}
-              onSubmitToolResult={onSubmitToolResult}
-              onPlanConfirm={onPlanConfirm}
-            />
-          );
-        }}
+        renderItem={renderTurn}
         style={styles.flex}
         contentContainerStyle={[
           styles.list,
@@ -588,7 +609,7 @@ interface TranscriptTurnRowProps {
   ) => void | Promise<void>;
 }
 
-function TranscriptTurnRow({
+const TranscriptTurnRow = memo(function TranscriptTurnRow({
   turn,
   isLastTurn,
   isStreaming,
@@ -629,7 +650,18 @@ function TranscriptTurnRow({
       })}
     </View>
   );
-}
+}, (previous, next) => (
+  previous.turn.renderSignature === next.turn.renderSignature &&
+  previous.isLastTurn === next.isLastTurn &&
+  previous.isStreaming === next.isStreaming &&
+  previous.isThinking === next.isThinking &&
+  previous.activeToolCallId === next.activeToolCallId &&
+  previous.sessionId === next.sessionId &&
+  previous.onApproveTool === next.onApproveTool &&
+  previous.onDenyTool === next.onDenyTool &&
+  previous.onSubmitToolResult === next.onSubmitToolResult &&
+  previous.onPlanConfirm === next.onPlanConfirm
+));
 
 const styles = StyleSheet.create({
   flex: {

--- a/apps/mobile/hooks/presentationCadence.ts
+++ b/apps/mobile/hooks/presentationCadence.ts
@@ -1,0 +1,66 @@
+export interface LiveActivitySemanticState {
+  chatTitle: string;
+  status: "working" | "needs_input" | "completed";
+  toolCount: number;
+  filesAdded: number;
+  filesRemoved: number;
+  toolApprovalId?: string;
+  toolApprovalName?: string;
+  toolApprovalSessionId?: string;
+}
+
+export interface ChatWidgetCadenceState {
+  sessionId: string | null;
+  hasActiveSession: boolean;
+  sessionTitle: string;
+  lastMessage: string;
+  model: string;
+  isStreaming: boolean;
+  tokenCount: number;
+  serverConnected: boolean;
+}
+
+export function liveActivityStateEqual(
+  left: LiveActivitySemanticState | null,
+  right: LiveActivitySemanticState | null,
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+
+  return (
+    left.chatTitle === right.chatTitle &&
+    left.status === right.status &&
+    left.toolCount === right.toolCount &&
+    left.filesAdded === right.filesAdded &&
+    left.filesRemoved === right.filesRemoved &&
+    left.toolApprovalId === right.toolApprovalId &&
+    left.toolApprovalName === right.toolApprovalName &&
+    left.toolApprovalSessionId === right.toolApprovalSessionId
+  );
+}
+
+export function shouldSyncChatWidget(
+  previous: ChatWidgetCadenceState | null,
+  next: ChatWidgetCadenceState,
+): boolean {
+  if (!previous) return true;
+
+  const lifecycleChanged =
+    previous.sessionId !== next.sessionId ||
+    previous.hasActiveSession !== next.hasActiveSession ||
+    previous.sessionTitle !== next.sessionTitle ||
+    previous.model !== next.model ||
+    previous.isStreaming !== next.isStreaming ||
+    previous.serverConnected !== next.serverConnected;
+
+  if (lifecycleChanged) return true;
+
+  // A Home Screen widget is a lifecycle snapshot, not a streaming surface.
+  // Final content and usage are written after the stream settles.
+  if (next.isStreaming) return false;
+
+  return (
+    previous.lastMessage !== next.lastMessage ||
+    previous.tokenCount !== next.tokenCount
+  );
+}

--- a/apps/mobile/hooks/useLiveActivity.ts
+++ b/apps/mobile/hooks/useLiveActivity.ts
@@ -1,5 +1,9 @@
 import { useRef, useCallback, useEffect } from 'react';
 import { Platform } from 'react-native';
+import {
+  liveActivityStateEqual,
+  type LiveActivitySemanticState,
+} from './presentationCadence';
 
 // Native-only imports — loaded dynamically to avoid crash on web
 let addUserInteractionListener: any = () => ({ remove: () => {} });
@@ -19,16 +23,14 @@ type LiveActivityInteractionEvent = {
   target?: unknown;
 };
 
-interface StreamState {
-  chatTitle: string;
-  status: 'working' | 'needs_input' | 'completed';
-  toolCount: number;
-  filesAdded: number;
-  filesRemoved: number;
-  toolApprovalId?: string;
-  toolApprovalName?: string;
-  toolApprovalSessionId?: string;
+type StreamState = LiveActivitySemanticState;
+
+interface ActivityContentState extends StreamState {
+  startedAtMs: number;
+  elapsedSeconds: number;
 }
+
+const MIN_ACTIVITY_UPDATE_INTERVAL_MS = 2_000;
 
 interface UseLiveActivityOptions {
   onToolApproval?: (
@@ -61,16 +63,72 @@ function parseApprovalTarget(
 export function useLiveActivity(options?: UseLiveActivityOptions) {
   const activityRef = useRef<LiveActivity | null>(null);
   const startTimeRef = useRef<number>(0);
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const stateRef = useRef<StreamState | null>(null);
   const sessionIdRef = useRef<string | null>(null);
+  const pendingUpdateRef = useRef<ActivityContentState | null>(null);
+  const pendingUpdateUrgentRef = useRef(false);
+  const updateInFlightRef = useRef(false);
+  const updateGenerationRef = useRef(0);
+  const lastUpdateStartedAtRef = useRef(0);
+  const updateDelayRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const clearTimer = useCallback(() => {
-    if (timerRef.current) {
-      clearInterval(timerRef.current);
-      timerRef.current = null;
+  const clearUpdateDelay = useCallback(() => {
+    if (updateDelayRef.current) {
+      clearTimeout(updateDelayRef.current);
+      updateDelayRef.current = null;
     }
   }, []);
+
+  const runPendingUpdateRef = useRef<(generation: number) => void>(() => {});
+
+  const schedulePendingUpdate = useCallback((force = false) => {
+    if (!activityRef.current || !pendingUpdateRef.current) return;
+    if (force) pendingUpdateUrgentRef.current = true;
+
+    const generation = updateGenerationRef.current;
+    const elapsed = Date.now() - lastUpdateStartedAtRef.current;
+    const delay = pendingUpdateUrgentRef.current
+      ? 0
+      : Math.max(0, MIN_ACTIVITY_UPDATE_INTERVAL_MS - elapsed);
+
+    if (delay === 0 && !updateInFlightRef.current) {
+      clearUpdateDelay();
+      runPendingUpdateRef.current(generation);
+      return;
+    }
+
+    if (!updateDelayRef.current && !updateInFlightRef.current) {
+      updateDelayRef.current = setTimeout(() => {
+        updateDelayRef.current = null;
+        runPendingUpdateRef.current(generation);
+      }, delay);
+    }
+  }, [clearUpdateDelay]);
+
+  runPendingUpdateRef.current = (generation: number) => {
+    if (
+      generation !== updateGenerationRef.current ||
+      updateInFlightRef.current ||
+      !activityRef.current ||
+      !pendingUpdateRef.current
+    ) {
+      return;
+    }
+
+    const activity = activityRef.current;
+    const content = pendingUpdateRef.current;
+    pendingUpdateRef.current = null;
+    pendingUpdateUrgentRef.current = false;
+    updateInFlightRef.current = true;
+    lastUpdateStartedAtRef.current = Date.now();
+
+    void activity.update(content).catch(() => {}).finally(() => {
+      updateInFlightRef.current = false;
+      if (pendingUpdateRef.current && activityRef.current) {
+        schedulePendingUpdate(pendingUpdateUrgentRef.current);
+      }
+    });
+  };
 
   const closeExistingActivities = useCallback(() => {
     if (!ChatStreamActivityFactory) return;
@@ -124,7 +182,10 @@ export function useLiveActivity(options?: UseLiveActivityOptions) {
       return;
     }
 
-    clearTimer();
+    clearUpdateDelay();
+    updateGenerationRef.current += 1;
+    pendingUpdateRef.current = null;
+    pendingUpdateUrgentRef.current = false;
     if (activityRef.current) {
       void activityRef.current.end('immediate').catch(() => {});
       activityRef.current = null;
@@ -144,8 +205,10 @@ export function useLiveActivity(options?: UseLiveActivityOptions) {
     try {
       activityRef.current = ChatStreamActivityFactory.start({
         ...stateRef.current,
+        startedAtMs: startTimeRef.current,
         elapsedSeconds: 0,
       }, `krusty://?sessionId=${encodeURIComponent(sessionId)}`);
+      lastUpdateStartedAtRef.current = Date.now();
     } catch {
       // Live Activities may not be available (simulator, unsupported device)
       activityRef.current = null;
@@ -154,53 +217,60 @@ export function useLiveActivity(options?: UseLiveActivityOptions) {
       return;
     }
 
-    // Update elapsed time every second
-    timerRef.current = setInterval(() => {
-      if (!activityRef.current || !stateRef.current) return;
-      const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
-      activityRef.current.update({
-        ...stateRef.current,
-        elapsedSeconds: elapsed,
-      }).catch(() => {});
-    }, 1000);
-  }, [clearTimer, closeExistingActivities]);
+  }, [clearUpdateDelay, closeExistingActivities]);
 
   const updateActivity = useCallback((partial: Partial<StreamState>) => {
     if (!activityRef.current || !stateRef.current) return;
 
-    stateRef.current = { ...stateRef.current, ...partial };
-    const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
+    const previous = stateRef.current;
+    const next = { ...previous, ...partial };
+    if (liveActivityStateEqual(previous, next)) return;
 
-    activityRef.current.update({
-      ...stateRef.current,
+    stateRef.current = next;
+    const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
+    pendingUpdateRef.current = {
+      ...next,
+      startedAtMs: startTimeRef.current,
       elapsedSeconds: elapsed,
-    }).catch(() => {});
-  }, []);
+    };
+
+    const statusChanged = previous.status !== next.status;
+    schedulePendingUpdate(statusChanged);
+  }, [schedulePendingUpdate]);
 
   const endActivity = useCallback(() => {
-    clearTimer();
+    clearUpdateDelay();
 
     if (!activityRef.current || !stateRef.current) return;
 
+    const activity = activityRef.current;
+    const finalState = stateRef.current;
     const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
+    updateGenerationRef.current += 1;
+    pendingUpdateRef.current = null;
+    pendingUpdateUrgentRef.current = false;
 
-    activityRef.current.end({ after: new Date(Date.now() + 60_000) }, {
-      ...stateRef.current,
+    activity.end({ after: new Date(Date.now() + 60_000) }, {
+      ...finalState,
       status: 'completed',
+      startedAtMs: startTimeRef.current,
       elapsedSeconds: elapsed,
     }, new Date()).catch(() => {});
 
     activityRef.current = null;
     stateRef.current = null;
     sessionIdRef.current = null;
-  }, [clearTimer]);
+  }, [clearUpdateDelay]);
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      clearTimer();
+      clearUpdateDelay();
+      updateGenerationRef.current += 1;
+      pendingUpdateRef.current = null;
+      pendingUpdateUrgentRef.current = false;
     };
-  }, [clearTimer]);
+  }, [clearUpdateDelay]);
 
   return { startActivity, updateActivity, endActivity };
 }

--- a/apps/mobile/hooks/useNotifications.ts
+++ b/apps/mobile/hooks/useNotifications.ts
@@ -145,11 +145,14 @@ interface UseNotificationsOptions {
 
 export function useNotifications(options?: UseNotificationsOptions) {
   const [pushToken, setPushToken] = useState<string | null>(null);
+  const [nativeDeviceToken, setNativeDeviceToken] = useState<string | null>(null);
   const [notificationLevel, setNotificationLevel] =
     useState<NotificationLevel>("important");
   const responseListenerRef = useRef<any>(null);
   const handledResponseIdRef = useRef<string | null>(null);
   const nativeDeliveryRegisteredRef = useRef(false);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
 
   useEffect(() => {
     if (!Notifications) return;
@@ -163,16 +166,15 @@ export function useNotifications(options?: UseNotificationsOptions) {
       },
     );
 
-    registerForPushNotifications().then(async ({ displayToken, nativeDeviceToken }) => {
-      if (displayToken) {
-        setPushToken(displayToken);
-        await SecureStore.setItemAsync(PUSH_TOKEN_KEY, displayToken);
-      }
-      if (nativeDeviceToken) {
-        nativeDeliveryRegisteredRef.current =
-          (await options?.onRegisterNativeDevice?.(nativeDeviceToken)) === true;
-      }
-    });
+    registerForPushNotifications().then(
+      async ({ displayToken, nativeDeviceToken: token }) => {
+        if (displayToken) {
+          setPushToken(displayToken);
+          await SecureStore.setItemAsync(PUSH_TOKEN_KEY, displayToken);
+        }
+        if (token) setNativeDeviceToken(token);
+      },
+    );
 
     const handleResponse = (response: NotificationResponseEvent) => {
       const responseId = response.notification.request.identifier;
@@ -188,17 +190,17 @@ export function useNotifications(options?: UseNotificationsOptions) {
       );
 
       if (actionId === "APPROVE" && data.requestId && data.sessionId) {
-        options?.onToolApproval?.(data.sessionId, data.requestId, true);
+        optionsRef.current?.onToolApproval?.(data.sessionId, data.requestId, true);
       } else if (actionId === "DENY" && data.requestId && data.sessionId) {
-        options?.onToolApproval?.(data.sessionId, data.requestId, false);
+        optionsRef.current?.onToolApproval?.(data.sessionId, data.requestId, false);
       } else if (actionId === "VIEW_CHAT" && data.sessionId) {
-        options?.onNavigate?.("/(tabs)", { sessionId: data.sessionId });
+        optionsRef.current?.onNavigate?.("/(tabs)", { sessionId: data.sessionId });
       } else if (actionId === "OPEN_MAKO") {
         const params: Record<string, string> = { focus: "mako" };
         if (data.sessionId) {
           params.sessionId = data.sessionId;
         }
-        options?.onNavigate?.("/(tabs)", params);
+        optionsRef.current?.onNavigate?.("/(tabs)", params);
       } else if (
         actionId === Notifications?.DEFAULT_ACTION_IDENTIFIER &&
         (data.sessionId || data.focus === "mako")
@@ -210,7 +212,7 @@ export function useNotifications(options?: UseNotificationsOptions) {
         if (data.focus) {
           params.focus = data.focus;
         }
-        options?.onNavigate?.("/(tabs)", params);
+        optionsRef.current?.onNavigate?.("/(tabs)", params);
       }
 
       if (responseId) {
@@ -232,7 +234,27 @@ export function useNotifications(options?: UseNotificationsOptions) {
     return () => {
       responseListenerRef.current?.remove();
     };
-  }, [options?.onNavigate, options?.onRegisterNativeDevice, options?.onToolApproval]);
+  }, []);
+
+  useEffect(() => {
+    if (!nativeDeviceToken || !options?.onRegisterNativeDevice) return;
+    let cancelled = false;
+
+    void Promise.resolve()
+      .then(() => options.onRegisterNativeDevice?.(nativeDeviceToken))
+      .then((registered) => {
+        if (!cancelled) {
+          nativeDeliveryRegisteredRef.current = registered === true;
+        }
+      })
+      .catch(() => {
+        if (!cancelled) nativeDeliveryRegisteredRef.current = false;
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [nativeDeviceToken, options?.onRegisterNativeDevice]);
 
   const changeNotificationLevel = useCallback(
     async (level: NotificationLevel) => {

--- a/apps/mobile/hooks/useWidgetSync.ts
+++ b/apps/mobile/hooks/useWidgetSync.ts
@@ -1,5 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Platform } from "react-native";
+import {
+  shouldSyncChatWidget,
+  type ChatWidgetCadenceState,
+} from "./presentationCadence";
 
 // Native-only — widget instances loaded dynamically to avoid crash on web
 let MakoWidgetInstance: any = null;
@@ -15,6 +19,7 @@ if (Platform.OS === "ios") {
 }
 
 interface ChatState {
+  sessionId: string | null;
   hasActiveSession: boolean;
   sessionTitle: string;
   lastMessage: string;
@@ -25,15 +30,23 @@ interface ChatState {
 }
 
 export function useWidgetSync(chatState: ChatState) {
+  const previousStateRef = useRef<ChatWidgetCadenceState | null>(null);
+
   useEffect(() => {
     if (Platform.OS !== "ios") return;
+    const nextState: ChatWidgetCadenceState = chatState;
+    if (!shouldSyncChatWidget(previousStateRef.current, nextState)) return;
+
+    previousStateRef.current = nextState;
+    const { sessionId: _sessionId, ...snapshot } = nextState;
 
     try {
-      ChatWidgetInstance.updateSnapshot(chatState);
+      ChatWidgetInstance.updateSnapshot(snapshot);
     } catch {
       // Widget may not be configured yet
     }
   }, [
+    chatState.sessionId,
     chatState.hasActiveSession,
     chatState.sessionTitle,
     chatState.lastMessage,

--- a/apps/mobile/widgets/ChatStreamActivity.tsx
+++ b/apps/mobile/widgets/ChatStreamActivity.tsx
@@ -7,7 +7,9 @@ import {
   font,
   foregroundStyle,
   frame,
+  layoutPriority,
   lineLimit,
+  monospacedDigit,
   opacity,
   padding,
   resizable,
@@ -55,7 +57,8 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
     toolApprovalSessionId,
   } = props;
   const statusColor =
-    status === "needs_input" ? "#ef4444" : status === "completed" ? "#22c55e" : "#ff6b35";
+    status === "needs_input" ? "#fbbf24" : status === "completed" ? "#34c759" : "#ff7a32";
+  const timerColor = "#ff7a32";
   const statusLabel =
     status === "needs_input" ? "Needs input" : status === "completed" ? "Completed" : "Working";
   const elapsed = formatElapsed(elapsedSeconds);
@@ -70,8 +73,8 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
       modifiers={[
         resizable(),
         aspectRatio({ ratio: 1, contentMode: "fit" }),
-        frame({ width: 30, height: 30 }),
-        cornerRadius(9),
+        frame({ width: 28, height: 28 }),
+        cornerRadius(8),
         clipped(),
       ]}
     />
@@ -82,49 +85,51 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
       modifiers={[
         resizable(),
         aspectRatio({ ratio: 1, contentMode: "fit" }),
-        frame({ width: 18, height: 18 }),
+        frame({ width: 17, height: 17 }),
         cornerRadius(5),
         clipped(),
       ]}
     />
   );
   const metrics = (
-    <HStack spacing={14}>
-      <HStack spacing={5}>
-        <Image systemName="wrench" modifiers={[foregroundStyle("#60a5fa"), font({ size: 11 })]} />
-        <Text modifiers={[font({ size: 11 }), opacity(0.78)]}>{toolCount} tools</Text>
+    <HStack spacing={16}>
+      <HStack spacing={6}>
+        <Image systemName="wrench" size={12} color="#a8b0bc" />
+        <Text modifiers={[font({ size: 10, weight: "medium" }), opacity(0.76)]}>{toolCount} tools</Text>
       </HStack>
-      <HStack spacing={5}>
-        <Image systemName="doc.text.magnifyingglass" modifiers={[foregroundStyle("#60a5fa"), font({ size: 11 })]} />
-        <Text modifiers={[font({ size: 11, design: "monospaced" }), foregroundStyle("#22c55e")]}>+{filesAdded}</Text>
-        <Text modifiers={[font({ size: 11, design: "monospaced" }), foregroundStyle("#ef4444")]}>−{filesRemoved}</Text>
+      <HStack spacing={6}>
+        <Image systemName="doc.text.magnifyingglass" size={12} color="#a8b0bc" />
+        <HStack spacing={3}>
+          <Text modifiers={[font({ size: 10, weight: "medium" }), monospacedDigit(), foregroundStyle("#34c759")]}>+{filesAdded}</Text>
+          <Text modifiers={[font({ size: 10, weight: "medium" }), monospacedDigit(), foregroundStyle("#ff5b62")]}>−{filesRemoved}</Text>
+        </HStack>
       </HStack>
     </HStack>
   );
 
   return {
     banner: (
-      <VStack alignment="leading" spacing={9} modifiers={[padding({ all: 14 })]}>
-        <HStack spacing={9}>
+      <VStack alignment="leading" spacing={10} modifiers={[padding({ horizontal: 14, vertical: 13 })]}>
+        <HStack spacing={10}>
           {logo}
-          <Text modifiers={[font({ size: 14, weight: "semibold" }), lineLimit(1)]}>
+          <Text modifiers={[font({ size: 13, weight: "semibold" }), lineLimit(1), layoutPriority(1)]}>
             {chatTitle || "Krusty session"}
           </Text>
           <Spacer />
-          <VStack alignment="trailing" spacing={2}>
-            <Text modifiers={[font({ size: 17, weight: "medium", design: "monospaced" }), foregroundStyle(statusColor)]}>
+          <VStack alignment="trailing" spacing={3} modifiers={[frame({ minWidth: 58, alignment: "trailing" })]}>
+            <Text modifiers={[font({ size: 15, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
               {elapsed}
             </Text>
             <HStack spacing={4}>
-              <Image systemName="circle.fill" modifiers={[foregroundStyle(statusColor), font({ size: 6 })]} />
-              <Text modifiers={[font({ size: 9, weight: "semibold" }), foregroundStyle(statusColor)]}>{statusLabel}</Text>
+              <Image systemName="circle.fill" size={5} color={statusColor} />
+              <Text modifiers={[font({ size: 9, weight: "medium" }), foregroundStyle(statusColor)]}>{statusLabel}</Text>
             </HStack>
           </VStack>
         </HStack>
         <HStack>
           {metrics}
           <Spacer />
-          <Image systemName="chevron.right" modifiers={[foregroundStyle("#60a5fa"), font({ size: 11 })]} />
+          <Image systemName="chevron.right" size={9} color="#8b93a1" />
         </HStack>
         {status === "needs_input" && approvalTarget && (
           <VStack spacing={6}>
@@ -143,29 +148,32 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
       <HStack spacing={6}>
         {compactLogo}
         <HStack spacing={3}>
-          <Text modifiers={[font({ size: 9, design: "monospaced" }), foregroundStyle("#22c55e")]}>+{filesAdded}</Text>
-          <Text modifiers={[font({ size: 9, design: "monospaced" }), foregroundStyle("#ef4444")]}>−{filesRemoved}</Text>
+          <Text modifiers={[font({ size: 9, weight: "medium" }), monospacedDigit(), foregroundStyle("#34c759")]}>+{filesAdded}</Text>
+          <Text modifiers={[font({ size: 9, weight: "medium" }), monospacedDigit(), foregroundStyle("#ff5b62")]}>−{filesRemoved}</Text>
         </HStack>
       </HStack>
     ),
     compactTrailing: (
-      <Text modifiers={[font({ size: 11, weight: "medium", design: "monospaced" }), foregroundStyle(statusColor)]}>
+      <Text modifiers={[font({ size: 11, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
         {elapsed}
       </Text>
     ),
     minimal: compactLogo,
     expandedLeading: logo,
     expandedCenter: (
-      <Text modifiers={[font({ size: 13, weight: "semibold" }), lineLimit(1)]}>
+      <Text modifiers={[font({ size: 12, weight: "semibold" }), lineLimit(1)]}>
         {chatTitle || "Krusty session"}
       </Text>
     ),
     expandedTrailing: (
-      <VStack alignment="trailing" spacing={2}>
-        <Text modifiers={[font({ size: 12, weight: "medium", design: "monospaced" }), foregroundStyle(statusColor)]}>
+      <VStack alignment="trailing" spacing={3}>
+        <Text modifiers={[font({ size: 11, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
           {elapsed}
         </Text>
-        <Text modifiers={[font({ size: 9, weight: "semibold" }), foregroundStyle(statusColor)]}>{statusLabel}</Text>
+        <HStack spacing={3}>
+          <Image systemName="circle.fill" size={4} color={statusColor} />
+          <Text modifiers={[font({ size: 8, weight: "medium" }), foregroundStyle(statusColor)]}>{statusLabel}</Text>
+        </HStack>
       </VStack>
     ),
     expandedBottom: (

--- a/apps/mobile/widgets/ChatStreamActivity.tsx
+++ b/apps/mobile/widgets/ChatStreamActivity.tsx
@@ -65,6 +65,12 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
   const timerColor = "#ff7a32";
   const statusLabel =
     status === "needs_input" ? "Needs input" : status === "completed" ? "Completed" : "Working";
+  const compactStatusSymbol =
+    status === "needs_input"
+      ? "exclamationmark.circle.fill"
+      : status === "completed"
+        ? "checkmark.circle.fill"
+        : "circle.fill";
   const elapsed = formatElapsed(elapsedSeconds);
   const approvalTarget =
     toolApprovalId && toolApprovalSessionId
@@ -186,9 +192,12 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
       </HStack>
     ),
     compactTrailing: (
-      <Text modifiers={[font({ size: 11, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
-        {elapsed}
-      </Text>
+      <HStack spacing={4}>
+        <Image systemName={compactStatusSymbol} size={7} color={statusColor} />
+        <Text modifiers={[font({ size: 11, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
+          {elapsed}
+        </Text>
+      </HStack>
     ),
     minimal: compactLogo,
     expandedLeading: logo,

--- a/apps/mobile/widgets/ChatStreamActivity.tsx
+++ b/apps/mobile/widgets/ChatStreamActivity.tsx
@@ -19,6 +19,7 @@ import type { LiveActivityComponent } from "expo-widgets";
 export interface ChatStreamProps {
   chatTitle: string;
   status: "working" | "needs_input" | "completed";
+  startedAtMs: number;
   elapsedSeconds: number;
   toolCount: number;
   filesAdded: number;
@@ -52,6 +53,7 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
   const {
     chatTitle,
     status,
+    startedAtMs,
     elapsedSeconds,
     toolCount,
     filesAdded,
@@ -72,6 +74,34 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
         ? "checkmark.circle.fill"
         : "circle.fill";
   const elapsed = formatElapsed(elapsedSeconds);
+  const timerInterval = {
+    lower: new Date(startedAtMs),
+    upper: new Date(startedAtMs + 24 * 60 * 60 * 1000),
+  };
+  const bannerTimer =
+    status === "completed" ? (
+      <Text modifiers={[font({ size: 15, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
+        {elapsed}
+      </Text>
+    ) : (
+      <Text
+        timerInterval={timerInterval}
+        countsDown={false}
+        modifiers={[font({ size: 15, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}
+      />
+    );
+  const compactTimer =
+    status === "completed" ? (
+      <Text modifiers={[font({ size: 11, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
+        {elapsed}
+      </Text>
+    ) : (
+      <Text
+        timerInterval={timerInterval}
+        countsDown={false}
+        modifiers={[font({ size: 11, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}
+      />
+    );
   const approvalTarget =
     toolApprovalId && toolApprovalSessionId
       ? `${encodeURIComponent(toolApprovalSessionId)}:${encodeURIComponent(toolApprovalId)}`
@@ -147,9 +177,7 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
           </Text>
           <Spacer />
           <VStack alignment="trailing" spacing={3} modifiers={[frame({ minWidth: 58, alignment: "trailing" })]}>
-            <Text modifiers={[font({ size: 15, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
-              {elapsed}
-            </Text>
+            {bannerTimer}
             <HStack spacing={4}>
               <Image systemName="circle.fill" size={5} color={statusColor} />
               <Text modifiers={[font({ size: 9, weight: "medium" }), foregroundStyle(statusColor)]}>{statusLabel}</Text>
@@ -194,9 +222,7 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
     compactTrailing: (
       <HStack spacing={4}>
         <Image systemName={compactStatusSymbol} size={7} color={statusColor} />
-        <Text modifiers={[font({ size: 11, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
-          {elapsed}
-        </Text>
+        {compactTimer}
       </HStack>
     ),
     minimal: compactLogo,
@@ -208,9 +234,7 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
     ),
     expandedTrailing: (
       <VStack alignment="trailing" spacing={3}>
-        <Text modifiers={[font({ size: 11, weight: "semibold" }), monospacedDigit(), foregroundStyle(timerColor)]}>
-          {elapsed}
-        </Text>
+        {compactTimer}
         <HStack spacing={3}>
           <Image systemName="circle.fill" size={4} color={statusColor} />
           <Text modifiers={[font({ size: 8, weight: "medium" }), foregroundStyle(statusColor)]}>{statusLabel}</Text>

--- a/apps/mobile/widgets/ChatStreamActivity.tsx
+++ b/apps/mobile/widgets/ChatStreamActivity.tsx
@@ -38,6 +38,10 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
   // where the main React Native asset bundle is not guaranteed to be readable.
   const KRUSTY_LOGO =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAMnElEQVRYCU1YSailRxWuqn+4U7+hu/MS04lpu4kJ6QgJiGjAhQQUE4kuXLgQ9y5cBARxABEDLtxJNoIuXGQbggZECQQTEUxIInQGM5jpJa+705033+GfqsrvO6f++27de+uvOnWG75w6NfzX2mxsbDTGmlSkYa2x/CUyx0lhN3IEBBTtkZTaiYhHjEFpMUaKCBNrpbNeGk0NDFnrcuqIYowtMSyPnh9KrHEypC1BD6oWp+AEIAD3UpQhTdATDmSJDH3VJTW6SYCYACKGkLOxLGyzy+igwSp1KSED6cm2ioFDOJeqRUQsqRBqFn1QiLDkKXR2e12gS4QwkLSoUTVAoiCThkjJMNUkDvSTNrQ42OvpbVgxhx5mgSYQXnZYIiknYEQCfQEkrGRSZxVcgtiTHe3Jj5qpiNZ76OydlD4ESz5BQZOCh/KiS7VQq2YZtemU0dBJPFbbFkkio6JhyeOITxQxN+CroukfpCExpTAMqU0YRAMgikg8lCgvIeZIbBVMNSRUPR/6oRqMyggrqtNspcuGeR1j08UiN5kEkhFSM2KemiEBZSuSRAXTNlCV2BaKzUw2oGkUAuCXKAhFC2SkONf62Pnopc5h2XFIVpk9fyb++Bsb+1N39ajrugAeH02IJlOAYk+00Iz0IKpPsUtywoAIaSuR2CEiAuol2YghfvPS5j2f3chGhXH5U89/uH3YZsBkTNOa71ya/+zBxdrR+k+vxh8+dGFcZvNZu7M7/9trN1qZLlXGoIgy2JA5k1Ci6i3BTN5PZjKPoRU8S6INwX/rc90PvlqsXzhjhuP/vPTehwcID9mLPDz9crhtOv/9q81WMXnskdPrRXjnf0f/fLt75tWuNYX4zOkCO+YFYUX4bFxigg4mlhizuegkp2AXomICF0iiDKCxje4fVR/fmF8YZ/mobqqqbbPCFVlmcmfePho8+rw35eDiul8cHbs8HhwvjmeN951xBYBLKFIgiAkRUlMpZkgkFFZpY2RUZJokPAkWKcLFdDNxXvuD4+Zwvzrt7YNfuHnrjvL9q8dvfVojjQaDMhS5j3aYNYPBuuT5DDDghyhQZzUk0Insgmqa5w/gyEbnQWCESO2DIXGRsGhwdEh4F43/9KhenxSlc7985BY7KX7zxPGvrvphmRcui841Pk4QsLdubB/6V67v7VWd2hNjYpm2aBvWiKFfeRIFoKIDkkMJjYSJgiiMDYtMG/dUa2HvaOH3jrth2Zl2emYa/WwGFVDOxRRtZyOyI86m7cz/9tmd63Vsiw0IwhCdT+EQtQkV2VMqiUkwYqcGbzIvSEUgIel3RcobrPm6i4vaz+a+7MImaOoUUrTl6d35EIM33ocQq+COuzwvs9PjAiHcnzatD1wF4gDjhAOfMIlWpowmGSHBLiDQko6Eg+0EUwcNAAWk0azu5lU7ia7LosWGE93tZ8yd54c2uMXC3V1MkObYrLIsR47D2o++cururdHP/3rtoyk2PTomkyYtDEsfltjEl0ktJWHRDmqCIR5g74GRFILp8O1i50LoIgz4Jn7//ukvHqviPIsvlfbKqdk1hsih5Fwx88O9T3xWVQsTh0ktFSMsCoCrTacUkwcYlCGDVBjiSYK2sshQAkQnWIKPTRs6bImdt5wgm7W1qY5jY8wsM8iybr0DH/VyH3/8X/uY0TpfywfEkYqigX0Co9/LAY3QCibaxydV4gklIJM5LOc4zN3aoBiXpijtqVE+GYYxzrBOAootsEAadSGIBqHN7RhTm2clbeDHJS97kE4TbSUwDFWUKRN4DBfBSJEnsDNUIsDBYW5HudmZ+uHZtdGZybbtvn5/8cCF6bmNLrw3NPc5e+/RJ/ttedXnNlNFmLeiLKHDMX9Ig2amtU4F0fGjzPLkPkRjhME4c0tLCFaQYeUG4579oHrh48XFzcxg/603x211up5ttfOiauLO0NxbOn/jzSvxj89xaz5sC15ROGsnZzCxiC0YorUTKHScBfchtABH+VBrl0NERmkIEq91r+9mJizOrecF/Bdttbezzko34rRDPs0788RHNdZKNhwWObFAiW7MVCURT7ZpH4Xkvia37jRQn9homwUOJKK4RGx2MDRumGdY7hbnF2Zw4AxSY5Q7rHGX4Rg1gwx6MuMwTRb7Fjrj0p47rZnKrIDq3gRaS4JYJzuusHisBAY0uiVSMocixsrCrM9LyCAznnnt+v7hYj106zbgbL9p3sZ34/F+2N12jz98hxmsHefDqsj/9Nz22Un93fvjr/9ewBNoldWeIs8o0zpUgkI4IPT7UA9bMdMPjYwES93ijcxhs/d4WfnHu4cv7lQMhkA3L6f3rEtr8ZVHjq52zTvFeD4ZPumqyzvx9e3KDrC/QI0WCT/0KwTUgknHEiB0TvhlRNlIF2SRcLDZuxA77EMFuYFGxG3mcgDFBh0HBfbxbr9p9/J6Ee0MB7IvDC51NEn7UthBg5BkxS2HELH+giYswqgzjaHlBJMs/oDCDG2jefC+O+65y26WcTxylz88evqNuXNZ5yJePAe3bZ1tR2dDMR+V3/5ScW3hnn9zdw/omBoKRZAxTMBIR5YwAfIkQivUhH4ZHRlKbkEHjtgvX5zcPgq3xtnN6/WTtvvL6zZDikA1Us3Xoy4OfO7L8NBdww+uHb38Vr1r+pu7okr+Ew+TiLolgHwNQoPA8WVRtGpc2eAWx9ihJJIFp2xVNwe+K7tqK7Zt3YAFmS4TYP28mTbmqO1q67CB7x7M2xZPrAaqT9HQTuqv0gAohREscnEh4oQKjx6ZwCEe8nQB95BQW7vwDiesJCe3D/HL1t5hc2pwXgRT+9gGzkzAjQRHj+Ch9gRM9HGb6kt6c00AhCrhAL/g1IfEFYOJDZZwvvrawBjeeKBc9r+0y9tZY46buMAp3IaFDw1OtmSesyVpo4pQs6FEnTEw6pQxLHRUKuI62bHFmyWdPaLlttzhFI0tAOFYgTDuq8IGSh0QvOhbj/QHekroFwxSSKEmVUdYLOjLnyboc/0pCdGVTBMt4gFbGtWkDbei0HUemdR2oao8rka5jT/5nr3zM9CBKYt43ag73BwNGHBRBCRs2gIs2aYmWk9dNU4A2EiYGFKITwMDBBJHCZTKKFzwsYHMHo/LU6OybAsz9t4yWAcH+3U9nkQz73B/RZBC7v1oVG6cGt267rOunDbIPA1ij0MNs8ZSESCcMuLk9kQSOPswME4UFwIjqFpsmeEmEfdmzbkzG2UWB5PY2Hnru989NTSl29zwR01Av0Woqua+z595+IHbv3jnwQe7zR/+feONXQZA54kGk1LRzDY/kkMEIzZloSirUiiFIUwZGXg5eXGnvnxl9rWL7ZZpFm1zy1qo5y2OlGKCPda+P/ePvrBXB4P7I6ZpY+y38vnB9en164vFDMsAfx/2HtNMj02xoOartNriLGG4D0iPDDxpE2Ck6MqVWYHseCAYvGhgbVfRIWlgRu495rjLLs8GJmDjAbPfmwe8Nk2bgIsKcgmLMvKmRvuo+6hLj+hQuFOTrjnDKAgrjfeYFIkm9nrpTk8m790wmcBHnuJlDV/RhRpnWuaHg+gLeouXATC0uPNzGVInTfUflRF7bKpdsLnBpqSJOAkztER8KODRhsha2L0wbC9N/J+vxPPj+qaBz2KYOPNpm/+3WsscbheU5WuArinv79ms1gqzaPnKtj0v5mYkbBIDdZ0IBSceFMYhPuDLpeqifaDrISmyFaLp2iY0lS2HWPEGLxv0y5piUA6HODswbxICwUNkoasqgx2UxZnBMM9xu0WwNByCQwRS1MDFnZrJyhYqsgKP/NAFAfwnRGjl69+ISgsbcXWU/QFdCMu1ToWgUWKF422A6cOixDC4kD00REv67NEIAST6jlXGUTZFCZpMYxJ7AgYZSkoBreOpzgcujskNvQerOLkoKWoAAjgLxU1hfKT0qNihMcUoKFf+0uOogBDVEE2IhM6xXiUaWoSDXJisXlhsqiRjiyHKoyiNtoWyiok8JBKX3IcQRdBYU1DxSpyWgVI3OJdJH57KzpSgGPvi6KrHCYQOc7Tn4Lwp/yo75xP77kD19b70SpZeirqeqlwCJ+GQeCVTZBU7ysDeSiQAQkylLBLmlTYjwpuDFEGv8e1ZxJneeyoWBdpIncQimtIAmEAlDCx9nqeiPrksY4q4F9UZFXYh9YCok7qIUb6o9HjG/8hCESu9h4mytCNWKQ9m/Poun0kvyFJOxknoeZfxx05NiFy9/TC7XPxim0lDIUkXLCaxR8VcPlLIqysQTJChAFWIGnD0S1a5qZS2xEf8I4GeqIYWIaH/f8rzY1cH1l+6AAAAAElFTkSuQmCC";
+  const CODE_ICON =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAAAXNSR0IArs4c6QAAAGxlWElmTU0AKgAAAAgABAEaAAUAAAABAAAAPgEbAAUAAAABAAAARgEoAAMAAAABAAIAAIdpAAQAAAABAAAATgAAAAAAAADYAAAAAQAAANgAAAABAAKgAgAEAAAAAQAAAEigAwAEAAAAAQAAAEgAAAAARDxGgQAAAAlwSFlzAAAhOAAAITgBRZYxYAAABNtJREFUeAHtm71PFEEUwGfuvAO1UIxacZUJldhopYUxkqAIEdEQDUbkDxA7ba/VTjor1EhICCpGRDFaWGinhVoYEiuwUSKa+AF33o7zzgzZ3Xu7N7vzwRYzCdndtzPv43ezM/teFkJccwQcAUfAEXAEHAFHwBFwBBACFJFlTjQ5/ewAzeduMkI6ucPvGa1dOtff/dqGo5kHdPfeXHs+X/hICd0qgHBQK5XKn87hwb7PQmbqmDOlWJfefK5w0Q8H9PJfta2l0HJGl404PZkHxOH0xwVg+t4m0wZU9E/OzJf4+P2YjgpjLzC5blmmZxBluZNYwIyRTxcGuj9g93TLMg2IL8bo48XXoBndIKL0ZRbQxMRsG6X0MOa4x5gDRLcUT3A4DWskY+zLwrtXVt6B4MfJ7AzKRe5e9FG5XPawmWVClklA4+PjrYySY1jAlNlbf8B+wxTGnLIt27yt1MVtrr85C/uMsF+rP5aei2sbRyVAY2NzLTtLxWt8Gg6Ds3ze316ofrtSHhysqDjPZ08/lgPx2fN0ZGRkNUp3eWqq2FHYcd3vz/Ji5eroaM9a1Jhm8tSPGMDZVSo+yFFymb/7b4c/OAcHmxmNu8/XF+4T68P6eCR+96rDCfkDPoKvmD4ZWSpAAg6l5HjYiPj1wnLZ6459hw7y7X030v8v+115jMjXRZht8FEFUmJAcXDWPVU4yVE89+Lb+8uhod6VNKpVICUCJAMH1qE0QYgxKm/PcbbTQpIGJAOH50hPYFEUwSY93rk/v5cHsgcbx6j3EJP7ZWAbfPDL/OdpIEkBkoXzdbFySmXHKNAcmnsRRt7wCuKiP1jsHGyDDzohNQVkCw4EHFX74e8/0rmXbkixgGzCqdd+KF77qTJPGhCA1gkpEpBNOPXZo7n2owsSCsg2HACksnvBeKzpgNQAaCPgmKz9qEIKANoIOPDLm679qEAKAILEE94VsOkKMtg+VbdyTLeN2o8sJGDg9zEAiF/Us3J/B3FuCo7N2o8MpDADpXKHgKdyzFLtB4sjMINM5DKYUb8Maj/+a3HerPYj+iU5yqyxYQYBQCZymbgAVGo/cXqxezJwYBkJ55IBQDLPaJqED3MYZCq1nyidmFwWDrYBBQCBcpuQTNR+woBU4ICuBkAgtAXJxNsz+C+aKhzQgwKCG6YhqdZ+wMe4pgMO6I8EBDdNQlKt/YB/UU0XHNAfCwg6mIKko/YD/oWbTjiguykg6KQbks7aD/gnmm44oFcKEHSUhRTOZWBsuJn67sdELikNCIKUgcQVRuZzApSp3SvOdtpcMhEgWUgCBHY0WfvB7IEsLRwYmxgQDIqbSeFcBvr7m8naD2ZbBQ74nQoQDBSQPEZu8Hrpd/iDc/h4Ae5HNZO1H7Ad9gdLH6J8w+TYRxRYPy0yqP20trUvh797riv3SN/Zga5ZLYY0KrFaD8p67QfjmvoRw5Q1k9ms/TTzRfa+NUA2az+ywcv0swbIVu1HJugkfawBslH7SRK4bF9rgEy9PcsGmrafFUCmaz9pg5cZZwVQkdKjqDOS3/2gYy0JrQCKiiXJdz9ROkzLrQBaq65N8zUo+AEmIz9rXvWW6QBV9VsB9P9/S2u9PF97y5PHav1Y846cP92zpBqAG+8IOAKOgCPgCDgCjoAj4AhsCIF/S/I8n8HpBxIAAAAASUVORK5CYII=";
+  const TOOLBOX_ICON =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAAAXNSR0IArs4c6QAAAGxlWElmTU0AKgAAAAgABAEaAAUAAAABAAAAPgEbAAUAAAABAAAARgEoAAMAAAABAAIAAIdpAAQAAAABAAAATgAAAAAAAADYAAAAAQAAANgAAAABAAKgAgAEAAAAAQAAAEigAwAEAAAAAQAAAEgAAAAARDxGgQAAAAlwSFlzAAAhOAAAITgBRZYxYAAABOhJREFUeAHtnM1PFDEUwNtlWaPxIMab8abyH+hJJRERjQbWmBVC8KRnb3DlKl7krCcNAYlxMRpFxAT1pH+CejPejF6MBli2vjfjrG2n3c5Hux/QSTYz89q+tr990/a10yHEH56AJ+CQAHWoW1C9UF09Syi9Rgk9TRg5TCjZL0Qw3TDyC9J8Y4S9I4w9Gi8PvTElsRHuHND849VjhR56j1J6xkaBIx2Msbf1bXZz4urQ50jm4uwU0MLyyilCik8hkz4XhWeE/CSkNjI+OvzehX7U6QxQYDnFwgdXcCIgCKleq590ZUmFKCPb5+CxcmQ5fFnxD8C8eJnNayeAsEG23eY0qzTmFXQCzSJlDCtmTNc8GfRWygiMbRLCprZ/bz6YmLgE7UfyY37+eV/PvtJ1aBVmoTcsxVKGeVrv2ZwACrryWA1QwKbGykNzyiCD8B/QucXqKsSkd+Xo+jzlmOnunTxiwThHUQ60HIU4lUirA8dWDg43gDSDwLSPlaq+Wh2aPFU60sjcAEpTgg6P6wEZ/iDrA8Wwiy+sGfJ1EsxYfdC2j2YN0MOllaPF3p77rRz/qCijj1bb2r4xWRn+ogpPK7MCaKH6egDGJk9wVJu2AC7iBz4aY1fGy+fW8+rPDSh4pEjhGXh1e/MWxmp6Rv4wUr+c95HLBahj4USkLUDKDKjj4ViClAmQGQ7bgFm/6Sw+V1SvpOeGj0bpbXBB9ijT5bCk1ICSwamXx8rnXyoL60i4WH11gdBC1TakVIA6FU7E3AWkxIA6HY4rSIkAdQscF5CMgLoNjm1ITQF1KxybkLSAuh2OLUhKQOhbwRTmC737gOOc1nflUaXTnpP1buyiyneLAQq88lLxIwRoHM/ughPBNEFCB7e2WTshzwLEJsyCKYsdBgchBQNXsHpYONiIoPFnNAisOy/DawFQ0O5o19C703L4ChshKdbXxGUf3XoWUk/R5swsLZWO9x6cpZTAOhb8Z4w8+LT1Y2qmUoF1sfxHHv0ICR63st4toRUoYWN9TbAg7doSOJ5pfKv+0oE7BUpuodniD68RWH40oYa8+kNLYtOq8sgzogIge+tZhUk588iaZHm2+/z6k66viYA0a0vatShN7VQ9oEqmSW4Uq3SpZM0UaeskMRABNdO4S8M8IMMfD5b5/1hcXoPxkj/GRgcbXLwFGezBA/KADAQMwd6CPCADAUOw6ItpIvOtuiaKINb1hmn1CEq5G1v6dXq4rERvng/w1yEB3wYZLMEJoOD1EyljlUyKkvhWpUslS6ywSUQ3gGD+R84T54RkWdZ7lS6VLKt+Pl2iRppPkOT6+9fN6UNHSvBOlThhliRtkjiu9fNlaPgcKNS16rZ6Hz7jTrhOUl8nj1gnVN5WGTwgA0kPyAMyEDAEewtKBQh3FisOfA9QIe5qkbZOEgPRgmDbtarW4UY2VUj3yrR1khgIA0Xckw6Lh/3xatNZ3MjWirdW43nblTTeisWdi4oj2JfPyYWBYrg2356NKFyZ2nopb4gRAGHJ4N2gdXn5ta0lbmHmuBEG3hEa4LMU2yAIwa8ZuPKM+Yw77RrrjHWXyxUDFG7Qr43sJkhhXWsjqo8TxAAhQfzUA37NAE1OJrrT7oNvgEBddZ+3iLVBMgBsuGHeIvtXW2SF7b5v01dk2l1tn78n4Al4Ap7AbiTwF7tHQuje7xuFAAAAAElFTkSuQmCC";
 
   function formatElapsed(seconds: number): string {
     const minutes = Math.floor(Math.max(0, seconds) / 60);
@@ -91,14 +95,34 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
       ]}
     />
   );
+  const toolIcon = (
+    <Image
+      uiImage={TOOLBOX_ICON}
+      modifiers={[
+        resizable(),
+        aspectRatio({ ratio: 1, contentMode: "fit" }),
+        frame({ width: 12, height: 12 }),
+      ]}
+    />
+  );
+  const codeIcon = (
+    <Image
+      uiImage={CODE_ICON}
+      modifiers={[
+        resizable(),
+        aspectRatio({ ratio: 1, contentMode: "fit" }),
+        frame({ width: 12, height: 12 }),
+      ]}
+    />
+  );
   const metrics = (
     <HStack spacing={16}>
       <HStack spacing={6}>
-        <Image systemName="wrench" size={12} color="#a8b0bc" />
+        {toolIcon}
         <Text modifiers={[font({ size: 10, weight: "medium" }), opacity(0.76)]}>{toolCount} tools</Text>
       </HStack>
       <HStack spacing={6}>
-        <Image systemName="doc.text.magnifyingglass" size={12} color="#a8b0bc" />
+        {codeIcon}
         <HStack spacing={3}>
           <Text modifiers={[font({ size: 10, weight: "medium" }), monospacedDigit(), foregroundStyle("#34c759")]}>+{filesAdded}</Text>
           <Text modifiers={[font({ size: 10, weight: "medium" }), monospacedDigit(), foregroundStyle("#ff5b62")]}>−{filesRemoved}</Text>
@@ -147,6 +171,14 @@ const ChatStreamActivity: LiveActivityComponent<ChatStreamProps> = (props) => {
     compactLeading: (
       <HStack spacing={6}>
         {compactLogo}
+        <Image
+          uiImage={CODE_ICON}
+          modifiers={[
+            resizable(),
+            aspectRatio({ ratio: 1, contentMode: "fit" }),
+            frame({ width: 10, height: 10 }),
+          ]}
+        />
         <HStack spacing={3}>
           <Text modifiers={[font({ size: 9, weight: "medium" }), monospacedDigit(), foregroundStyle("#34c759")]}>+{filesAdded}</Text>
           <Text modifiers={[font({ size: 9, weight: "medium" }), monospacedDigit(), foregroundStyle("#ff5b62")]}>−{filesRemoved}</Text>

--- a/crates/krusty-cli/Cargo.toml
+++ b/crates/krusty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "The most elegant coding CLI to ever exist"
 default-run = "krusty"

--- a/crates/krusty-client-state/Cargo.toml
+++ b/crates/krusty-client-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client-state"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Headless Rust state machine for Krusty chat clients"
 

--- a/crates/krusty-client/Cargo.toml
+++ b/crates/krusty-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Async Rust client for the Krusty server API"
 

--- a/crates/krusty-core/Cargo.toml
+++ b/crates/krusty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-core"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Core library for Krusty - AI, storage, tools, and extensions"
 

--- a/crates/krusty-server/Cargo.toml
+++ b/crates/krusty-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-server"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Self-hosted Krusty API server library"
 

--- a/docs/operations/build-and-deploy.md
+++ b/docs/operations/build-and-deploy.md
@@ -16,7 +16,7 @@ The Rust side of Krusty is organized as a Cargo workspace with seven Krusty crat
 The workspace root `Cargo.toml` sets a few important release profile options: link-time optimization (`lto = true`), a single codegen unit (`codegen-units = 1`), and symbol stripping (`strip = true`). These produce smaller, faster release binaries at the cost of longer compile times. The workspace also defines shared lint rules so all workspace crates enforce the same code quality standards through Clippy.
 
 The product-facing Krusty crates and desktop bundle currently share version
-`0.8.1` and edition 2021. The internal Mako daemon/protocol crates have their
+`0.8.2` and edition 2021. The internal Mako daemon/protocol crates have their
 own `0.1.0` package versions; release tags are validated against the `krusty`
 package version.
 
@@ -66,7 +66,7 @@ The preflight is safe for validation: it reads repository metadata, remote refs,
 
 ## Release automation
 
-Releases are triggered by pushing a Git tag that matches `v*` (for example, `v0.8.1`). Before packaging, the release workflow calls `.github/workflows/client-quality.yml`; no release build starts unless the API streaming/error contracts, shared-state type-check/tests, mobile TypeScript check, and Expo web export all pass. The remaining release workflow (`.github/workflows/release.yml`) has three artifact stages:
+Releases are triggered by pushing a Git tag that matches `v*` (for example, `v0.8.2`). Before packaging, the release workflow calls `.github/workflows/client-quality.yml`; no release build starts unless the API streaming/error contracts, shared-state type-check/tests, mobile TypeScript check, and Expo web export all pass. The remaining release workflow (`.github/workflows/release.yml`) has three artifact stages:
 
 **1. Build matrix.** A matrix job compiles release binaries for five targets:
 
@@ -109,7 +109,7 @@ sh install.sh --self-test
 You can pin a specific version by setting `VERSION` before running the script:
 
 ```bash
-curl -fsSL ... | VERSION=v0.8.1 sh
+curl -fsSL ... | VERSION=v0.8.2 sh
 ```
 
 ## Self-hosted systemd service
@@ -185,7 +185,7 @@ GitHub does not publish the versioned source archive until its tag exists, so
 AUR metadata is updated after the protected release tag is published. Run:
 
 ```bash
-./aur/update-release.sh 0.8.1
+./aur/update-release.sh 0.8.2
 cd aur
 makepkg --verifysource -f
 makepkg --printsrcinfo | diff -u .SRCINFO -

--- a/packages/state/src/session/streaming.ts
+++ b/packages/state/src/session/streaming.ts
@@ -116,7 +116,9 @@ export function createStreamCallbacks(
 	let compactedInPlace = false;
 	let streamLagged = false;
 	let pendingTextDelta = "";
-	let textFlushScheduled = false;
+	let pendingThinkingDelta = "";
+	const pendingToolOutputDeltas = new Map<string, string>();
+	let streamFlushScheduled = false;
 
 	function updateLastAssistantMessage(
 		updater?: (state: SessionStoreState) => Partial<SessionStoreState>,
@@ -129,20 +131,94 @@ export function createStreamCallbacks(
 		});
 	}
 
-	function flushPendingTextDelta() {
-		if (!pendingTextDelta) return;
-		ref.current.content += pendingTextDelta;
-		appendTextRenderPart(ref, pendingTextDelta);
-		pendingTextDelta = "";
+	function flushPendingDeltas() {
+		let changed = false;
+		let flushedText = false;
+		let flushedThinking = false;
+
+		if (pendingTextDelta) {
+			ref.current.content += pendingTextDelta;
+			appendTextRenderPart(ref, pendingTextDelta);
+			pendingTextDelta = "";
+			changed = true;
+			flushedText = true;
+		}
+
+		if (pendingThinkingDelta) {
+			ref.current.thinking =
+				(ref.current.thinking || "") + pendingThinkingDelta;
+			appendThinkingRenderPart(ref, pendingThinkingDelta);
+			pendingThinkingDelta = "";
+			const delegatedIndex = (ref.current.toolCalls || []).findIndex(
+				(toolCall) =>
+					resolveDelegatedKind(
+						toolCall.name,
+						toolCall.arguments,
+						toolCall.delegated?.kind,
+					) !== undefined,
+			);
+			if (delegatedIndex >= 0) {
+				const toolCalls = [...(ref.current.toolCalls || [])];
+				const delegatedTool = toolCalls[delegatedIndex];
+				const delegatedKind = resolveDelegatedKind(
+					delegatedTool.name,
+					delegatedTool.arguments,
+					delegatedTool.delegated?.kind,
+				);
+				if (delegatedKind) {
+					toolCalls[delegatedIndex] = {
+						...delegatedTool,
+						delegated: mergeDelegatedArtifactState(delegatedTool.delegated, {
+							...(delegatedTool.delegated ||
+								createDelegatedArtifactState(
+									delegatedKind,
+									delegatedTool.arguments,
+								)),
+							kind: delegatedKind,
+							thinking: ref.current.thinking || "",
+						}),
+					};
+					ref.current.toolCalls = toolCalls;
+				}
+			}
+			changed = true;
+			flushedThinking = true;
+		}
+
+		if (pendingToolOutputDeltas.size > 0) {
+			let toolCallsChanged = false;
+			if (ref.current.toolCalls?.length) {
+				ref.current.toolCalls = ref.current.toolCalls.map((toolCall) => {
+					const delta = pendingToolOutputDeltas.get(toolCall.id);
+					if (!delta) return toolCall;
+					toolCallsChanged = true;
+					return {
+						...toolCall,
+						output: (toolCall.output || "") + delta,
+					};
+				});
+			}
+			pendingToolOutputDeltas.clear();
+			changed = changed || toolCallsChanged;
+		}
+
+		if (!changed) return;
 		updateLastAssistantMessage(() => ({
-			isLoading: false,
-			isThinking: false,
+			...(flushedText
+				? { isLoading: false, isThinking: false }
+				: {}),
+			...(flushedThinking
+				? {
+						isThinking: true,
+						thinkingContent: ref.current.thinking || "",
+					}
+				: {}),
 		}));
 	}
 
-	function scheduleTextFlush() {
-		if (textFlushScheduled) return;
-		textFlushScheduled = true;
+	function scheduleStreamFlush() {
+		if (streamFlushScheduled) return;
+		streamFlushScheduled = true;
 		type FrameScheduler = (callback: (timestamp: number) => void) => unknown;
 		const runtime = globalThis as typeof globalThis & {
 			requestAnimationFrame?: FrameScheduler;
@@ -151,8 +227,8 @@ export function createStreamCallbacks(
 			? runtime.requestAnimationFrame.bind(runtime)
 			: (callback) => setTimeout(() => callback(Date.now()), 16);
 		schedule(() => {
-			textFlushScheduled = false;
-			flushPendingTextDelta();
+			streamFlushScheduled = false;
+			flushPendingDeltas();
 		});
 	}
 
@@ -171,59 +247,23 @@ export function createStreamCallbacks(
 
 	return {
 		onTextDelta: (delta) => {
+			if (pendingThinkingDelta || pendingToolOutputDeltas.size > 0) {
+				flushPendingDeltas();
+			}
 			pendingTextDelta += delta;
-			scheduleTextFlush();
+			scheduleStreamFlush();
 		},
 
 		onThinkingDelta: (thinking) => {
-			flushPendingTextDelta();
-			ref.current.thinking = (ref.current.thinking || "") + thinking;
-			appendThinkingRenderPart(ref, thinking);
-			const delegatedIndex = (ref.current.toolCalls || []).findIndex(
-				(toolCall) =>
-					resolveDelegatedKind(
-						toolCall.name,
-						toolCall.arguments,
-						toolCall.delegated?.kind,
-					) !== undefined,
-			);
-			if (delegatedIndex >= 0) {
-				const toolCalls = [...(ref.current.toolCalls || [])];
-				const delegatedTool = toolCalls[delegatedIndex];
-				const delegatedKind = resolveDelegatedKind(
-					delegatedTool.name,
-					delegatedTool.arguments,
-					delegatedTool.delegated?.kind,
-				);
-				if (!delegatedKind) {
-					updateLastAssistantMessage(() => ({
-						isThinking: true,
-						thinkingContent: ref.current.thinking || "",
-					}));
-					return;
-				}
-				toolCalls[delegatedIndex] = {
-					...delegatedTool,
-					delegated: mergeDelegatedArtifactState(delegatedTool.delegated, {
-						...(delegatedTool.delegated ||
-							createDelegatedArtifactState(
-								delegatedKind,
-								delegatedTool.arguments,
-							)),
-						kind: delegatedKind,
-						thinking: ref.current.thinking || "",
-					}),
-				};
-				ref.current.toolCalls = toolCalls;
+			if (pendingTextDelta || pendingToolOutputDeltas.size > 0) {
+				flushPendingDeltas();
 			}
-			updateLastAssistantMessage(() => ({
-				isThinking: true,
-				thinkingContent: ref.current.thinking || "",
-			}));
+			pendingThinkingDelta += thinking;
+			scheduleStreamFlush();
 		},
 
 		onToolCallStart: (id, name) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			if ((ref.current.toolCalls || []).some((toolCall) => toolCall.id === id)) {
 				appendToolRenderPart(ref, id);
 				return;
@@ -245,7 +285,7 @@ export function createStreamCallbacks(
 		},
 
 		onToolCallComplete: (id, _name, args) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			mapToolCalls(id, (toolCall) => {
 				const delegatedKind = resolveDelegatedKind(
 					toolCall.name,
@@ -266,7 +306,7 @@ export function createStreamCallbacks(
 		},
 
 		onToolResult: (id, output, isError) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			mapToolCalls(id, (toolCall) => {
 				const delegatedKind = resolveDelegatedKind(
 					toolCall.name,
@@ -307,27 +347,30 @@ export function createStreamCallbacks(
 		},
 
 		onToolOutputDelta: (id, delta) => {
-			flushPendingTextDelta();
-			mapToolCalls(id, (toolCall) => ({
-				...toolCall,
-				output: (toolCall.output || "") + delta,
-			}));
+			if (pendingTextDelta || pendingThinkingDelta) {
+				flushPendingDeltas();
+			}
+			pendingToolOutputDeltas.set(
+				id,
+				(pendingToolOutputDeltas.get(id) || "") + delta,
+			);
+			scheduleStreamFlush();
 		},
 
 		onDelegatedProgress: (event) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			mapToolCalls(event.tool_call_id, (toolCall) =>
 				applyDelegatedProgress(toolCall, event),
 			);
 		},
 
 		onPlanUpdate: (items: PlanItem[]) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			planStore.getState().setItems(items);
 		},
 
 		onModeChange: (mode) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			const nextMode: SessionMode = mode === "plan" ? "plan" : "build";
 			set({ mode: nextMode });
 			planStore.getState().setVisible(nextMode === "plan");
@@ -335,7 +378,7 @@ export function createStreamCallbacks(
 		},
 
 		onPlanComplete: (toolCallId, title, taskCount) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			const planConfirmCall: ToolCall = {
 				id: toolCallId,
 				name: "PlanConfirm",
@@ -351,7 +394,7 @@ export function createStreamCallbacks(
 		},
 
 		onTurnComplete: (_turn, hasMore) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			if (hasMore) {
 				const completed = ref.current;
 				const hasRenderableContent = Boolean(
@@ -369,7 +412,7 @@ export function createStreamCallbacks(
 		},
 
 		onToolApprovalRequired: (id, _name, args) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			mapToolCalls(id, (toolCall) => ({
 				...toolCall,
 				arguments: args,
@@ -378,12 +421,12 @@ export function createStreamCallbacks(
 		},
 
 		onToolApproved: (id) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			mapToolCalls(id, (toolCall) => ({ ...toolCall, status: "running" }));
 		},
 
 		onToolDenied: (id) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			mapToolCalls(id, (toolCall) => ({
 				...toolCall,
 				status: "error",
@@ -392,7 +435,7 @@ export function createStreamCallbacks(
 		},
 
 		onSteeringInjected: (pendingId, message) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			const id = pendingId
 				? `user-steering-${pendingId}`
 				: createChatMessageId("user-steering");
@@ -422,7 +465,7 @@ export function createStreamCallbacks(
 		},
 
 		onUsage: (promptTokens, completionTokens, metrics) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			set({
 				tokenCount:
 					metrics?.totalTokens ?? promptTokens + completionTokens,
@@ -435,7 +478,7 @@ export function createStreamCallbacks(
 		},
 
 		onSessionPinched: (event: SessionContinuationEvent) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			if (event.type === "session_pinched") {
 				pinchedSessionId = event.new_session_id;
 				return;
@@ -451,13 +494,13 @@ export function createStreamCallbacks(
 		},
 
 		onTitleUpdate: (title) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			set({ title });
 			sessionsStore.getState().loadSessions();
 		},
 
 		onFinish: (sessionId) => {
-			flushPendingTextDelta();
+			flushPendingDeltas();
 			const currentState = get();
 			const queued = currentState.queuedMessages;
 			const activeSessionId = pinchedSessionId ?? sessionId;
@@ -564,8 +607,8 @@ export function createStreamCallbacks(
 		},
 
 		onError: (error) => {
-			// Flush rAF-batched text so the last frame is not dropped on failure.
-			flushPendingTextDelta();
+			// Flush frame-batched stream content so the final update is not dropped.
+			flushPendingDeltas();
 			set((state) => ({
 				isLoading: false,
 				isStreaming: false,

--- a/packages/state/test/mobile-presentation-cadence.test.ts
+++ b/packages/state/test/mobile-presentation-cadence.test.ts
@@ -1,0 +1,74 @@
+import {
+  liveActivityStateEqual,
+  shouldSyncChatWidget,
+  type ChatWidgetCadenceState,
+  type LiveActivitySemanticState,
+} from "../../../apps/mobile/hooks/presentationCadence.ts";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+const baseActivity: LiveActivitySemanticState = {
+  chatTitle: "Build notifications",
+  status: "working",
+  toolCount: 2,
+  filesAdded: 12,
+  filesRemoved: 3,
+};
+
+Deno.test("Live Activity equality ignores render-only stream churn", () => {
+  assert(
+    liveActivityStateEqual(baseActivity, { ...baseActivity }),
+    "equal semantic activity states should not trigger native updates",
+  );
+  assert(
+    !liveActivityStateEqual(baseActivity, {
+      ...baseActivity,
+      status: "needs_input",
+      toolApprovalId: "tool-1",
+    }),
+    "needs-input transitions must update immediately",
+  );
+});
+
+const baseWidget: ChatWidgetCadenceState = {
+  sessionId: "session-1",
+  hasActiveSession: true,
+  sessionTitle: "Build notifications",
+  lastMessage: "Initial response",
+  model: "gpt-5.4",
+  isStreaming: true,
+  tokenCount: 120,
+  serverConnected: true,
+};
+
+Deno.test("chat widget skips token-by-token content while streaming", () => {
+  assert(
+    !shouldSyncChatWidget(baseWidget, {
+      ...baseWidget,
+      lastMessage: "Initial response with another streamed token",
+      tokenCount: 121,
+    }),
+    "stream deltas should not reload WidgetKit timelines",
+  );
+});
+
+Deno.test("chat widget syncs lifecycle transitions and settled content", () => {
+  assert(
+    shouldSyncChatWidget(baseWidget, {
+      ...baseWidget,
+      isStreaming: false,
+      lastMessage: "Final response",
+      tokenCount: 400,
+    }),
+    "completion must publish the final widget snapshot",
+  );
+  assert(
+    shouldSyncChatWidget(baseWidget, {
+      ...baseWidget,
+      sessionId: "session-2",
+    }),
+    "session changes must publish a new widget snapshot",
+  );
+});

--- a/packages/state/test/stream-boundaries.test.ts
+++ b/packages/state/test/stream-boundaries.test.ts
@@ -24,6 +24,7 @@ function assertEquals(actual: unknown, expected: unknown, message: string) {
 
 function testHarness() {
   const ref = { current: createStreamingAssistantMessage() };
+  let setCount = 0;
   let state: any = {
     messages: [ref.current],
     queuedMessages: [],
@@ -33,6 +34,7 @@ function testHarness() {
     thinkingContent: '',
   };
   const set = (partial: any) => {
+    setCount += 1;
     const update = typeof partial === 'function' ? partial(state) : partial;
     state = { ...state, ...update };
   };
@@ -42,7 +44,7 @@ function testHarness() {
     persistSessionMode: async () => {},
   });
 
-  return { callbacks, ref, state: () => state };
+  return { callbacks, ref, state: () => state, setCount: () => setCount };
 }
 
 Deno.test('duplicate tool starts remain one live tool block', () => {
@@ -60,6 +62,43 @@ Deno.test('duplicate tool starts remain one live tool block', () => {
     'tool render part should be idempotent',
   );
   assertEquals(ref.current.toolCalls?.[0]?.status, 'success', 'result updates the tool');
+});
+
+Deno.test('bursty thinking and tool output deltas commit once per frame', async () => {
+  const thinking = testHarness();
+  const thinkingBaseline = thinking.setCount();
+  thinking.callbacks.onThinkingDelta('one ');
+  thinking.callbacks.onThinkingDelta('two');
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  assertEquals(
+    thinking.setCount() - thinkingBaseline,
+    1,
+    'thinking deltas should share one presentation update',
+  );
+  assertEquals(
+    thinking.ref.current.thinking,
+    'one two',
+    'thinking content should retain every delta',
+  );
+
+  const tools = testHarness();
+  tools.callbacks.onToolCallStart('tool-stream', 'bash');
+  const toolBaseline = tools.setCount();
+  tools.callbacks.onToolOutputDelta?.('tool-stream', 'one ');
+  tools.callbacks.onToolOutputDelta?.('tool-stream', 'two');
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  assertEquals(
+    tools.setCount() - toolBaseline,
+    1,
+    'tool output deltas should share one presentation update',
+  );
+  assertEquals(
+    tools.ref.current.toolCalls?.[0]?.output,
+    'one two',
+    'tool output should retain every delta',
+  );
 });
 
 Deno.test('tool-loop completion starts a distinct live assistant subturn', () => {


### PR DESCRIPTION
## What changed
- moved the Live Activity timer to the native SwiftUI timer instead of one JavaScript update per second
- serialized, deduplicated, and throttled ActivityKit and WidgetKit synchronization while keeping approval transitions urgent
- batched text, thinking, and tool-output presentation updates once per animation frame
- memoized stable transcript rows, reduced repeated bottom anchoring, and paused overlapping session polling during streams
- stabilized notification listeners and native-device registration

## Why
Long streaming runs were causing avoidable React/store churn, native extension updates, scroll work, and polling. Together those paths could produce chat stutter and unnecessary battery/memory pressure.

## Validation
- mobile TypeScript check
- Expo web export
- focused stream and presentation cadence regressions
- cargo fmt --check
- cargo check --workspace
- cargo test --workspace
- cargo clippy --workspace -- -D warnings

## TestFlight objective
Use the resulting device build to profile a long full-cycle stream with Instruments Energy Log, Time Profiler, and Allocations while observing chat, Lock Screen, and Dynamic Island transitions.