### PR TITLE
fix(release): restore real crate versions after 0.9.13 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.13"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [

--- a/apps/desktop/shell/src-tauri/Cargo.lock
+++ b/apps/desktop/shell/src-tauri/Cargo.lock
@@ -644,7 +644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml 0.9.13+spec-1.1.0",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1594,7 +1594,7 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 0.9.13+spec-1.1.0",
+ "toml 0.9.12+spec-1.1.0",
  "vswhom",
  "winreg 0.55.0",
 ]
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.13"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
@@ -6302,7 +6302,7 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.13+spec-1.1.0",
+ "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
@@ -6430,7 +6430,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.13+spec-1.1.0",
+ "toml 0.9.12+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -6445,7 +6445,7 @@ checksum = "1087b111fe2b005e42dbdc1990fc18593234238d47453b0c99b7de1c9ab2c1e0"
 dependencies = [
  "dunce",
  "embed-resource",
- "toml 0.9.13+spec-1.1.0",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.13+spec-1.1.0"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [


### PR DESCRIPTION
## Summary
- The v0.9.13 version bump accidentally rewrote `parking_lot_core` and `toml` lock entries that shared the `0.9.12` prefix.
- That made cargo resolution fail in CI/release because those crate versions do not exist.
- This restores the real dependency versions while keeping the package version at 0.9.13.

## Test plan
- [x] Diff confirms only false-positive lock rewrites are reverted
- [ ] CI green on this PR
- [ ] Re-run/reattach `v0.9.13` release after merge
- [ ] TestFlight submit from fixed main