### PR TITLE
Release v0.9.11: tolerate supervised startup recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "krusty"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client-state"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "krusty-client",
  "serde",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/desktop/shell/package.json
+++ b/apps/desktop/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krusty/desktop-shell",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "private": true,
   "packageManager": "bun@1.3.0",
   "type": "module",

--- a/apps/desktop/shell/src-tauri/Cargo.lock
+++ b/apps/desktop/shell/src-tauri/Cargo.lock
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -3115,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-desktop"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "krusty-core",
  "krusty-server",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/desktop/shell/src-tauri/Cargo.toml
+++ b/apps/desktop/shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-desktop"
-version = "0.9.10"
+version = "0.9.11"
 edition = "2021"
 
 [build-dependencies]

--- a/apps/desktop/shell/src-tauri/tauri.conf.json
+++ b/apps/desktop/shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Krusty Desktop",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "identifier": "io.krusty.desktop",
   "build": {
     "beforeDevCommand": "cd ../../mobile && npx expo start --web --port 5173",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Krusty",
     "slug": "krusty",
-    "version": "0.9.10",
+    "version": "0.9.11",
     "orientation": "portrait",
     "icon": "./assets/icons/ios-light.png",
     "userInterfaceStyle": "automatic",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krusty/mobile",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",

--- a/crates/krusty-cli/Cargo.toml
+++ b/crates/krusty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty"
-version = "0.9.10"
+version = "0.9.11"
 edition = "2021"
 description = "The most elegant coding CLI to ever exist"
 default-run = "krusty"

--- a/crates/krusty-client-state/Cargo.toml
+++ b/crates/krusty-client-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client-state"
-version = "0.9.10"
+version = "0.9.11"
 edition = "2021"
 description = "Headless Rust state machine for Krusty chat clients"
 

--- a/crates/krusty-client/Cargo.toml
+++ b/crates/krusty-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client"
-version = "0.9.10"
+version = "0.9.11"
 edition = "2021"
 description = "Async Rust client for the Krusty server API"
 

--- a/crates/krusty-core/Cargo.toml
+++ b/crates/krusty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-core"
-version = "0.9.10"
+version = "0.9.11"
 edition = "2021"
 description = "Core library for Krusty - AI, storage, tools, and extensions"
 

--- a/crates/krusty-server/Cargo.toml
+++ b/crates/krusty-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-server"
-version = "0.9.10"
+version = "0.9.11"
 edition = "2021"
 description = "Self-hosted Krusty API server library"
 

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,8 @@ DAEMON_BINARY="krusty-mako"
 DEFAULT_INSTALL_DIR="$HOME/.local/bin"
 INSTALL_DIR="${INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
 SYSTEMD_UNITS="krusty-mako.socket krusty-mako.service krusty-serve.service"
+ACTIVATION_HEALTH_ATTEMPTS=20
+ACTIVATION_STABLE_PASSES=2
 
 TMP_DIR=""
 INSTALL_LOCK=""
@@ -741,14 +743,28 @@ restart_previously_active() {
 
 verify_previously_active() {
     [ -n "$ACTIVE_UNITS" ] || return 0
-    health_pass=1
-    while [ "$health_pass" -le 2 ]; do
+    health_attempt=1
+    stable_health_passes=0
+    while [ "$health_attempt" -le "$ACTIVATION_HEALTH_ATTEMPTS" ]; do
         health_pause
+        all_units_active=true
         for health_unit in $ACTIVE_UNITS; do
-            run_systemctl --user is-active --quiet "$health_unit" >/dev/null 2>&1 || return 1
+            if ! run_systemctl --user is-active --quiet "$health_unit" >/dev/null 2>&1; then
+                all_units_active=false
+                break
+            fi
         done
-        health_pass=$((health_pass + 1))
+        if [ "$all_units_active" = true ]; then
+            stable_health_passes=$((stable_health_passes + 1))
+            if [ "$stable_health_passes" -ge "$ACTIVATION_STABLE_PASSES" ]; then
+                return 0
+            fi
+        else
+            stable_health_passes=0
+        fi
+        health_attempt=$((health_attempt + 1))
     done
+    return 1
 }
 
 restart_and_verify_previously_active() {
@@ -1018,7 +1034,7 @@ run_self_test() (
     SELF_ADD_DEPENDENCY=false
     SELF_FAIL_RELOAD_ONCE=false
     SELF_FAIL_RESTART_ONCE=false
-    SELF_FAIL_HEALTH_ONCE=false
+    SELF_FAIL_HEALTH_COUNT=0
     SELF_HEALTH_CHECKS=0
 
     self_unit_active() {
@@ -1048,8 +1064,8 @@ run_self_test() (
                 shift
                 if [ "$SELF_AFTER_RESTART" = true ] && [ "$1" = "krusty-serve.service" ]; then
                     SELF_HEALTH_CHECKS=$((SELF_HEALTH_CHECKS + 1))
-                    if [ "$SELF_FAIL_HEALTH_ONCE" = true ]; then
-                        SELF_FAIL_HEALTH_ONCE=false
+                    if [ "$SELF_FAIL_HEALTH_COUNT" -gt 0 ]; then
+                        SELF_FAIL_HEALTH_COUNT=$((SELF_FAIL_HEALTH_COUNT - 1))
                         return 1
                     fi
                 fi
@@ -1138,7 +1154,7 @@ run_self_test() (
         SELF_ADD_DEPENDENCY=false
         SELF_FAIL_RELOAD_ONCE=false
         SELF_FAIL_RESTART_ONCE=false
-        SELF_FAIL_HEALTH_ONCE=false
+        SELF_FAIL_HEALTH_COUNT=0
         SELF_HEALTH_CHECKS=0
     }
     release_self_install_lock() {
@@ -1267,6 +1283,15 @@ run_self_test() (
     [ "$SELF_HEALTH_CHECKS" -ge 2 ]
     assert_no_activation_residue
 
+    # A service can fail its first health sample while systemd applies its
+    # configured restart policy. Activation should accept eventual stability.
+    reset_self_systemd
+    ACTIVE_UNITS=" krusty-serve.service"
+    SELF_AFTER_RESTART=true
+    SELF_FAIL_HEALTH_COUNT=1
+    verify_previously_active
+    [ "$SELF_HEALTH_CHECKS" -ge 3 ]
+
     # The marker does not authorize unrelated absolute unit links.
     rejected_unit="$SYSTEMD_USER_DIR/krusty-mako.socket"
     rejected_target="$self_root/unmanaged-krusty-mako.socket"
@@ -1318,7 +1343,7 @@ run_self_test() (
 
     reset_self_systemd
     SELF_ADD_DEPENDENCY=true
-    SELF_FAIL_HEALTH_ONCE=true
+    SELF_FAIL_HEALTH_COUNT=$ACTIVATION_HEALTH_ATTEMPTS
     if activate_unix_release; then fail "Self-test expected unhealthy-service rollback."; exit 1; fi
     case "$SELF_LOG" in
         *'|restart:krusty-serve.service|stop:krusty-mako.socket|daemon-reload|restart:krusty-serve.service'*) ;;


### PR DESCRIPTION
## Summary
- allow installer activation checks to tolerate systemd's bounded restart recovery
- require two consecutive healthy service samples before accepting activation
- preserve rollback when services remain unhealthy through the recovery window
- bump shipping versions to v0.9.11

## Root cause
The v0.9.10 installer sampled service health twice at one-second intervals, but krusty-serve.service retries after three seconds. When Mako's scheduler was still initializing, the server's first start failed correctly, yet the installer rolled back before systemd could perform its configured recovery.

## Validation
- cargo fmt --all -- --check
- cargo check --workspace
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- cd apps/mobile && npx expo export --platform web
- sh -n install.sh
- sh install.sh --self-test

The installer self-test now covers both transient recovery and persistent-health rollback.