### PR TITLE
fix(agent): wire exploration loop guards including observational bash

### DIFF
--- a/crates/krusty-core/src/agent/failure.rs
+++ b/crates/krusty-core/src/agent/failure.rs
@@ -8,6 +8,10 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 use crate::ai::types::{AiToolCall, Content, ModelMessage, Role};
+use crate::agent::hooks::shell_policy::{
+    classify_bash_command, is_proven_read_only_bash_command, semantic_bash_signature,
+    BashFileOperationKind,
+};
 use crate::tools::registry::{
     agent_call_execution_profile, agent_call_starts_run, effective_tool_call, tool_policy_for_call,
     ToolCategory,
@@ -21,8 +25,50 @@ pub const REPEATED_READ_ONLY_SEQUENCE_THRESHOLD: usize = 3;
 /// validation-only turns.
 pub const REPEATED_VALIDATION_SEQUENCE_THRESHOLD: usize = 3;
 
+/// True when a tool call is pure exploration (native read tools or observational bash).
+///
+/// `bash` is categorized as write-capable for permissioning, but many agent
+/// death-spirals are repeated `git show` / `rg` / `sed` pipelines. Count those
+/// as exploration so the loop guard can stop them.
+pub(crate) fn is_exploration_probe(call: &AiToolCall) -> bool {
+    let (name, arguments) = effective_tool_call(&call.name, &call.arguments);
+    if tool_policy_for_call(name, arguments).category == ToolCategory::ReadOnly {
+        return true;
+    }
+    if !matches!(name, "bash" | "shell" | "execute") {
+        return false;
+    }
+    let Some(command) = bash_command_text(arguments) else {
+        return false;
+    };
+    if is_proven_read_only_bash_command(command) {
+        return true;
+    }
+    let class = classify_bash_command(command);
+    if class.safety_violation.is_some() {
+        return false;
+    }
+    matches!(
+        class.file_operation.as_ref().map(|op| op.kind),
+        Some(BashFileOperationKind::Read | BashFileOperationKind::Search)
+    )
+}
+
+fn bash_command_text(arguments: &serde_json::Value) -> Option<&str> {
+    arguments
+        .get("command")
+        .and_then(|value| value.as_str())
+        .or_else(|| arguments.get("cmd").and_then(|value| value.as_str()))
+}
+
 fn exploration_signature(call: &AiToolCall) -> String {
     let (name, arguments) = effective_tool_call(&call.name, &call.arguments);
+    if matches!(name, "bash" | "shell" | "execute") {
+        if let Some(command) = bash_command_text(arguments) {
+            return format!("bash:{}", semantic_bash_signature(command));
+        }
+    }
+
     let mut arguments = arguments.clone();
 
     // Increasing only an output cap is not a new exploration strategy. Treat
@@ -120,16 +166,14 @@ pub fn detect_repeated_failures(
 /// Detect repeated identical read-only tool sequences across turns.
 ///
 /// This guards against agent loops that keep reissuing the same exploration
-/// pattern without taking action on the gathered evidence.
+/// pattern without taking action on the gathered evidence. Native read tools
+/// and observational bash (including git show/log pipelines flagged as
+/// file-read/search misuse) all count as exploration probes.
 pub fn detect_repeated_read_only_sequence(
     counters: &mut HashMap<String, usize>,
     tool_calls: &[AiToolCall],
 ) -> Option<String> {
-    if tool_calls.is_empty()
-        || !tool_calls.iter().all(|call| {
-            tool_policy_for_call(&call.name, &call.arguments).category == ToolCategory::ReadOnly
-        })
-    {
+    if tool_calls.is_empty() || !tool_calls.iter().all(is_exploration_probe) {
         counters.clear();
         return None;
     }
@@ -371,10 +415,9 @@ pub fn detect_post_explore_manual_fallback(
         return None;
     }
 
-    let read_only_probe = tool_calls
-        .iter()
-        .all(|call| matches!(call.name.as_str(), "read" | "glob" | "grep" | "list"));
-    if !read_only_probe {
+    // Include observational bash probes; permissioning treats bash as writeable
+    // but the death-spiral we care about is post-explore manual archaeology.
+    if !tool_calls.iter().all(is_exploration_probe) {
         return None;
     }
 
@@ -787,6 +830,43 @@ mod tests {
 
         assert!(detect_repeated_read_only_sequence(&mut counters, &write).is_none());
         assert!(counters.is_empty());
+    }
+
+    #[test]
+    fn repeated_observational_bash_sequence_trips_threshold() {
+        let calls = vec![AiToolCall {
+            id: "call_1".to_string(),
+            name: "bash".to_string(),
+            arguments: json!({
+                "command": "git show abc123:apps/mobile/components/chat/ChatBar.tsx | rg -n 'shouldGrow' | head -40"
+            }),
+        }];
+
+        let mut counters = HashMap::new();
+        for _ in 0..(REPEATED_READ_ONLY_SEQUENCE_THRESHOLD - 1) {
+            assert!(detect_repeated_read_only_sequence(&mut counters, &calls).is_none());
+        }
+        assert!(detect_repeated_read_only_sequence(&mut counters, &calls).is_some());
+    }
+
+    #[test]
+    fn observational_bash_and_native_reads_count_as_exploration_batch() {
+        let calls = vec![
+            AiToolCall {
+                id: "call_1".to_string(),
+                name: "bash".to_string(),
+                arguments: json!({"command": "git log --oneline -5 -- apps/mobile"}),
+            },
+            AiToolCall {
+                id: "call_2".to_string(),
+                name: "read".to_string(),
+                arguments: json!({"path": "apps/mobile/components/chat/ChatBar.tsx"}),
+            },
+        ];
+        assert!(calls.iter().all(is_exploration_probe));
+        let mut counters = HashMap::new();
+        assert!(detect_repeated_read_only_sequence(&mut counters, &calls).is_none());
+        assert!(!counters.is_empty());
     }
 
     #[test]

--- a/crates/krusty-core/src/agent/orchestrator.rs
+++ b/crates/krusty-core/src/agent/orchestrator.rs
@@ -1738,6 +1738,9 @@ impl AgenticOrchestrator {
             let fail_diagnostic = guard.repeated_failure;
             let explore_diagnostic =
                 failure::detect_terminal_explore_failure(&result.tool_calls, &tool_results);
+            let read_only_loop_diagnostic = guard.repeated_read_only;
+            let post_explore_diagnostic =
+                failure::detect_post_explore_manual_fallback(&conversation, &result.tool_calls);
             let validation_diagnostic = guard.repeated_validation;
             let progress_telemetry = guard.progress;
             let progress_diagnostic = progress_telemetry
@@ -1750,6 +1753,8 @@ impl AgenticOrchestrator {
             let blocker_fingerprint = fail_diagnostic
                 .as_ref()
                 .or(explore_diagnostic.as_ref())
+                .or(read_only_loop_diagnostic.as_ref())
+                .or(post_explore_diagnostic.as_ref())
                 .or(progress_diagnostic.as_ref())
                 .cloned();
             let goal_runtime_stop = goal_token_stop.or_else(|| {
@@ -1955,16 +1960,19 @@ impl AgenticOrchestrator {
                 return;
             }
 
-            // Check fail-fast
+            // Check fail-fast (errors, failed explore, repeated pure exploration,
+            // post-explore manual probing, and semantic no-progress).
             if let Some(diagnostic) = fail_diagnostic
                 .or(explore_diagnostic)
+                .or(read_only_loop_diagnostic)
+                .or(post_explore_diagnostic)
                 .or(progress_diagnostic)
             {
                 tracing::warn!(
                     iteration,
                     session_id = %session_id,
                     diagnostic = %diagnostic,
-                    "Fail-fast: stopping repeated tool failure loop"
+                    "Fail-fast: stopping repeated tool failure or exploration loop"
                 );
                 block_active_goal_for_stop(&db_path, &session_id, "semantic_no_progress");
                 clear_recovery_state(&db_path, &session_id);

--- a/crates/krusty-core/src/agent/progress.rs
+++ b/crates/krusty-core/src/agent/progress.rs
@@ -98,6 +98,8 @@ impl ProgressGuardTelemetry {
 pub struct LoopGuardOutcome {
     pub repeated_failure: Option<String>,
     pub repeated_validation: Option<String>,
+    /// Same pure-exploration tool batch repeated without mutation.
+    pub repeated_read_only: Option<String>,
     pub progress: Option<ProgressGuardTelemetry>,
 }
 
@@ -106,6 +108,7 @@ pub struct LoopGuard {
     progress: ProgressLedger,
     failure_signatures: HashMap<String, usize>,
     validation_signatures: HashMap<String, usize>,
+    read_only_signatures: HashMap<String, usize>,
 }
 
 impl LoopGuard {
@@ -117,6 +120,7 @@ impl LoopGuard {
         self.progress.reset_for_steering();
         self.failure_signatures.clear();
         self.validation_signatures.clear();
+        self.read_only_signatures.clear();
     }
 
     pub fn evaluate(
@@ -134,6 +138,10 @@ impl LoopGuard {
                 &mut self.validation_signatures,
                 tool_calls,
                 tool_results,
+            ),
+            repeated_read_only: failure::detect_repeated_read_only_sequence(
+                &mut self.read_only_signatures,
+                tool_calls,
             ),
             progress: self.progress.record_turn(tool_calls, tool_results),
         }

--- a/crates/krusty-core/src/agent/subagent/execution/runtime.rs
+++ b/crates/krusty-core/src/agent/subagent/execution/runtime.rs
@@ -886,11 +886,17 @@ pub(crate) async fn execute_agent_loop<C: AgentConfig>(
         let guard = loop_guard.evaluate(&progress_calls, &tool_results);
         let progress_telemetry = guard.progress;
         let validation_completion = guard.repeated_validation;
-        let guard_diagnostic = guard.repeated_failure.or_else(|| {
-            progress_telemetry
-                .as_ref()
-                .and_then(|telemetry| telemetry.diagnostic())
-        });
+        let post_explore_diagnostic =
+            crate::agent::failure::detect_post_explore_manual_fallback(&messages, &progress_calls);
+        let guard_diagnostic = guard
+            .repeated_failure
+            .or(guard.repeated_read_only)
+            .or(post_explore_diagnostic)
+            .or_else(|| {
+                progress_telemetry
+                    .as_ref()
+                    .and_then(|telemetry| telemetry.diagnostic())
+            });
 
         messages.push(ModelMessage {
             role: Role::User,

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -133,9 +133,15 @@ After all tool calls in a batch are executed, the orchestrator collects the resu
 
 The orchestrator then performs two safety checks before looping:
 
-**Failure detection.** `failure::detect_repeated_failures` tracks tool error signatures across iterations. If the same tool keeps failing with the same error (a stuck loop), it triggers a `LoopGuardTriggered` stop. Similarly, `detect_repeated_read_only_sequence` catches the AI reading the same files in a cycle without making progress.
+**Failure and exploration detection (`LoopGuard`).** After each tool batch the orchestrator evaluates:
 
-**Exploration budget.** The orchestrator counts consecutive read-only tool calls (read, glob, grep). If the AI spends too many turns exploring without taking action, a soft warning is logged at 15 calls and a hard threshold triggers at 30. This prevents the AI from endlessly reading files without doing anything.
+- `detect_repeated_failures` — same tool + same error signature ≥ 2 times → stop
+- `detect_repeated_validation_sequence` — same successful test/lint/build pattern ≥ 3 times → clean complete
+- `detect_repeated_read_only_sequence` — same pure-exploration batch ≥ 3 times (native read tools **and** observational bash such as `git show` / `rg` pipelines) → stop
+- `detect_post_explore_manual_fallback` — after a usable delegated explore result, further pure manual probes → stop
+- semantic no-progress ledger — replan then stop when work produces no verified state change
+
+These guards are shared with subagent runtimes via the same `LoopGuard` type.
 
 If both checks pass, the orchestrator emits a `LoopEvent::TurnComplete { has_more: true }`, sets the agent state to "streaming", and loops back to step 3 -- context injection, AI call, stream processing, tool execution. This is the agentic loop: the AI keeps working, calling tools and receiving results, until it produces a response with no tool calls.
 


### PR DESCRIPTION
## Summary
Wires the previously dead exploration loop detectors that would have helped stop the recent honey tool-loop spiral:

- `detect_repeated_read_only_sequence` → `LoopGuard` + parent/subagent fail-fast
- `detect_post_explore_manual_fallback` → parent/subagent fail-fast
- Exploration probes now include **observational bash** (`git show`/`log`, `rg`/`sed`/`head` pipelines, shell file-read/search class), not only native `read`/`grep`/`glob`/`list`

Without the bash inclusion, the detector would never fire on the live spiral (bash is permission-category Write).

## Test plan
- [x] `cargo test -p krusty-core --lib failure`
- [x] `cargo check -p krusty-core -p krusty-server -p krusty`
- [ ] Deploy binary to honey and re-run a similar git-archaeology session

## Out of scope
TUI rebuild / theme / BlockEvent cleanup (side branch).