### PR TITLE
Release v0.9.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "krusty"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client-state"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "krusty-client",
  "serde",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "axum",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [

--- a/apps/desktop/shell/package.json
+++ b/apps/desktop/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krusty/desktop-shell",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "private": true,
   "packageManager": "bun@1.3.0",
   "type": "module",

--- a/apps/desktop/shell/src-tauri/Cargo.lock
+++ b/apps/desktop/shell/src-tauri/Cargo.lock
@@ -644,7 +644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml 0.9.12+spec-1.1.0",
+ "toml 0.9.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -1594,7 +1594,7 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 0.9.12+spec-1.1.0",
+ "toml 0.9.13+spec-1.1.0",
  "vswhom",
  "winreg 0.55.0",
 ]
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
@@ -6302,7 +6302,7 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.12+spec-1.1.0",
+ "toml 0.9.13+spec-1.1.0",
  "walkdir",
 ]
 
@@ -6430,7 +6430,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 0.9.13+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -6445,7 +6445,7 @@ checksum = "1087b111fe2b005e42dbdc1990fc18593234238d47453b0c99b7de1c9ab2c1e0"
 dependencies = [
  "dunce",
  "embed-resource",
- "toml 0.9.12+spec-1.1.0",
+ "toml 0.9.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "0.9.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [

--- a/apps/desktop/shell/src-tauri/Cargo.toml
+++ b/apps/desktop/shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-desktop"
-version = "0.9.12"
+version = "0.9.13"
 edition = "2021"
 
 [build-dependencies]

--- a/apps/desktop/shell/src-tauri/tauri.conf.json
+++ b/apps/desktop/shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Krusty Desktop",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "identifier": "io.krusty.desktop",
   "build": {
     "beforeDevCommand": "cd ../../mobile && npx expo start --web --port 5173",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Krusty",
     "slug": "krusty",
-    "version": "0.9.12",
+    "version": "0.9.13",
     "orientation": "portrait",
     "icon": "./assets/icons/ios-light.png",
     "userInterfaceStyle": "automatic",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krusty/mobile",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",

--- a/crates/krusty-cli/Cargo.toml
+++ b/crates/krusty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty"
-version = "0.9.12"
+version = "0.9.13"
 edition = "2021"
 description = "The most elegant coding CLI to ever exist"
 default-run = "krusty"

--- a/crates/krusty-client-state/Cargo.toml
+++ b/crates/krusty-client-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client-state"
-version = "0.9.12"
+version = "0.9.13"
 edition = "2021"
 description = "Headless Rust state machine for Krusty chat clients"
 

--- a/crates/krusty-client/Cargo.toml
+++ b/crates/krusty-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client"
-version = "0.9.12"
+version = "0.9.13"
 edition = "2021"
 description = "Async Rust client for the Krusty server API"
 

--- a/crates/krusty-core/Cargo.toml
+++ b/crates/krusty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-core"
-version = "0.9.12"
+version = "0.9.13"
 edition = "2021"
 description = "Core library for Krusty - AI, storage, tools, and extensions"
 

--- a/crates/krusty-server/Cargo.toml
+++ b/crates/krusty-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-server"
-version = "0.9.12"
+version = "0.9.13"
 edition = "2021"
 description = "Self-hosted Krusty API server library"
 


### PR DESCRIPTION
## Summary
- Bump Krusty packages to v0.9.13 after the mobile stream chrome / agent-TUI main merge
- Enables packaged server install on Honey and a clean release artifact set

## Test plan
- [ ] CI green
- [ ] Tag v0.9.13 and verify Release workflow assets
- [ ] Honey install/restart health verifies 0.9.13 runtime identity
- [ ] TestFlight workflow for main remains healthy