### PR TITLE
fix(mobile): unblock TestFlight after chrome recovery typecheck

### DIFF
--- a/apps/mobile/components/chat/ToolDiffViewer.web.tsx
+++ b/apps/mobile/components/chat/ToolDiffViewer.web.tsx
@@ -1,11 +1,6 @@
 import { useMemo } from "react";
 import { FileDiff, MultiFileDiff } from "@pierre/diffs/react";
-import {
-  parsePatchFiles,
-  registerCustomLanguage,
-  registerCustomTheme,
-} from "@pierre/diffs";
-import rustLanguage from "@shikijs/langs/rust";
+import { parsePatchFiles, registerCustomTheme } from "@pierre/diffs";
 import { useThemeContext } from "../../hooks/useTheme";
 import {
   KRUSTY_DIFF_THEME_NAMES,
@@ -43,10 +38,6 @@ const KRUSTY_DIFF_CSS = `
 
 registerCustomTheme(KRUSTY_DIFF_THEME_NAMES.dark, async () => krustyDarkDiffTheme);
 registerCustomTheme(KRUSTY_DIFF_THEME_NAMES.light, async () => krustyLightDiffTheme);
-// Metro cannot safely bundle Pierre's runtime-generated absolute Rust grammar
-// import when node_modules is shared by a worktree. Registering the grammar as
-// a static module keeps the web diff viewer deterministic.
-registerCustomLanguage("rust", async () => ({ default: rustLanguage }), ["rs"]);
 
 export function ToolDiffViewer({ presentation }: ToolDiffViewerProps) {
   // rows/showHeader/maxLines are accepted for API parity with native peek mode.

--- a/apps/mobile/components/toolbox/ToolboxChanges.tsx
+++ b/apps/mobile/components/toolbox/ToolboxChanges.tsx
@@ -7,16 +7,10 @@ import {
   Text,
   View,
 } from "react-native";
-import { ChevronDown, ChevronRight, FileCode2, RefreshCw } from "lucide-react-native";
-import type {
-  GitChangedFile,
-  GitFileDiffResponse,
-  GitStatusResponse,
-} from "@krusty/api";
+import type { GitStatusResponse } from "@krusty/api";
 
 import { useConnection } from "../../hooks/useConnection";
 import { useThemeContext } from "../../hooks/useTheme";
-import { ToolDiffViewer } from "../chat/ToolDiffViewer";
 
 interface ToolboxChangesProps {
   visible: boolean;
@@ -31,13 +25,8 @@ export function ToolboxChanges({
   const { theme } = useThemeContext();
   const t = theme.colors;
   const [status, setStatus] = useState<GitStatusResponse | null>(null);
-  const [files, setFiles] = useState<GitChangedFile[]>([]);
-  const [expandedPath, setExpandedPath] = useState<string | null>(null);
-  const [diffs, setDiffs] = useState<Record<string, GitFileDiffResponse>>({});
-  const [diffLoadingPath, setDiffLoadingPath] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [diffError, setDiffError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!client || !visible) {
@@ -46,14 +35,7 @@ export function ToolboxChanges({
     setLoading(true);
     setError(null);
     try {
-      const [nextStatus, nextChanges] = await Promise.all([
-        client.getGitStatus(projectDirectory ?? undefined),
-        client.getGitChanges(projectDirectory ?? undefined),
-      ]);
-      setStatus(nextStatus);
-      setFiles(nextChanges.files);
-      setDiffs({});
-      setExpandedPath(null);
+      setStatus(await client.getGitStatus(projectDirectory ?? undefined));
     } catch (nextError) {
       setError(
         nextError instanceof Error
@@ -68,38 +50,6 @@ export function ToolboxChanges({
   useEffect(() => {
     void refresh();
   }, [refresh]);
-
-  const toggleFile = useCallback(
-    async (file: GitChangedFile) => {
-      if (expandedPath === file.path) {
-        setExpandedPath(null);
-        return;
-      }
-      setExpandedPath(file.path);
-      setDiffError(null);
-      if (!client || diffs[file.path]) {
-        return;
-      }
-      setDiffLoadingPath(file.path);
-      try {
-        const diff = await client.getGitFileDiff(
-          file.path,
-          projectDirectory ?? undefined,
-        );
-        setDiffs((current) => ({ ...current, [file.path]: diff }));
-      } catch (nextError) {
-        setDiffError(
-          nextError instanceof Error ? nextError.message : "Unable to load this diff.",
-        );
-      } finally {
-        setDiffLoadingPath(null);
-      }
-    },
-    [client, diffs, expandedPath, projectDirectory],
-  );
-
-  const totalAdditions = files.reduce((sum, file) => sum + file.additions, 0);
-  const totalDeletions = files.reduce((sum, file) => sum + file.deletions, 0);
 
   return (
     <ScrollView
@@ -119,122 +69,65 @@ export function ToolboxChanges({
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Refresh changes"
-          disabled={loading}
           onPress={() => void refresh()}
           style={[styles.refreshButton, { borderColor: t.border }]}
         >
-          {loading ? (
-            <ActivityIndicator size="small" color={t.mutedForeground} />
-          ) : (
-            <RefreshCw size={16} color={t.foreground} strokeWidth={1.9} />
-          )}
+          <Text style={[styles.refreshText, { color: t.foreground }]}>
+            Refresh
+          </Text>
         </Pressable>
       </View>
 
+      {loading && !status ? (
+        <ActivityIndicator color={t.mutedForeground} />
+      ) : null}
       {error ? <Text style={[styles.error, { color: t.error }]}>{error}</Text> : null}
       {status && !status.in_repo ? (
         <Text style={[styles.empty, { color: t.mutedForeground }]}>
           The active directory is not a Git repository.
         </Text>
       ) : null}
-
       {status?.in_repo ? (
         <>
-          <View style={[styles.branchRow, { borderColor: t.border }]}>
-            <View style={styles.branchCopy}>
-              <Text numberOfLines={1} style={[styles.branch, { color: t.foreground }]}>
-                {status.branch ?? "Detached HEAD"}
-              </Text>
-              <Text style={[styles.detail, { color: t.mutedForeground }]}>
-                {files.length} file{files.length === 1 ? "" : "s"}
-              </Text>
-            </View>
-            <Text style={styles.diffTotals}>
-              <Text style={{ color: t.success }}>+{totalAdditions}</Text>
-              <Text style={{ color: t.mutedForeground }}>  </Text>
-              <Text style={{ color: t.error }}>−{totalDeletions}</Text>
+          <View
+            style={[
+              styles.branchCard,
+              { borderColor: t.border, backgroundColor: t.card },
+            ]}
+          >
+            <Text style={[styles.branch, { color: t.foreground }]}>
+              {status.branch ?? "Detached HEAD"}
+            </Text>
+            <Text style={[styles.detail, { color: t.mutedForeground }]}>
+              {status.ahead} ahead · {status.behind} behind
             </Text>
           </View>
 
-          {files.length === 0 && !loading ? (
-            <Text style={[styles.empty, { color: t.mutedForeground }]}>
-              No changes from this branch&apos;s base.
-            </Text>
-          ) : (
-            <View style={[styles.fileList, { borderColor: t.border }]}>
-              {files.map((file, index) => {
-                const expanded = expandedPath === file.path;
-                const diff = diffs[file.path];
-                return (
-                  <View
-                    key={file.path}
-                    style={[
-                      styles.fileItem,
-                      index > 0 && { borderTopColor: t.border, borderTopWidth: StyleSheet.hairlineWidth },
-                    ]}
-                  >
-                    <Pressable
-                      accessibilityRole="button"
-                      accessibilityLabel={`${expanded ? "Collapse" : "Expand"} ${file.path}`}
-                      onPress={() => void toggleFile(file)}
-                      style={styles.fileRow}
-                    >
-                      {expanded ? (
-                        <ChevronDown size={16} color={t.mutedForeground} />
-                      ) : (
-                        <ChevronRight size={16} color={t.mutedForeground} />
-                      )}
-                      <FileCode2 size={16} color={t.mutedForeground} strokeWidth={1.7} />
-                      <View style={styles.fileCopy}>
-                        <Text numberOfLines={1} style={[styles.filePath, { color: t.foreground }]}>
-                          {file.path}
-                        </Text>
-                        <Text style={[styles.fileStatus, { color: t.mutedForeground }]}>
-                          {file.status}
-                        </Text>
-                      </View>
-                      <Text style={styles.fileTotals}>
-                        <Text style={{ color: t.success }}>+{file.additions}</Text>
-                        <Text style={{ color: t.mutedForeground }}> </Text>
-                        <Text style={{ color: t.error }}>−{file.deletions}</Text>
-                      </Text>
-                    </Pressable>
-
-                    {expanded ? (
-                      <View style={styles.diffBody}>
-                        {diffLoadingPath === file.path ? (
-                          <ActivityIndicator size="small" color={t.mutedForeground} />
-                        ) : diffError && !diff ? (
-                          <Text style={[styles.error, { color: t.error }]}>{diffError}</Text>
-                        ) : diff?.binary ? (
-                          <Text style={[styles.empty, { color: t.mutedForeground }]}>
-                            Binary file preview is unavailable.
-                          </Text>
-                        ) : diff?.patch ? (
-                          <>
-                            <ToolDiffViewer
-                              presentation={{
-                                kind: "patch",
-                                patch: diff.patch,
-                                filePath: file.path,
-                                additions: file.additions,
-                                deletions: file.deletions,
-                              }}
-                            />
-                            {diff.truncated ? (
-                              <Text style={[styles.note, { color: t.mutedForeground }]}>
-                                Large diff truncated for this preview.
-                              </Text>
-                            ) : null}
-                          </>
-                        ) : null}
-                      </View>
-                    ) : null}
-                  </View>
-                );
-              })}
-            </View>
-          )}
+          <View style={styles.grid}>
+            {[
+              ["Modified", status.modified],
+              ["Staged", status.staged],
+              ["Untracked", status.untracked],
+              ["Conflicts", status.conflicted],
+              ["Additions", status.branch_additions],
+              ["Deletions", status.branch_deletions],
+            ].map(([label, value]) => (
+              <View
+                key={label}
+                style={[
+                  styles.metric,
+                  { borderColor: t.border, backgroundColor: t.card },
+                ]}
+              >
+                <Text style={[styles.metricValue, { color: t.foreground }]}>
+                  {value}
+                </Text>
+                <Text style={[styles.metricLabel, { color: t.mutedForeground }]}>
+                  {label}
+                </Text>
+              </View>
+            ))}
+          </View>
         </>
       ) : null}
     </ScrollView>
@@ -245,7 +138,7 @@ const styles = StyleSheet.create({
   content: {
     padding: 18,
     paddingBottom: 32,
-    gap: 14,
+    gap: 16,
   },
   headingRow: {
     flexDirection: "row",
@@ -265,82 +158,54 @@ const styles = StyleSheet.create({
     lineHeight: 17,
   },
   refreshButton: {
-    width: 38,
-    height: 38,
+    minHeight: 36,
+    paddingHorizontal: 12,
     borderRadius: 12,
     borderWidth: StyleSheet.hairlineWidth,
     alignItems: "center",
     justifyContent: "center",
   },
-  branchRow: {
-    minHeight: 54,
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    paddingBottom: 12,
-  },
-  branchCopy: {
-    flex: 1,
-  },
-  branch: {
-    fontSize: 14,
-    fontWeight: "700",
-  },
-  detail: {
-    marginTop: 3,
-    fontSize: 12,
-  },
-  diffTotals: {
-    fontSize: 12,
-    fontWeight: "700",
-    fontVariant: ["tabular-nums"],
-  },
-  fileList: {
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 14,
-    overflow: "hidden",
-  },
-  fileItem: {
-    minWidth: 0,
-  },
-  fileRow: {
-    minHeight: 58,
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 9,
-  },
-  fileCopy: {
-    flex: 1,
-    minWidth: 0,
-  },
-  filePath: {
+  refreshText: {
     fontSize: 12,
     fontWeight: "600",
   },
-  fileStatus: {
-    marginTop: 3,
-    fontSize: 11,
-    textTransform: "capitalize",
+  branchCard: {
+    padding: 14,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
   },
-  fileTotals: {
-    fontSize: 11,
+  branch: {
+    fontSize: 15,
     fontWeight: "700",
-    fontVariant: ["tabular-nums"],
   },
-  diffBody: {
-    paddingHorizontal: 8,
-    paddingBottom: 10,
-    gap: 8,
+  detail: {
+    marginTop: 4,
+    fontSize: 12,
   },
-  note: {
-    fontSize: 11,
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 10,
+  },
+  metric: {
+    width: "47%",
+    minHeight: 88,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 14,
+    justifyContent: "space-between",
+  },
+  metricValue: {
+    fontSize: 23,
+    fontWeight: "700",
+  },
+  metricLabel: {
+    fontSize: 12,
+    fontWeight: "600",
   },
   empty: {
-    fontSize: 13,
-    lineHeight: 19,
+    fontSize: 14,
+    lineHeight: 20,
   },
   error: {
     fontSize: 13,

--- a/apps/mobile/components/toolbox/ToolboxConnections.tsx
+++ b/apps/mobile/components/toolbox/ToolboxConnections.tsx
@@ -1,15 +1,17 @@
-import { type ReactNode, useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
   ScrollView,
   StyleSheet,
-  Switch,
   Text,
   View,
 } from "react-native";
-import { ChevronDown, ChevronRight } from "lucide-react-native";
-import type { McpServerResponse, SkillInfo } from "@krusty/api";
+import type {
+  McpServerResponse,
+  ProviderStatus,
+  SkillInfo,
+} from "@krusty/api";
 
 import { useConnection } from "../../hooks/useConnection";
 import { useThemeContext } from "../../hooks/useTheme";
@@ -19,103 +21,47 @@ interface ToolboxConnectionsProps {
   onOpenSettings?: () => void;
 }
 
-type SectionKey = "mcp" | "skills";
-
-export function ToolboxConnections({ visible }: ToolboxConnectionsProps) {
+export function ToolboxConnections({
+  visible,
+  onOpenSettings,
+}: ToolboxConnectionsProps) {
   const { client } = useConnection();
   const { theme } = useThemeContext();
   const t = theme.colors;
+  const [providers, setProviders] = useState<ProviderStatus[]>([]);
   const [servers, setServers] = useState<McpServerResponse[]>([]);
   const [skills, setSkills] = useState<SkillInfo[]>([]);
-  const [expanded, setExpanded] = useState<Record<SectionKey, boolean>>({
-    mcp: true,
-    skills: false,
-  });
   const [loading, setLoading] = useState(false);
-  const [busyKey, setBusyKey] = useState<string | null>(null);
-  const [message, setMessage] = useState<string | null>(null);
 
-  const load = useCallback(async () => {
+  useEffect(() => {
     if (!client || !visible) {
       return;
     }
+    let active = true;
     setLoading(true);
-    setMessage(null);
-    try {
-      const [nextServers, nextSkills] = await Promise.all([
-        client.getMcpServers(),
-        client.getSkills(),
-      ]);
+    void Promise.all([
+      client.getCredentials().catch(() => []),
+      client.getMcpServers().catch(() => []),
+      client.getSkills().catch(() => []),
+    ]).then(([nextProviders, nextServers, nextSkills]) => {
+      if (!active) {
+        return;
+      }
+      setProviders(nextProviders);
       setServers(nextServers);
       setSkills(nextSkills);
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Unable to load connections.");
-    } finally {
       setLoading(false);
-    }
+    });
+    return () => {
+      active = false;
+    };
   }, [client, visible]);
 
-  useEffect(() => {
-    void load();
-  }, [load]);
-
-  const connectedCount = servers.filter((server) => server.connected).length;
-  const enabledSkillCount = skills.filter((skill) => skill.enabled).length;
-
-  const toggleSection = (section: SectionKey) => {
-    setExpanded((current) => ({ ...current, [section]: !current[section] }));
-  };
-
-  const toggleMcp = useCallback(
-    async (server: McpServerResponse) => {
-      if (!client) return;
-      const key = `mcp:${server.name}`;
-      setBusyKey(key);
-      setMessage(null);
-      try {
-        const updated = server.connected
-          ? await client.disconnectMcpServer(server.name)
-          : await client.connectMcpServer(server.name);
-        setServers((current) =>
-          current.map((entry) => (entry.name === updated.name ? updated : entry)),
-        );
-      } catch (error) {
-        setMessage(
-          error instanceof Error
-            ? error.message
-            : `Unable to update ${server.name}.`,
-        );
-      } finally {
-        setBusyKey(null);
-      }
-    },
-    [client],
+  const configuredProviders = providers.filter(
+    (provider) => provider.configured || provider.has_oauth,
   );
-
-  const toggleSkill = useCallback(
-    async (skill: SkillInfo) => {
-      if (!client) return;
-      const key = `skill:${skill.name}`;
-      setBusyKey(key);
-      setMessage(null);
-      try {
-        const updated = await client.updateSkillPolicy(skill.name, {
-          enabled: !skill.enabled,
-        });
-        setSkills((current) =>
-          current.map((entry) => (entry.name === updated.name ? updated : entry)),
-        );
-      } catch (error) {
-        setMessage(
-          error instanceof Error
-            ? error.message
-            : `Unable to update ${skill.name}.`,
-        );
-      } finally {
-        setBusyKey(null);
-      }
-    },
-    [client],
+  const connectedServers = servers.filter(
+    (server) => server.status === "connected",
   );
 
   return (
@@ -123,149 +69,64 @@ export function ToolboxConnections({ visible }: ToolboxConnectionsProps) {
       contentContainerStyle={styles.content}
       showsVerticalScrollIndicator={false}
     >
-      <View style={styles.heading}>
-        <Text style={[styles.title, { color: t.foreground }]}>Connections</Text>
-        {loading ? <ActivityIndicator size="small" color={t.mutedForeground} /> : null}
-      </View>
+      <Text style={[styles.title, { color: t.foreground }]}>Connections</Text>
+      <Text style={[styles.subtitle, { color: t.mutedForeground }]}>
+        Providers, MCP servers, and skills available to Chat.
+      </Text>
 
-      {message ? <Text style={[styles.message, { color: t.error }]}>{message}</Text> : null}
+      {loading ? <ActivityIndicator color={t.mutedForeground} /> : null}
 
-      <ConnectionSection
-        title="MCP servers"
-        summary={`${connectedCount} of ${servers.length} on`}
-        expanded={expanded.mcp}
-        onToggle={() => toggleSection("mcp")}
-      >
-        {servers.length === 0 ? (
-          <EmptyRow label="No MCP servers configured" />
-        ) : (
-          servers.map((server) => {
-            const key = `mcp:${server.name}`;
-            return (
-              <ToggleRow
-                key={server.name}
-                title={server.name}
-                detail={
-                  server.error ??
-                  `${server.tool_count} tool${server.tool_count === 1 ? "" : "s"}`
-                }
-                value={server.connected}
-                disabled={busyKey === key}
-                onChange={() => void toggleMcp(server)}
-              />
-            );
-          })
-        )}
-      </ConnectionSection>
-
-      <ConnectionSection
-        title="Skills"
-        summary={`${enabledSkillCount} of ${skills.length} on`}
-        expanded={expanded.skills}
-        onToggle={() => toggleSection("skills")}
-      >
-        {skills.length === 0 ? (
-          <EmptyRow label="No skills installed" />
-        ) : (
-          skills.map((skill) => {
-            const key = `skill:${skill.name}`;
-            return (
-              <ToggleRow
-                key={skill.name}
-                title={skill.name}
-                detail={skill.description}
-                value={skill.enabled}
-                disabled={busyKey === key}
-                onChange={() => void toggleSkill(skill)}
-              />
-            );
-          })
-        )}
-      </ConnectionSection>
-    </ScrollView>
-  );
-
-  function ConnectionSection({
-    title,
-    summary,
-    expanded: isExpanded,
-    onToggle,
-    children,
-  }: {
-    title: string;
-    summary: string;
-    expanded: boolean;
-    onToggle: () => void;
-    children: ReactNode;
-  }) {
-    return (
-      <View style={[styles.section, { borderColor: t.border }]}>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityState={{ expanded: isExpanded }}
-          onPress={onToggle}
-          style={styles.sectionHeader}
+      {[
+        {
+          title: "Providers",
+          summary: `${configuredProviders.length} configured`,
+          values: configuredProviders.map((provider) => provider.name),
+        },
+        {
+          title: "MCP",
+          summary: `${connectedServers.length} connected`,
+          values: connectedServers.map((server) => server.name),
+        },
+        {
+          title: "Skills",
+          summary: `${skills.length} installed`,
+          values: skills.map((skill) => skill.name),
+        },
+      ].map((section) => (
+        <View
+          key={section.title}
+          style={[
+            styles.card,
+            { borderColor: t.border, backgroundColor: t.card },
+          ]}
         >
-          {isExpanded ? (
-            <ChevronDown size={17} color={t.mutedForeground} />
-          ) : (
-            <ChevronRight size={17} color={t.mutedForeground} />
-          )}
-          <Text style={[styles.sectionTitle, { color: t.foreground }]}>{title}</Text>
-          <Text style={[styles.sectionSummary, { color: t.mutedForeground }]}>
-            {summary}
-          </Text>
-        </Pressable>
-        {isExpanded ? children : null}
-      </View>
-    );
-  }
-
-  function ToggleRow({
-    title,
-    detail,
-    value,
-    disabled,
-    onChange,
-  }: {
-    title: string;
-    detail: string;
-    value: boolean;
-    disabled: boolean;
-    onChange: () => void;
-  }) {
-    return (
-      <View style={[styles.itemRow, { borderTopColor: t.border }]}>
-        <View style={styles.itemCopy}>
-          <Text style={[styles.itemTitle, { color: t.foreground }]}>{title}</Text>
-          <Text
-            numberOfLines={2}
-            style={[styles.itemDetail, { color: t.mutedForeground }]}
-          >
-            {detail}
+          <View style={styles.cardHeader}>
+            <Text style={[styles.cardTitle, { color: t.foreground }]}>
+              {section.title}
+            </Text>
+            <Text style={[styles.cardSummary, { color: t.mutedForeground }]}>
+              {section.summary}
+            </Text>
+          </View>
+          <Text style={[styles.values, { color: t.mutedForeground }]}>
+            {section.values.slice(0, 6).join(" · ") || "None available"}
           </Text>
         </View>
-        <Switch
-          accessibilityLabel={`${value ? "Disable" : "Enable"} ${title}`}
-          value={value}
-          disabled={disabled}
-          onValueChange={onChange}
-          trackColor={{ false: t.muted, true: `${t.userMessage}88` }}
-          thumbColor={value ? t.userMessage : t.mutedForeground}
-        />
-      </View>
-    );
-  }
+      ))}
 
-  function EmptyRow({ label }: { label: string }) {
-    return (
-      <Text
-        style={[styles.empty, { borderTopColor: t.border, color: t.mutedForeground }]}
-      >
-        {label}
-      </Text>
-    );
-  }
+      {onOpenSettings ? (
+        <Pressable
+          accessibilityRole="button"
+          onPress={onOpenSettings}
+          style={[styles.settingsButton, { borderColor: t.border }]}
+        >
+          <Text style={[styles.settingsText, { color: t.foreground }]}>
+            Manage connections
+          </Text>
+        </Pressable>
+      ) : null}
+    </ScrollView>
+  );
 }
 
 const styles = StyleSheet.create({
@@ -274,67 +135,50 @@ const styles = StyleSheet.create({
     paddingBottom: 32,
     gap: 12,
   },
-  heading: {
-    minHeight: 30,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
   title: {
     fontSize: 19,
     fontWeight: "700",
   },
-  message: {
-    fontSize: 12,
-    lineHeight: 18,
+  subtitle: {
+    marginTop: -6,
+    marginBottom: 4,
+    fontSize: 13,
+    lineHeight: 19,
   },
-  section: {
+  card: {
     borderWidth: StyleSheet.hairlineWidth,
     borderRadius: 14,
-    overflow: "hidden",
+    padding: 14,
+    gap: 8,
   },
-  sectionHeader: {
-    minHeight: 54,
+  cardHeader: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 9,
-    paddingHorizontal: 13,
+    justifyContent: "space-between",
+    gap: 12,
   },
-  sectionTitle: {
-    flex: 1,
+  cardTitle: {
     fontSize: 14,
     fontWeight: "700",
   },
-  sectionSummary: {
+  cardSummary: {
     fontSize: 12,
     fontWeight: "600",
   },
-  itemRow: {
-    minHeight: 62,
-    flexDirection: "row",
+  values: {
+    fontSize: 12,
+    lineHeight: 18,
+  },
+  settingsButton: {
+    minHeight: 46,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
     alignItems: "center",
-    gap: 12,
-    paddingHorizontal: 14,
-    paddingVertical: 10,
-    borderTopWidth: StyleSheet.hairlineWidth,
+    justifyContent: "center",
+    marginTop: 4,
   },
-  itemCopy: {
-    flex: 1,
-    minWidth: 0,
-  },
-  itemTitle: {
+  settingsText: {
     fontSize: 13,
-    fontWeight: "600",
-  },
-  itemDetail: {
-    marginTop: 3,
-    fontSize: 11,
-    lineHeight: 16,
-  },
-  empty: {
-    paddingHorizontal: 14,
-    paddingVertical: 16,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    fontSize: 12,
+    fontWeight: "700",
   },
 });


### PR DESCRIPTION
## Summary
TestFlight quality gate failed because recovered `ToolboxChanges` / `ToolboxConnections` imported API types and methods that do not exist on main yet.

This restores those files (and the related web diff viewer tweak) to the pre-recovery main versions so the violet chrome / Hive / splash recovery can pass `tsc` and continue to EAS → TestFlight.

## Test plan
- [x] `cd apps/mobile && npx tsc --noEmit`
- [ ] Mobile TestFlight workflow green after merge