### PR TITLE
fix(mobile): bump iOS buildNumber to 267 for TestFlight

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -34,7 +34,7 @@
       "config": {
         "usesNonExemptEncryption": false
       },
-      "buildNumber": "266"
+      "buildNumber": "267"
     },
     "android": {
       "package": "io.krusty.mobile",


### PR DESCRIPTION
## Summary
- App Store Connect rejected resubmit of Mitsuro 0.9.20 because iOS build **266** is already used.
- Bump `apps/mobile/app.json` `ios.buildNumber` to **267** so TestFlight can rebuild and submit a unique build.

## Test plan
- [ ] Merge to main
- [ ] Mobile → TestFlight workflow builds and submits successfully
- [ ] Confirm ASC shows version 0.9.20 build 267