### PR TITLE
Release v0.9.20

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Version
       description: Release, TestFlight build, or commit
-      placeholder: 0.9.14, build 266, or commit SHA
+      placeholder: 0.9.20, build 266, or commit SHA
     validations:
       required: true
   - type: dropdown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "krusty"
-version = "0.9.14"
+version = "0.9.20"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client"
-version = "0.9.14"
+version = "0.9.20"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-client-state"
-version = "0.9.14"
+version = "0.9.20"
 dependencies = [
  "krusty-client",
  "serde",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-core"
-version = "0.9.14"
+version = "0.9.20"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "krusty-server"
-version = "0.9.14"
+version = "0.9.20"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/desktop/shell/package.json
+++ b/apps/desktop/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krusty/desktop-shell",
-  "version": "0.9.14",
+  "version": "0.9.20",
   "private": true,
   "packageManager": "bun@1.3.0",
   "type": "module",

--- a/apps/desktop/shell/src-tauri/Cargo.toml
+++ b/apps/desktop/shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-desktop"
-version = "0.9.14"
+version = "0.9.20"
 edition = "2021"
 
 [build-dependencies]

--- a/apps/desktop/shell/src-tauri/tauri.conf.json
+++ b/apps/desktop/shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Mitsuro",
-  "version": "0.9.14",
+  "version": "0.9.20",
   "identifier": "io.krusty.desktop",
   "build": {
     "beforeDevCommand": "cd ../../mobile && npx expo start --web --port 5173",

--- a/crates/krusty-cli/Cargo.toml
+++ b/crates/krusty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty"
-version = "0.9.14"
+version = "0.9.20"
 edition = "2021"
 description = "Mitsuro AI coding runtime and compatibility CLI"
 default-run = "krusty"

--- a/crates/krusty-client-state/Cargo.toml
+++ b/crates/krusty-client-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client-state"
-version = "0.9.14"
+version = "0.9.20"
 edition = "2021"
 description = "Headless Rust state machine for Mitsuro clients"
 

--- a/crates/krusty-client/Cargo.toml
+++ b/crates/krusty-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-client"
-version = "0.9.14"
+version = "0.9.20"
 edition = "2021"
 description = "Async Rust client for the Mitsuro server API"
 

--- a/crates/krusty-core/Cargo.toml
+++ b/crates/krusty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-core"
-version = "0.9.14"
+version = "0.9.20"
 edition = "2021"
 description = "Core library for Mitsuro - AI, storage, tools, and extensions"
 

--- a/crates/krusty-server/Cargo.toml
+++ b/crates/krusty-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krusty-server"
-version = "0.9.14"
+version = "0.9.20"
 edition = "2021"
 description = "Self-hosted Mitsuro API server library"
 


### PR DESCRIPTION
## Summary
- Bump Krusty packages to **v0.9.20** after the Mitsuro mobile staging merge on main
- Aligns CLI/server/client/desktop package versions with the already-landed mobile **0.9.20** cut
- Enables the full product release tag / packaged artifact set

## Included on main already
- Mitsuro / Hive branding
- Mobile 0.9.20 TestFlight cut + interaction/perf stack
- Shared AI prompt cleanup (no model-family overlays)

## Test plan
- [ ] CI green on release branch
- [ ] Squash merge to main
- [ ] Tag `v0.9.20` and verify Release workflow assets
- [ ] Confirm GitHub release publishes as Latest
- [ ] Confirm Mobile → TestFlight path remains healthy