### PR TITLE
feat(mobile): restore Changes diff explorer and Connections skill controls

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -34,7 +34,7 @@
       "config": {
         "usesNonExemptEncryption": false
       },
-      "buildNumber": "268"
+      "buildNumber": "269"
     },
     "android": {
       "package": "io.krusty.mobile",

--- a/apps/mobile/components/chat/ToolDiffViewer.web.tsx
+++ b/apps/mobile/components/chat/ToolDiffViewer.web.tsx
@@ -1,6 +1,11 @@
 import { useMemo } from "react";
 import { FileDiff, MultiFileDiff } from "@pierre/diffs/react";
-import { parsePatchFiles, registerCustomTheme } from "@pierre/diffs";
+import {
+  parsePatchFiles,
+  registerCustomLanguage,
+  registerCustomTheme,
+} from "@pierre/diffs";
+import rustLanguage from "@shikijs/langs/rust";
 import { useThemeContext } from "../../hooks/useTheme";
 import {
   KRUSTY_DIFF_THEME_NAMES,
@@ -38,6 +43,10 @@ const KRUSTY_DIFF_CSS = `
 
 registerCustomTheme(KRUSTY_DIFF_THEME_NAMES.dark, async () => krustyDarkDiffTheme);
 registerCustomTheme(KRUSTY_DIFF_THEME_NAMES.light, async () => krustyLightDiffTheme);
+// Metro cannot safely bundle Pierre's runtime-generated absolute Rust grammar
+// import when node_modules is shared by a worktree. Registering the grammar as
+// a static module keeps the web diff viewer deterministic.
+registerCustomLanguage("rust", async () => ({ default: rustLanguage }), ["rs"]);
 
 export function ToolDiffViewer({ presentation }: ToolDiffViewerProps) {
   // rows/showHeader/maxLines are accepted for API parity with native peek mode.

--- a/apps/mobile/components/toolbox/ToolboxChanges.tsx
+++ b/apps/mobile/components/toolbox/ToolboxChanges.tsx
@@ -7,10 +7,16 @@ import {
   Text,
   View,
 } from "react-native";
-import type { GitStatusResponse } from "@krusty/api";
+import { ChevronDown, ChevronRight, FileCode2, RefreshCw } from "lucide-react-native";
+import type {
+  GitChangedFile,
+  GitFileDiffResponse,
+  GitStatusResponse,
+} from "@krusty/api";
 
 import { useConnection } from "../../hooks/useConnection";
 import { useThemeContext } from "../../hooks/useTheme";
+import { ToolDiffViewer } from "../chat/ToolDiffViewer";
 
 interface ToolboxChangesProps {
   visible: boolean;
@@ -25,8 +31,13 @@ export function ToolboxChanges({
   const { theme } = useThemeContext();
   const t = theme.colors;
   const [status, setStatus] = useState<GitStatusResponse | null>(null);
+  const [files, setFiles] = useState<GitChangedFile[]>([]);
+  const [expandedPath, setExpandedPath] = useState<string | null>(null);
+  const [diffs, setDiffs] = useState<Record<string, GitFileDiffResponse>>({});
+  const [diffLoadingPath, setDiffLoadingPath] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [diffError, setDiffError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!client || !visible) {
@@ -35,7 +46,14 @@ export function ToolboxChanges({
     setLoading(true);
     setError(null);
     try {
-      setStatus(await client.getGitStatus(projectDirectory ?? undefined));
+      const [nextStatus, nextChanges] = await Promise.all([
+        client.getGitStatus(projectDirectory ?? undefined),
+        client.getGitChanges(projectDirectory ?? undefined),
+      ]);
+      setStatus(nextStatus);
+      setFiles(nextChanges.files);
+      setDiffs({});
+      setExpandedPath(null);
     } catch (nextError) {
       setError(
         nextError instanceof Error
@@ -50,6 +68,38 @@ export function ToolboxChanges({
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  const toggleFile = useCallback(
+    async (file: GitChangedFile) => {
+      if (expandedPath === file.path) {
+        setExpandedPath(null);
+        return;
+      }
+      setExpandedPath(file.path);
+      setDiffError(null);
+      if (!client || diffs[file.path]) {
+        return;
+      }
+      setDiffLoadingPath(file.path);
+      try {
+        const diff = await client.getGitFileDiff(
+          file.path,
+          projectDirectory ?? undefined,
+        );
+        setDiffs((current) => ({ ...current, [file.path]: diff }));
+      } catch (nextError) {
+        setDiffError(
+          nextError instanceof Error ? nextError.message : "Unable to load this diff.",
+        );
+      } finally {
+        setDiffLoadingPath(null);
+      }
+    },
+    [client, diffs, expandedPath, projectDirectory],
+  );
+
+  const totalAdditions = files.reduce((sum, file) => sum + file.additions, 0);
+  const totalDeletions = files.reduce((sum, file) => sum + file.deletions, 0);
 
   return (
     <ScrollView
@@ -69,65 +119,122 @@ export function ToolboxChanges({
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Refresh changes"
+          disabled={loading}
           onPress={() => void refresh()}
           style={[styles.refreshButton, { borderColor: t.border }]}
         >
-          <Text style={[styles.refreshText, { color: t.foreground }]}>
-            Refresh
-          </Text>
+          {loading ? (
+            <ActivityIndicator size="small" color={t.mutedForeground} />
+          ) : (
+            <RefreshCw size={16} color={t.foreground} strokeWidth={1.9} />
+          )}
         </Pressable>
       </View>
 
-      {loading && !status ? (
-        <ActivityIndicator color={t.mutedForeground} />
-      ) : null}
       {error ? <Text style={[styles.error, { color: t.error }]}>{error}</Text> : null}
       {status && !status.in_repo ? (
         <Text style={[styles.empty, { color: t.mutedForeground }]}>
           The active directory is not a Git repository.
         </Text>
       ) : null}
+
       {status?.in_repo ? (
         <>
-          <View
-            style={[
-              styles.branchCard,
-              { borderColor: t.border, backgroundColor: t.card },
-            ]}
-          >
-            <Text style={[styles.branch, { color: t.foreground }]}>
-              {status.branch ?? "Detached HEAD"}
-            </Text>
-            <Text style={[styles.detail, { color: t.mutedForeground }]}>
-              {status.ahead} ahead · {status.behind} behind
+          <View style={[styles.branchRow, { borderColor: t.border }]}>
+            <View style={styles.branchCopy}>
+              <Text numberOfLines={1} style={[styles.branch, { color: t.foreground }]}>
+                {status.branch ?? "Detached HEAD"}
+              </Text>
+              <Text style={[styles.detail, { color: t.mutedForeground }]}>
+                {files.length} file{files.length === 1 ? "" : "s"}
+              </Text>
+            </View>
+            <Text style={styles.diffTotals}>
+              <Text style={{ color: t.success }}>+{totalAdditions}</Text>
+              <Text style={{ color: t.mutedForeground }}>  </Text>
+              <Text style={{ color: t.error }}>−{totalDeletions}</Text>
             </Text>
           </View>
 
-          <View style={styles.grid}>
-            {[
-              ["Modified", status.modified],
-              ["Staged", status.staged],
-              ["Untracked", status.untracked],
-              ["Conflicts", status.conflicted],
-              ["Additions", status.branch_additions],
-              ["Deletions", status.branch_deletions],
-            ].map(([label, value]) => (
-              <View
-                key={label}
-                style={[
-                  styles.metric,
-                  { borderColor: t.border, backgroundColor: t.card },
-                ]}
-              >
-                <Text style={[styles.metricValue, { color: t.foreground }]}>
-                  {value}
-                </Text>
-                <Text style={[styles.metricLabel, { color: t.mutedForeground }]}>
-                  {label}
-                </Text>
-              </View>
-            ))}
-          </View>
+          {files.length === 0 && !loading ? (
+            <Text style={[styles.empty, { color: t.mutedForeground }]}>
+              No changes from this branch&apos;s base.
+            </Text>
+          ) : (
+            <View style={[styles.fileList, { borderColor: t.border }]}>
+              {files.map((file, index) => {
+                const expanded = expandedPath === file.path;
+                const diff = diffs[file.path];
+                return (
+                  <View
+                    key={file.path}
+                    style={[
+                      styles.fileItem,
+                      index > 0 && { borderTopColor: t.border, borderTopWidth: StyleSheet.hairlineWidth },
+                    ]}
+                  >
+                    <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel={`${expanded ? "Collapse" : "Expand"} ${file.path}`}
+                      onPress={() => void toggleFile(file)}
+                      style={styles.fileRow}
+                    >
+                      {expanded ? (
+                        <ChevronDown size={16} color={t.mutedForeground} />
+                      ) : (
+                        <ChevronRight size={16} color={t.mutedForeground} />
+                      )}
+                      <FileCode2 size={16} color={t.mutedForeground} strokeWidth={1.7} />
+                      <View style={styles.fileCopy}>
+                        <Text numberOfLines={1} style={[styles.filePath, { color: t.foreground }]}>
+                          {file.path}
+                        </Text>
+                        <Text style={[styles.fileStatus, { color: t.mutedForeground }]}>
+                          {file.status}
+                        </Text>
+                      </View>
+                      <Text style={styles.fileTotals}>
+                        <Text style={{ color: t.success }}>+{file.additions}</Text>
+                        <Text style={{ color: t.mutedForeground }}> </Text>
+                        <Text style={{ color: t.error }}>−{file.deletions}</Text>
+                      </Text>
+                    </Pressable>
+
+                    {expanded ? (
+                      <View style={styles.diffBody}>
+                        {diffLoadingPath === file.path ? (
+                          <ActivityIndicator size="small" color={t.mutedForeground} />
+                        ) : diffError && !diff ? (
+                          <Text style={[styles.error, { color: t.error }]}>{diffError}</Text>
+                        ) : diff?.binary ? (
+                          <Text style={[styles.empty, { color: t.mutedForeground }]}>
+                            Binary file preview is unavailable.
+                          </Text>
+                        ) : diff?.patch ? (
+                          <>
+                            <ToolDiffViewer
+                              presentation={{
+                                kind: "patch",
+                                patch: diff.patch,
+                                filePath: file.path,
+                                additions: file.additions,
+                                deletions: file.deletions,
+                              }}
+                            />
+                            {diff.truncated ? (
+                              <Text style={[styles.note, { color: t.mutedForeground }]}>
+                                Large diff truncated for this preview.
+                              </Text>
+                            ) : null}
+                          </>
+                        ) : null}
+                      </View>
+                    ) : null}
+                  </View>
+                );
+              })}
+            </View>
+          )}
         </>
       ) : null}
     </ScrollView>
@@ -138,7 +245,7 @@ const styles = StyleSheet.create({
   content: {
     padding: 18,
     paddingBottom: 32,
-    gap: 16,
+    gap: 14,
   },
   headingRow: {
     flexDirection: "row",
@@ -158,54 +265,82 @@ const styles = StyleSheet.create({
     lineHeight: 17,
   },
   refreshButton: {
-    minHeight: 36,
-    paddingHorizontal: 12,
+    width: 38,
+    height: 38,
     borderRadius: 12,
     borderWidth: StyleSheet.hairlineWidth,
     alignItems: "center",
     justifyContent: "center",
   },
-  refreshText: {
-    fontSize: 12,
-    fontWeight: "600",
+  branchRow: {
+    minHeight: 54,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    paddingBottom: 12,
   },
-  branchCard: {
-    padding: 14,
-    borderRadius: 14,
-    borderWidth: StyleSheet.hairlineWidth,
+  branchCopy: {
+    flex: 1,
   },
   branch: {
-    fontSize: 15,
+    fontSize: 14,
     fontWeight: "700",
   },
   detail: {
-    marginTop: 4,
+    marginTop: 3,
     fontSize: 12,
   },
-  grid: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 10,
-  },
-  metric: {
-    width: "47%",
-    minHeight: 88,
-    borderRadius: 14,
-    borderWidth: StyleSheet.hairlineWidth,
-    padding: 14,
-    justifyContent: "space-between",
-  },
-  metricValue: {
-    fontSize: 23,
+  diffTotals: {
+    fontSize: 12,
     fontWeight: "700",
+    fontVariant: ["tabular-nums"],
   },
-  metricLabel: {
+  fileList: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 14,
+    overflow: "hidden",
+  },
+  fileItem: {
+    minWidth: 0,
+  },
+  fileRow: {
+    minHeight: 58,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 9,
+  },
+  fileCopy: {
+    flex: 1,
+    minWidth: 0,
+  },
+  filePath: {
     fontSize: 12,
     fontWeight: "600",
   },
+  fileStatus: {
+    marginTop: 3,
+    fontSize: 11,
+    textTransform: "capitalize",
+  },
+  fileTotals: {
+    fontSize: 11,
+    fontWeight: "700",
+    fontVariant: ["tabular-nums"],
+  },
+  diffBody: {
+    paddingHorizontal: 8,
+    paddingBottom: 10,
+    gap: 8,
+  },
+  note: {
+    fontSize: 11,
+  },
   empty: {
-    fontSize: 14,
-    lineHeight: 20,
+    fontSize: 13,
+    lineHeight: 19,
   },
   error: {
     fontSize: 13,

--- a/apps/mobile/components/toolbox/ToolboxConnections.tsx
+++ b/apps/mobile/components/toolbox/ToolboxConnections.tsx
@@ -1,17 +1,15 @@
-import { useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
   ScrollView,
   StyleSheet,
+  Switch,
   Text,
   View,
 } from "react-native";
-import type {
-  McpServerResponse,
-  ProviderStatus,
-  SkillInfo,
-} from "@krusty/api";
+import { ChevronDown, ChevronRight } from "lucide-react-native";
+import type { McpServerResponse, SkillInfo } from "@krusty/api";
 
 import { useConnection } from "../../hooks/useConnection";
 import { useThemeContext } from "../../hooks/useTheme";
@@ -21,47 +19,103 @@ interface ToolboxConnectionsProps {
   onOpenSettings?: () => void;
 }
 
-export function ToolboxConnections({
-  visible,
-  onOpenSettings,
-}: ToolboxConnectionsProps) {
+type SectionKey = "mcp" | "skills";
+
+export function ToolboxConnections({ visible }: ToolboxConnectionsProps) {
   const { client } = useConnection();
   const { theme } = useThemeContext();
   const t = theme.colors;
-  const [providers, setProviders] = useState<ProviderStatus[]>([]);
   const [servers, setServers] = useState<McpServerResponse[]>([]);
   const [skills, setSkills] = useState<SkillInfo[]>([]);
+  const [expanded, setExpanded] = useState<Record<SectionKey, boolean>>({
+    mcp: true,
+    skills: false,
+  });
   const [loading, setLoading] = useState(false);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
 
-  useEffect(() => {
+  const load = useCallback(async () => {
     if (!client || !visible) {
       return;
     }
-    let active = true;
     setLoading(true);
-    void Promise.all([
-      client.getCredentials().catch(() => []),
-      client.getMcpServers().catch(() => []),
-      client.getSkills().catch(() => []),
-    ]).then(([nextProviders, nextServers, nextSkills]) => {
-      if (!active) {
-        return;
-      }
-      setProviders(nextProviders);
+    setMessage(null);
+    try {
+      const [nextServers, nextSkills] = await Promise.all([
+        client.getMcpServers(),
+        client.getSkills(),
+      ]);
       setServers(nextServers);
       setSkills(nextSkills);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Unable to load connections.");
+    } finally {
       setLoading(false);
-    });
-    return () => {
-      active = false;
-    };
+    }
   }, [client, visible]);
 
-  const configuredProviders = providers.filter(
-    (provider) => provider.configured || provider.has_oauth,
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const connectedCount = servers.filter((server) => server.connected).length;
+  const enabledSkillCount = skills.filter((skill) => skill.enabled).length;
+
+  const toggleSection = (section: SectionKey) => {
+    setExpanded((current) => ({ ...current, [section]: !current[section] }));
+  };
+
+  const toggleMcp = useCallback(
+    async (server: McpServerResponse) => {
+      if (!client) return;
+      const key = `mcp:${server.name}`;
+      setBusyKey(key);
+      setMessage(null);
+      try {
+        const updated = server.connected
+          ? await client.disconnectMcpServer(server.name)
+          : await client.connectMcpServer(server.name);
+        setServers((current) =>
+          current.map((entry) => (entry.name === updated.name ? updated : entry)),
+        );
+      } catch (error) {
+        setMessage(
+          error instanceof Error
+            ? error.message
+            : `Unable to update ${server.name}.`,
+        );
+      } finally {
+        setBusyKey(null);
+      }
+    },
+    [client],
   );
-  const connectedServers = servers.filter(
-    (server) => server.status === "connected",
+
+  const toggleSkill = useCallback(
+    async (skill: SkillInfo) => {
+      if (!client) return;
+      const key = `skill:${skill.name}`;
+      setBusyKey(key);
+      setMessage(null);
+      try {
+        const updated = await client.updateSkillPolicy(skill.name, {
+          enabled: !skill.enabled,
+        });
+        setSkills((current) =>
+          current.map((entry) => (entry.name === updated.name ? updated : entry)),
+        );
+      } catch (error) {
+        setMessage(
+          error instanceof Error
+            ? error.message
+            : `Unable to update ${skill.name}.`,
+        );
+      } finally {
+        setBusyKey(null);
+      }
+    },
+    [client],
   );
 
   return (
@@ -69,64 +123,149 @@ export function ToolboxConnections({
       contentContainerStyle={styles.content}
       showsVerticalScrollIndicator={false}
     >
-      <Text style={[styles.title, { color: t.foreground }]}>Connections</Text>
-      <Text style={[styles.subtitle, { color: t.mutedForeground }]}>
-        Providers, MCP servers, and skills available to Chat.
-      </Text>
+      <View style={styles.heading}>
+        <Text style={[styles.title, { color: t.foreground }]}>Connections</Text>
+        {loading ? <ActivityIndicator size="small" color={t.mutedForeground} /> : null}
+      </View>
 
-      {loading ? <ActivityIndicator color={t.mutedForeground} /> : null}
+      {message ? <Text style={[styles.message, { color: t.error }]}>{message}</Text> : null}
 
-      {[
-        {
-          title: "Providers",
-          summary: `${configuredProviders.length} configured`,
-          values: configuredProviders.map((provider) => provider.name),
-        },
-        {
-          title: "MCP",
-          summary: `${connectedServers.length} connected`,
-          values: connectedServers.map((server) => server.name),
-        },
-        {
-          title: "Skills",
-          summary: `${skills.length} installed`,
-          values: skills.map((skill) => skill.name),
-        },
-      ].map((section) => (
-        <View
-          key={section.title}
-          style={[
-            styles.card,
-            { borderColor: t.border, backgroundColor: t.card },
-          ]}
-        >
-          <View style={styles.cardHeader}>
-            <Text style={[styles.cardTitle, { color: t.foreground }]}>
-              {section.title}
-            </Text>
-            <Text style={[styles.cardSummary, { color: t.mutedForeground }]}>
-              {section.summary}
-            </Text>
-          </View>
-          <Text style={[styles.values, { color: t.mutedForeground }]}>
-            {section.values.slice(0, 6).join(" · ") || "None available"}
-          </Text>
-        </View>
-      ))}
+      <ConnectionSection
+        title="MCP servers"
+        summary={`${connectedCount} of ${servers.length} on`}
+        expanded={expanded.mcp}
+        onToggle={() => toggleSection("mcp")}
+      >
+        {servers.length === 0 ? (
+          <EmptyRow label="No MCP servers configured" />
+        ) : (
+          servers.map((server) => {
+            const key = `mcp:${server.name}`;
+            return (
+              <ToggleRow
+                key={server.name}
+                title={server.name}
+                detail={
+                  server.error ??
+                  `${server.tool_count} tool${server.tool_count === 1 ? "" : "s"}`
+                }
+                value={server.connected}
+                disabled={busyKey === key}
+                onChange={() => void toggleMcp(server)}
+              />
+            );
+          })
+        )}
+      </ConnectionSection>
 
-      {onOpenSettings ? (
-        <Pressable
-          accessibilityRole="button"
-          onPress={onOpenSettings}
-          style={[styles.settingsButton, { borderColor: t.border }]}
-        >
-          <Text style={[styles.settingsText, { color: t.foreground }]}>
-            Manage connections
-          </Text>
-        </Pressable>
-      ) : null}
+      <ConnectionSection
+        title="Skills"
+        summary={`${enabledSkillCount} of ${skills.length} on`}
+        expanded={expanded.skills}
+        onToggle={() => toggleSection("skills")}
+      >
+        {skills.length === 0 ? (
+          <EmptyRow label="No skills installed" />
+        ) : (
+          skills.map((skill) => {
+            const key = `skill:${skill.name}`;
+            return (
+              <ToggleRow
+                key={skill.name}
+                title={skill.name}
+                detail={skill.description}
+                value={skill.enabled}
+                disabled={busyKey === key}
+                onChange={() => void toggleSkill(skill)}
+              />
+            );
+          })
+        )}
+      </ConnectionSection>
     </ScrollView>
   );
+
+  function ConnectionSection({
+    title,
+    summary,
+    expanded: isExpanded,
+    onToggle,
+    children,
+  }: {
+    title: string;
+    summary: string;
+    expanded: boolean;
+    onToggle: () => void;
+    children: ReactNode;
+  }) {
+    return (
+      <View style={[styles.section, { borderColor: t.border }]}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityState={{ expanded: isExpanded }}
+          onPress={onToggle}
+          style={styles.sectionHeader}
+        >
+          {isExpanded ? (
+            <ChevronDown size={17} color={t.mutedForeground} />
+          ) : (
+            <ChevronRight size={17} color={t.mutedForeground} />
+          )}
+          <Text style={[styles.sectionTitle, { color: t.foreground }]}>{title}</Text>
+          <Text style={[styles.sectionSummary, { color: t.mutedForeground }]}>
+            {summary}
+          </Text>
+        </Pressable>
+        {isExpanded ? children : null}
+      </View>
+    );
+  }
+
+  function ToggleRow({
+    title,
+    detail,
+    value,
+    disabled,
+    onChange,
+  }: {
+    title: string;
+    detail: string;
+    value: boolean;
+    disabled: boolean;
+    onChange: () => void;
+  }) {
+    return (
+      <View style={[styles.itemRow, { borderTopColor: t.border }]}>
+        <View style={styles.itemCopy}>
+          <Text style={[styles.itemTitle, { color: t.foreground }]}>{title}</Text>
+          <Text
+            numberOfLines={2}
+            style={[styles.itemDetail, { color: t.mutedForeground }]}
+          >
+            {detail}
+          </Text>
+        </View>
+        <Switch
+          accessibilityLabel={`${value ? "Disable" : "Enable"} ${title}`}
+          value={value}
+          disabled={disabled}
+          onValueChange={onChange}
+          trackColor={{ false: t.muted, true: `${t.userMessage}88` }}
+          thumbColor={value ? t.userMessage : t.mutedForeground}
+        />
+      </View>
+    );
+  }
+
+  function EmptyRow({ label }: { label: string }) {
+    return (
+      <Text
+        style={[styles.empty, { borderTopColor: t.border, color: t.mutedForeground }]}
+      >
+        {label}
+      </Text>
+    );
+  }
 }
 
 const styles = StyleSheet.create({
@@ -135,50 +274,67 @@ const styles = StyleSheet.create({
     paddingBottom: 32,
     gap: 12,
   },
+  heading: {
+    minHeight: 30,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
   title: {
     fontSize: 19,
     fontWeight: "700",
   },
-  subtitle: {
-    marginTop: -6,
-    marginBottom: 4,
-    fontSize: 13,
-    lineHeight: 19,
-  },
-  card: {
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 14,
-    padding: 14,
-    gap: 8,
-  },
-  cardHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 12,
-  },
-  cardTitle: {
-    fontSize: 14,
-    fontWeight: "700",
-  },
-  cardSummary: {
-    fontSize: 12,
-    fontWeight: "600",
-  },
-  values: {
+  message: {
     fontSize: 12,
     lineHeight: 18,
   },
-  settingsButton: {
-    minHeight: 46,
-    borderRadius: 14,
+  section: {
     borderWidth: StyleSheet.hairlineWidth,
-    alignItems: "center",
-    justifyContent: "center",
-    marginTop: 4,
+    borderRadius: 14,
+    overflow: "hidden",
   },
-  settingsText: {
-    fontSize: 13,
+  sectionHeader: {
+    minHeight: 54,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 9,
+    paddingHorizontal: 13,
+  },
+  sectionTitle: {
+    flex: 1,
+    fontSize: 14,
     fontWeight: "700",
+  },
+  sectionSummary: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  itemRow: {
+    minHeight: 62,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  itemCopy: {
+    flex: 1,
+    minWidth: 0,
+  },
+  itemTitle: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  itemDetail: {
+    marginTop: 3,
+    fontSize: 11,
+    lineHeight: 16,
+  },
+  empty: {
+    paddingHorizontal: 14,
+    paddingVertical: 16,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    fontSize: 12,
   },
 });

--- a/crates/krusty-core/src/git/changes.rs
+++ b/crates/krusty-core/src/git/changes.rs
@@ -1,0 +1,286 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Component, Path};
+
+use anyhow::{anyhow, bail, Result};
+
+use super::command::{resolve_repo_root, run_git, should_suppress_display};
+use super::model::{GitChangedFileSummary, GitChangesSummary, GitFileDiff};
+use super::status::diff::resolve_base_ref;
+
+const MAX_PATCH_BYTES: usize = 240_000;
+
+/// List files changed from the current branch base through the working tree.
+pub fn changes(path: &Path) -> Result<Option<GitChangesSummary>> {
+    let repo_root = match resolve_repo_root(path)? {
+        Some(root) => root,
+        None => return Ok(None),
+    };
+    if should_suppress_display(&repo_root) {
+        return Ok(None);
+    }
+
+    let base = diff_base(&repo_root)?;
+    let base_arg = base.as_deref().unwrap_or("HEAD");
+    let name_output = run_git(
+        &[
+            "diff",
+            "--no-ext-diff",
+            "--no-renames",
+            "--name-status",
+            "-z",
+            base_arg,
+            "--",
+        ],
+        &repo_root,
+    )?;
+    let numstat_output = run_git(
+        &[
+            "diff",
+            "--no-ext-diff",
+            "--no-renames",
+            "--numstat",
+            "-z",
+            base_arg,
+            "--",
+        ],
+        &repo_root,
+    )?;
+
+    let counts = parse_numstat(&numstat_output.stdout);
+    let mut files = parse_name_status(&name_output.stdout)
+        .into_iter()
+        .map(|(path, status)| {
+            let (additions, deletions) = counts.get(&path).copied().unwrap_or_default();
+            GitChangedFileSummary {
+                path,
+                status,
+                additions,
+                deletions,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let untracked_output = run_git(
+        &["ls-files", "--others", "--exclude-standard", "-z"],
+        &repo_root,
+    )?;
+    for path in nul_fields(&untracked_output.stdout) {
+        if files.iter().any(|file| file.path == path) {
+            continue;
+        }
+        let additions = count_text_lines(&repo_root.join(&path)).unwrap_or_default();
+        files.push(GitChangedFileSummary {
+            path,
+            status: "untracked".to_string(),
+            additions,
+            deletions: 0,
+        });
+    }
+
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(Some(GitChangesSummary { repo_root, files }))
+}
+
+/// Load a bounded unified patch for one changed file.
+pub fn file_diff(path: &Path, file: &str) -> Result<Option<GitFileDiff>> {
+    validate_relative_file(file)?;
+    let repo_root = match resolve_repo_root(path)? {
+        Some(root) => root,
+        None => return Ok(None),
+    };
+    if should_suppress_display(&repo_root) {
+        return Ok(None);
+    }
+
+    let changed = changes(&repo_root)?
+        .ok_or_else(|| anyhow!("Path is not inside a displayable git repository"))?;
+    let entry = changed
+        .files
+        .iter()
+        .find(|entry| entry.path == file)
+        .ok_or_else(|| anyhow!("File is not part of the current repository changes"))?;
+
+    if entry.status == "untracked" {
+        return Ok(Some(untracked_diff(&repo_root, file)?));
+    }
+
+    let base = diff_base(&repo_root)?;
+    let base_arg = base.as_deref().unwrap_or("HEAD");
+    let output = run_git(
+        &[
+            "diff",
+            "--no-ext-diff",
+            "--no-renames",
+            "--unified=3",
+            base_arg,
+            "--",
+            file,
+        ],
+        &repo_root,
+    )?;
+    let binary = output
+        .stdout
+        .windows(b"Binary files".len())
+        .any(|window| window == b"Binary files");
+    let (patch, truncated) = bounded_utf8(&output.stdout);
+    Ok(Some(GitFileDiff {
+        path: file.to_string(),
+        patch,
+        truncated,
+        binary,
+    }))
+}
+
+fn diff_base(repo_root: &Path) -> Result<Option<String>> {
+    let upstream = run_git(
+        &[
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        ],
+        repo_root,
+    )
+    .ok()
+    .and_then(|output| {
+        let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        (!value.is_empty()).then_some(value)
+    });
+    let Some(base_ref) = resolve_base_ref(repo_root, upstream.as_deref()) else {
+        return Ok(None);
+    };
+    let output = run_git(&["merge-base", "HEAD", base_ref.as_str()], repo_root)?;
+    let merge_base = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok((!merge_base.is_empty()).then_some(merge_base))
+}
+
+fn validate_relative_file(file: &str) -> Result<()> {
+    let path = Path::new(file);
+    if file.trim().is_empty() || path.is_absolute() {
+        bail!("File path must be a non-empty repository-relative path");
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir | Component::RootDir))
+    {
+        bail!("File path must stay inside the repository");
+    }
+    Ok(())
+}
+
+fn parse_name_status(bytes: &[u8]) -> Vec<(String, String)> {
+    let fields = nul_fields(bytes);
+    fields
+        .chunks_exact(2)
+        .map(|pair| {
+            let status = match pair[0].chars().next().unwrap_or('M') {
+                'A' => "added",
+                'D' => "deleted",
+                'U' => "conflicted",
+                'T' => "type changed",
+                _ => "modified",
+            };
+            (pair[1].clone(), status.to_string())
+        })
+        .collect()
+}
+
+fn parse_numstat(bytes: &[u8]) -> HashMap<String, (usize, usize)> {
+    nul_fields(bytes)
+        .into_iter()
+        .filter_map(|field| {
+            let mut parts = field.splitn(3, '\t');
+            let additions = parts.next()?.parse().unwrap_or(0);
+            let deletions = parts.next()?.parse().unwrap_or(0);
+            let path = parts.next()?.to_string();
+            Some((path, (additions, deletions)))
+        })
+        .collect()
+}
+
+fn nul_fields(bytes: &[u8]) -> Vec<String> {
+    bytes
+        .split(|byte| *byte == 0)
+        .filter(|field| !field.is_empty())
+        .map(|field| String::from_utf8_lossy(field).into_owned())
+        .collect()
+}
+
+fn count_text_lines(path: &Path) -> Option<usize> {
+    let bytes = fs::read(path).ok()?;
+    if bytes.contains(&0) {
+        return None;
+    }
+    let text = std::str::from_utf8(&bytes).ok()?;
+    Some(text.lines().count())
+}
+
+fn untracked_diff(repo_root: &Path, file: &str) -> Result<GitFileDiff> {
+    let bytes = fs::read(repo_root.join(file))?;
+    if bytes.contains(&0) || std::str::from_utf8(&bytes).is_err() {
+        return Ok(GitFileDiff {
+            path: file.to_string(),
+            patch: String::new(),
+            truncated: false,
+            binary: true,
+        });
+    }
+    let text = String::from_utf8_lossy(&bytes);
+    let mut patch = format!(
+        "diff --git a/{file} b/{file}\nnew file mode 100644\n--- /dev/null\n+++ b/{file}\n@@ -0,0 +1,{} @@\n",
+        text.lines().count()
+    );
+    for line in text.lines() {
+        patch.push('+');
+        patch.push_str(line);
+        patch.push('\n');
+    }
+    let (patch, truncated) = bounded_utf8(patch.as_bytes());
+    Ok(GitFileDiff {
+        path: file.to_string(),
+        patch,
+        truncated,
+        binary: false,
+    })
+}
+
+fn bounded_utf8(bytes: &[u8]) -> (String, bool) {
+    if bytes.len() <= MAX_PATCH_BYTES {
+        return (String::from_utf8_lossy(bytes).into_owned(), false);
+    }
+    let mut end = MAX_PATCH_BYTES;
+    while end > 0 && std::str::from_utf8(&bytes[..end]).is_err() {
+        end -= 1;
+    }
+    let mut patch = String::from_utf8_lossy(&bytes[..end]).into_owned();
+    patch.push_str("\n... diff truncated ...\n");
+    (patch, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_name_status, parse_numstat, validate_relative_file};
+
+    #[test]
+    fn parses_nul_delimited_change_metadata() {
+        let names = parse_name_status(b"M\0src/main.rs\0A\0new file.ts\0");
+        assert_eq!(
+            names,
+            vec![
+                ("src/main.rs".to_string(), "modified".to_string()),
+                ("new file.ts".to_string(), "added".to_string()),
+            ]
+        );
+        let counts = parse_numstat(b"4\t2\tsrc/main.rs\0-\t-\tasset.png\0");
+        assert_eq!(counts.get("src/main.rs"), Some(&(4, 2)));
+        assert_eq!(counts.get("asset.png"), Some(&(0, 0)));
+    }
+
+    #[test]
+    fn rejects_paths_that_escape_the_repository() {
+        assert!(validate_relative_file("../secret").is_err());
+        assert!(validate_relative_file("/tmp/secret").is_err());
+        assert!(validate_relative_file("src/main.rs").is_ok());
+    }
+}

--- a/crates/krusty-core/src/git/mod.rs
+++ b/crates/krusty-core/src/git/mod.rs
@@ -1,5 +1,6 @@
 //! Lightweight git helpers shared by server and clients.
 
+mod changes;
 mod command;
 mod model;
 mod pr;
@@ -7,6 +8,10 @@ mod status;
 #[cfg(test)]
 mod tests;
 
+pub use changes::{changes, file_diff};
 pub use command::{checkout, resolve_repo_root, should_suppress_display};
-pub use model::{GitBranchSummary, GitStatusSummary, GitWorktreeSummary};
+pub use model::{
+    GitBranchSummary, GitChangedFileSummary, GitChangesSummary, GitFileDiff, GitStatusSummary,
+    GitWorktreeSummary,
+};
 pub use status::{branches, status, worktrees};

--- a/crates/krusty-core/src/git/model.rs
+++ b/crates/krusty-core/src/git/model.rs
@@ -51,6 +51,32 @@ pub struct GitWorktreeSummary {
     pub is_current: bool,
 }
 
+/// A changed file relative to the branch base used by the Changes surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitChangedFileSummary {
+    pub path: String,
+    pub status: String,
+    pub additions: usize,
+    pub deletions: usize,
+}
+
+/// Repository changes available for file-by-file inspection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitChangesSummary {
+    pub repo_root: PathBuf,
+    pub files: Vec<GitChangedFileSummary>,
+}
+
+/// A bounded patch for a single changed file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitFileDiff {
+    pub path: String,
+    pub patch: String,
+    pub truncated: bool,
+    pub binary: bool,
+}
+
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(super) struct BranchDiffSummary {
     pub(super) files: usize,

--- a/crates/krusty-core/src/git/status/diff.rs
+++ b/crates/krusty-core/src/git/status/diff.rs
@@ -29,7 +29,7 @@ pub(super) fn compute_worktree_diff_summary(repo_root: &Path) -> Option<BranchDi
     Some(parse_numstat(&stdout))
 }
 
-fn resolve_base_ref(repo_root: &Path, upstream: Option<&str>) -> Option<String> {
+pub(crate) fn resolve_base_ref(repo_root: &Path, upstream: Option<&str>) -> Option<String> {
     if let Some(upstream) = upstream.filter(|u| !u.trim().is_empty()) {
         if ref_exists(repo_root, upstream) {
             return Some(upstream.to_string());

--- a/crates/krusty-core/src/git/status/mod.rs
+++ b/crates/krusty-core/src/git/status/mod.rs
@@ -7,7 +7,7 @@ use super::command::{resolve_repo_root, run_git, should_suppress_display};
 use super::model::{GitBranchSummary, GitStatusSummary, GitWorktreeSummary};
 use super::pr::resolve_pr_number;
 
-mod diff;
+pub(super) mod diff;
 mod parse;
 
 use diff::{compute_branch_diff_summary, compute_worktree_diff_summary};

--- a/crates/krusty-server/src/routes/git.rs
+++ b/crates/krusty-server/src/routes/git.rs
@@ -12,7 +12,8 @@ use super::session_access::request_workspace_scope;
 use crate::auth::CurrentUser;
 use crate::error::AppError;
 use crate::types::{
-    GitBranchResponse, GitBranchesResponse, GitCheckoutRequest, GitQuery, GitStatusResponse,
+    GitBranchResponse, GitBranchesResponse, GitChangedFileResponse, GitChangesResponse,
+    GitCheckoutRequest, GitDiffQuery, GitFileDiffResponse, GitQuery, GitStatusResponse,
     GitWorktreeResponse, GitWorktreesResponse,
 };
 use crate::utils::workspace::resolve_scoped_workspace_path;
@@ -22,10 +23,61 @@ use crate::AppState;
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/status", get(get_status))
+        .route("/changes", get(list_changes))
+        .route("/diff", get(get_file_diff))
         .route("/branches", get(list_branches))
         .route("/worktrees", get(list_worktrees))
         .route("/checkout", post(checkout_branch))
 }
+
+async fn list_changes(
+    State(state): State<AppState>,
+    user: Option<CurrentUser>,
+    Query(query): Query<GitQuery>,
+) -> Result<Json<GitChangesResponse>, AppError> {
+    let path = resolve_git_path(&state, user.as_ref(), query.path.as_deref())?;
+    let changes = krusty_core::git::changes(&path).map_err(to_bad_request)?;
+    let Some(changes) = changes else {
+        return Ok(Json(GitChangesResponse {
+            in_repo: false,
+            repo_root: None,
+            files: Vec::new(),
+        }));
+    };
+
+    Ok(Json(GitChangesResponse {
+        in_repo: true,
+        repo_root: Some(changes.repo_root.display().to_string()),
+        files: changes
+            .files
+            .into_iter()
+            .map(|file| GitChangedFileResponse {
+                path: file.path,
+                status: file.status,
+                additions: file.additions,
+                deletions: file.deletions,
+            })
+            .collect(),
+    }))
+}
+
+async fn get_file_diff(
+    State(state): State<AppState>,
+    user: Option<CurrentUser>,
+    Query(query): Query<GitDiffQuery>,
+) -> Result<Json<GitFileDiffResponse>, AppError> {
+    let path = resolve_git_path(&state, user.as_ref(), query.path.as_deref())?;
+    let diff = krusty_core::git::file_diff(&path, &query.file)
+        .map_err(to_bad_request)?
+        .ok_or_else(|| AppError::BadRequest("Path is not inside a git repository".to_string()))?;
+    Ok(Json(GitFileDiffResponse {
+        path: diff.path,
+        patch: diff.patch,
+        truncated: diff.truncated,
+        binary: diff.binary,
+    }))
+}
+
 
 async fn get_status(
     State(state): State<AppState>,

--- a/crates/krusty-server/src/types/git.rs
+++ b/crates/krusty-server/src/types/git.rs
@@ -31,6 +31,37 @@ pub struct GitStatusResponse {
 }
 
 #[derive(Serialize)]
+pub struct GitChangedFileResponse {
+    pub path: String,
+    pub status: String,
+    pub additions: usize,
+    pub deletions: usize,
+}
+
+#[derive(Serialize)]
+pub struct GitChangesResponse {
+    pub in_repo: bool,
+    pub repo_root: Option<String>,
+    pub files: Vec<GitChangedFileResponse>,
+}
+
+#[derive(Deserialize)]
+pub struct GitDiffQuery {
+    /// Optional repository path. If omitted, defaults to the current workspace.
+    pub path: Option<String>,
+    /// Repository-relative file path selected from `/git/changes`.
+    pub file: String,
+}
+
+#[derive(Serialize)]
+pub struct GitFileDiffResponse {
+    pub path: String,
+    pub patch: String,
+    pub truncated: bool,
+    pub binary: bool,
+}
+
+#[derive(Serialize)]
 pub struct GitBranchResponse {
     pub name: String,
     pub is_current: bool,

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -8,6 +8,8 @@ import type {
 	SessionPresenceResponse,
 	ModelsResponse,
 	GitStatusResponse,
+	GitChangesResponse,
+	GitFileDiffResponse,
 	GitBranchesResponse,
 	GitWorktreesResponse,
 	ProviderStatus,
@@ -546,6 +548,20 @@ export class KrustyClient {
 		return this.request(`/git/status${q}`);
 	}
 
+	async getGitChanges(path?: string): Promise<GitChangesResponse> {
+		const q = path ? `?path=${encodeURIComponent(path)}` : "";
+		return this.request(`/git/changes${q}`);
+	}
+
+	async getGitFileDiff(
+		file: string,
+		path?: string,
+	): Promise<GitFileDiffResponse> {
+		const params = new URLSearchParams({ file });
+		if (path) params.set("path", path);
+		return this.request(`/git/diff?${params}`);
+	}
+
 	async getGitBranches(path?: string): Promise<GitBranchesResponse> {
 		const q = path ? `?path=${encodeURIComponent(path)}` : "";
 		return this.request(`/git/branches${q}`);
@@ -710,6 +726,16 @@ export class KrustyClient {
 	async getSkills(scope: "all" | "global" = "all"): Promise<SkillInfo[]> {
 		const query = scope === "global" ? "?scope=global" : "";
 		return this.request(`/skills${query}`);
+	}
+
+	async updateSkillPolicy(
+		name: string,
+		update: { enabled?: boolean; permission?: SkillInfo["permission"] },
+	): Promise<SkillInfo> {
+		return this.request(`/skills/${encodeURIComponent(name)}/policy`, {
+			method: "POST",
+			body: JSON.stringify(update),
+		});
 	}
 
 	// Tools

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1444,6 +1444,27 @@ export interface GitStatusResponse {
 	total_changes: number;
 }
 
+export interface GitChangedFile {
+  path: string;
+  status: string;
+  additions: number;
+  deletions: number;
+}
+
+export interface GitChangesResponse {
+  in_repo: boolean;
+  repo_root: string | null;
+  files: GitChangedFile[];
+}
+
+export interface GitFileDiffResponse {
+  path: string;
+  patch: string;
+  truncated: boolean;
+  binary: boolean;
+}
+
+
 export interface GitBranch {
 	name: string;
 	is_current: boolean;
@@ -1688,15 +1709,20 @@ export interface McpServerResponse {
 	error?: string | null;
 }
 
-export type SkillSource = "global" | "project";
+export type SkillSource = "global" | "project" | "package";
 
 export interface SkillInfo {
-	name: string;
-	description: string;
-	version?: string | null;
-	author?: string | null;
-	tags: string[];
-	source: SkillSource;
+  name: string;
+  description: string;
+  version?: string | null;
+  author?: string | null;
+  tags: string[];
+  source: SkillSource;
+  origin: string;
+  path: string;
+  enabled: boolean;
+  permission: "allow" | "ask" | "deny";
+  model_invocable: boolean;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Recovers the toolbox work that lived only in `/tmp/krusty-staging-beam-button-20260729` and was previously blocked by missing API surface:

- **Changes**: file list with expandable per-file diffs (`getGitChanges` / `getGitFileDiff`)
- **Connections**: skill toggles + permission controls (`updateSkillPolicy` + richer `SkillInfo`)
- Server: `GET /git/changes`, `GET /git/diff` + core git helpers
- Client: types + `KrustyClient` methods
- iOS **buildNumber 269**

## Test plan
- [x] `cargo check -p krusty-core -p krusty-server`
- [x] `cd apps/mobile && npx tsc --noEmit`
- [ ] Mobile TestFlight after merge
- [ ] In Code toolbox: open Changes, expand a file, see patch; Connections skill toggles work against a live server with skills